### PR TITLE
Fix auth lock contention and empty error logs (runtime errors)

### DIFF
--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -54,7 +54,13 @@ export function ConversationList({
       .order("last_message_at", { ascending: false });
 
     if (error) {
-      console.error("Failed to fetch conversations:", error);
+      // Supabase errors have non-enumerable properties — log fields explicitly
+      console.error("Failed to fetch conversations:", {
+        message: error.message,
+        details: error.details,
+        hint: error.hint,
+        code: error.code,
+      });
       setLoading(false);
       return;
     }

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,8 +1,18 @@
 import { createBrowserClient } from '@supabase/ssr'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// Singleton instance — one client shared across the whole browser session.
+// Creating multiple clients causes auth-lock contention ("Lock was released
+// because another request stole it") and intermittent fetch failures.
+let browserClient: SupabaseClient | undefined
 
 export function createClient() {
-  return createBrowserClient(
+  if (browserClient) return browserClient
+
+  browserClient = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   )
+
+  return browserClient
 }


### PR DESCRIPTION
## Summary

Fixes two runtime errors that appear in the browser when running the app:

1. `Lock "lock:sb-xxx-auth-token" was released because another request stole it`
2. `Failed to fetch conversations: {}` (empty error object)

## Root cause

\`src/lib/supabase/client.ts\` exported a \`createClient()\` function that created a **new** \`BrowserClient\` on every call. The codebase calls it 65 times across 33 files. Each client instance registers its own auth listener and tries to acquire the auth storage lock — they fight each other, causing both errors above.

## Changes

- \`src/lib/supabase/client.ts\` — cache the client in a module-level variable; return the cached instance on subsequent calls. No call sites need to change because the function signature stays the same.
- \`src/components/inbox/conversation-list.tsx\` — log Supabase error fields (\`message\`, \`details\`, \`hint\`, \`code\`) explicitly, so future errors show useful info instead of \`{}\`.

## Test plan

- [ ] \`npm run dev\` → log in → navigate between pages → no more lock errors in console
- [ ] Open Inbox → conversations load without errors (or shows empty state if no conversations yet)
- [ ] Sign out and sign back in → auth state syncs correctly

## Not a breaking change
The singleton returns the **same** client on every call, so RLS, session persistence, and realtime subscriptions all still work. No call sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)