### PR TITLE
Fix: dashboard stuck on infinite 'Loading...' spinner

### DIFF
--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -16,43 +16,79 @@ export function useAuth() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const supabase = createClient();
-
-  const fetchProfile = useCallback(
-    async (userId: string) => {
-      const { data } = await supabase
-        .from("profiles")
-        .select("id, full_name, email, avatar_url")
-        .eq("id", userId)
-        .single();
-
-      if (data) {
-        setProfile(data);
-      }
-    },
-    [supabase]
-  );
-
   useEffect(() => {
-    const getUser = async () => {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
+    const supabase = createClient();
+    let mounted = true;
 
-      setUser(user);
-
-      if (user) {
-        await fetchProfile(user.id);
+    // Safety net: if something hangs, surface it instead of an infinite spinner.
+    const safetyTimer = setTimeout(() => {
+      if (mounted) {
+        console.warn("[useAuth] getUser() timed out after 10s, clearing loading state");
+        setLoading(false);
       }
+    }, 10000);
 
-      setLoading(false);
+    const fetchProfile = async (userId: string) => {
+      try {
+        // profiles.user_id (NOT profiles.id) references auth.users.id
+        const { data, error } = await supabase
+          .from("profiles")
+          .select("id, full_name, email, avatar_url")
+          .eq("user_id", userId)
+          .maybeSingle();
+
+        if (error) {
+          console.error("[useAuth] fetchProfile error:", {
+            message: error.message,
+            details: error.details,
+            hint: error.hint,
+            code: error.code,
+          });
+          return;
+        }
+
+        if (data && mounted) {
+          setProfile(data);
+        }
+      } catch (err) {
+        console.error("[useAuth] fetchProfile threw:", err);
+      }
     };
 
-    getUser();
+    const init = async () => {
+      try {
+        const {
+          data: { user },
+          error,
+        } = await supabase.auth.getUser();
+
+        if (error) {
+          // AuthSessionMissingError is expected when not logged in — don't log as error
+          if (error.name !== "AuthSessionMissingError") {
+            console.error("[useAuth] getUser error:", error.message);
+          }
+        }
+
+        if (!mounted) return;
+        setUser(user);
+
+        if (user) {
+          await fetchProfile(user.id);
+        }
+      } catch (err) {
+        console.error("[useAuth] init threw:", err);
+      } finally {
+        if (mounted) setLoading(false);
+        clearTimeout(safetyTimer);
+      }
+    };
+
+    init();
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, session) => {
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      if (!mounted) return;
       const currentUser = session?.user ?? null;
       setUser(currentUser);
 
@@ -66,16 +102,21 @@ export function useAuth() {
     });
 
     return () => {
+      mounted = false;
+      clearTimeout(safetyTimer);
       subscription.unsubscribe();
     };
-  }, [supabase, fetchProfile]);
+    // Intentionally run once on mount — createClient() is a singleton
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const signOut = useCallback(async () => {
+    const supabase = createClient();
     await supabase.auth.signOut();
     setUser(null);
     setProfile(null);
     window.location.href = "/login";
-  }, [supabase]);
+  }, []);
 
   return { user, profile, loading, signOut };
 }


### PR DESCRIPTION
## Summary

Fixes the dashboard being stuck on an infinite "Loading..." spinner with no visible errors in the terminal or browser console.

## Root cause

Three compounding bugs in \`src/hooks/use-auth.ts\`:

### 1. Profile query used wrong column
\`\`\`ts
.from("profiles").eq("id", userId)  // ❌ profiles.id is the profile's own UUID
\`\`\`
The foreign key to \`auth.users.id\` is \`profiles.user_id\`, not \`profiles.id\`. The query returned nothing. Combined with \`.single()\` (which throws on 0 rows), this could reject the promise.

### 2. No try/catch/finally around \`supabase.auth.getUser()\`
If \`getUser()\` threw for any reason (e.g. the auth-lock contention from PR #2), \`setLoading(false)\` never ran — infinite spinner, no error.

### 3. useEffect dependencies caused infinite re-subscription
The effect depended on \`supabase\` and \`fetchProfile\`. Since \`createClient()\` returned a new instance each call (pre-PR #2), both refs changed every render, re-running the effect forever and racing \`getUser()\` calls against the auth lock.

## Changes in \`src/hooks/use-auth.ts\`

- \`fetchProfile\` now uses \`.eq("user_id", userId)\` and \`.maybeSingle()\` (returns \`{ data: null }\` instead of throwing on 0 rows)
- \`init()\` wrapped in \`try/catch/finally\` — \`setLoading(false)\` **always** runs
- 10-second safety timer clears loading state if anything hangs
- \`useEffect\` runs once on mount (empty deps; \`createClient()\` is a singleton)
- Logs Supabase error fields explicitly so we don't see empty \`{}\` in console
- Suppresses \`AuthSessionMissingError\` (normal for logged-out users)

## Test plan

- [ ] \`npm run dev\` locally, log in → dashboard loads immediately (no infinite spinner)
- [ ] Sidebar shows user's full name and email (profile fetch works)
- [ ] Sign out → redirect to /login
- [ ] Log in on a fresh session → profile loads correctly

## Related PRs
- PR #2 (singleton client) complements this fix — they address different symptoms of the same underlying auth flow issue. Merging both gives the cleanest result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)