### PR TITLE
Fix 404 errors: remove /dashboard prefix from nav links

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -234,7 +234,7 @@ export default function DashboardPage() {
             </h2>
           </div>
           <button
-            onClick={() => router.push("/dashboard/inbox")}
+            onClick={() => router.push("/inbox")}
             className="flex items-center gap-1 text-xs text-emerald-400 hover:text-emerald-300 transition-colors"
           >
             View all
@@ -261,7 +261,7 @@ export default function DashboardPage() {
             recentConversations.map((conv) => (
               <button
                 key={conv.id}
-                onClick={() => router.push("/dashboard/inbox")}
+                onClick={() => router.push("/inbox")}
                 className="flex w-full items-center gap-3 px-5 py-3 text-left transition-colors hover:bg-slate-800/50"
               >
                 <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-sm font-medium text-emerald-500">

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -6,12 +6,12 @@ import { LogOut } from "lucide-react";
 
 const pageTitles: Record<string, string> = {
   "/dashboard": "Dashboard",
-  "/dashboard/inbox": "Inbox",
-  "/dashboard/contacts": "Contacts",
-  "/dashboard/pipelines": "Pipelines",
-  "/dashboard/broadcasts": "Broadcasts",
-  "/dashboard/automations": "Automations",
-  "/dashboard/settings": "Settings",
+  "/inbox": "Inbox",
+  "/contacts": "Contacts",
+  "/pipelines": "Pipelines",
+  "/broadcasts": "Broadcasts",
+  "/automations": "Automations",
+  "/settings": "Settings",
 };
 
 function getPageTitle(pathname: string): string {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -17,15 +17,15 @@ import {
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/dashboard/inbox", label: "Inbox", icon: MessageSquare },
-  { href: "/dashboard/contacts", label: "Contacts", icon: Users },
-  { href: "/dashboard/pipelines", label: "Pipelines", icon: GitBranch },
-  { href: "/dashboard/broadcasts", label: "Broadcasts", icon: Radio },
-  { href: "/dashboard/automations", label: "Automations", icon: Zap },
+  { href: "/inbox", label: "Inbox", icon: MessageSquare },
+  { href: "/contacts", label: "Contacts", icon: Users },
+  { href: "/pipelines", label: "Pipelines", icon: GitBranch },
+  { href: "/broadcasts", label: "Broadcasts", icon: Radio },
+  { href: "/automations", label: "Automations", icon: Zap },
 ];
 
 const bottomNavItems = [
-  { href: "/dashboard/settings", label: "Settings", icon: Settings },
+  { href: "/settings", label: "Settings", icon: Settings },
 ];
 
 export function Sidebar() {


### PR DESCRIPTION
## Summary

Fixes 404 errors when navigating to Inbox, Contacts, Pipelines, Broadcasts, Automations, or Settings from the sidebar.

## Problem

Next.js route groups like \`(dashboard)\` don't appear in the URL path — they're only for code organization. So the actual URL for \`src/app/(dashboard)/inbox/page.tsx\` is \`/inbox\`, not \`/dashboard/inbox\`. But the sidebar, header, and dashboard page were all linking to the \`/dashboard/xxx\` paths, which don't exist → 404.

## Changes

- \`src/components/layout/sidebar.tsx\` — nav href values
- \`src/components/layout/header.tsx\` — page title map keys
- \`src/app/(dashboard)/dashboard/page.tsx\` — \`router.push\` calls

## Test plan

- [ ] \`npm run dev\` locally, log in, click each sidebar link — should navigate, not 404
- [ ] Click "View all" in Recent Conversations card on dashboard — should go to /inbox
- [ ] URL bar should show /inbox, /contacts, /pipelines, etc. (not /dashboard/inbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)