### PR TITLE
fix: webhook message insert uses wrong schema field names

### DIFF
--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -184,13 +184,13 @@ async function handleStatusUpdate(status: {
   timestamp: string
   recipient_id: string
 }) {
+  // The messages table schema uses `message_id` (not whatsapp_message_id)
+  // and has no `updated_at` column. Meta's status values (sent/delivered/
+  // read/failed) already match our CHECK constraint.
   const { error } = await supabaseAdmin()
     .from('messages')
-    .update({
-      status: status.status,
-      updated_at: new Date().toISOString(),
-    })
-    .eq('whatsapp_message_id', status.id)
+    .update({ status: status.status })
+    .eq('message_id', status.id)
 
   if (error) {
     console.error('Error updating message status:', error)
@@ -227,18 +227,23 @@ async function processMessage(
   )
   if (!conversation) return
 
-  // Insert message
+  // Insert message — field names MUST match the messages table schema
+  // (see supabase/migrations/001_initial_schema.sql):
+  //   conversation_id, sender_type, content_type, content_text,
+  //   media_url, template_name, message_id, status, created_at
+  // `mediaType` is intentionally unused — the schema has no media_type
+  // column; the MIME type is only used to construct the proxy URL during
+  // parseMessageContent. Silence the unused-var warning:
+  void mediaType
   const { error: msgError } = await supabaseAdmin().from('messages').insert({
     conversation_id: conversation.id,
-    user_id: userId,
-    whatsapp_message_id: message.id,
-    direction: 'inbound',
-    message_type: message.type,
+    sender_type: 'customer',
+    content_type: message.type,
     content_text: contentText,
     media_url: mediaUrl,
-    media_type: mediaType,
-    status: 'received',
-    timestamp: new Date(parseInt(message.timestamp) * 1000).toISOString(),
+    message_id: message.id,
+    status: 'delivered',
+    created_at: new Date(parseInt(message.timestamp) * 1000).toISOString(),
   })
 
   if (msgError) {


### PR DESCRIPTION
## Summary

Fixes the Inbox showing contacts but no messages, and instantly showing \"24-hour session expired\" even after a customer just sent a message.

## Root cause

When a WhatsApp webhook arrives:
1. \`findOrCreateContact\` → works ✅
2. \`findOrCreateConversation\` → works ✅
3. \`messages.insert\` → **fails silently** ❌
4. \`conversations.update(last_message_text)\` → works ✅

The contact and conversation appear in the Inbox because their inserts/updates use correct field names. But the \`messages\` insert was writing fields that don't exist in the schema:

| Webhook wrote | Schema has |
|---|---|
| \`user_id\` | *(doesn't exist)* |
| \`whatsapp_message_id\` | \`message_id\` |
| \`direction: 'inbound'\` | \`sender_type\` (\`customer\`/\`agent\`/\`bot\`) |
| \`message_type\` | \`content_type\` |
| \`media_type\` | *(doesn't exist)* |
| \`status: 'received'\` | \`status\` (sending/sent/**delivered**/read/failed) |
| \`timestamp\` | \`created_at\` |

The error was caught and \`console.error\`'d, but not thrown — silently swallowed. The conversation update then succeeded (its fields matched), making the inbox show the contact and last message text while zero message rows actually existed.

The 24-hour session timer works by finding the most recent \`created_at\` where \`sender_type = 'customer'\`. With no messages in the DB, it defaults to \"no customer messages → expired\".

## Changes in \`src/app/api/whatsapp/webhook/route.ts\`

**\`processMessage()\`** — message insert now uses correct schema columns:
\`\`\`ts
{
  conversation_id: conversation.id,
  sender_type: 'customer',
  content_type: message.type,
  content_text: contentText,
  media_url: mediaUrl,
  message_id: message.id,
  status: 'delivered',
  created_at: <ISO from Meta timestamp>,
}
\`\`\`

**\`handleStatusUpdate()\`** — lookup uses \`message_id\` (not \`whatsapp_message_id\`) and no longer writes a non-existent \`updated_at\` column.

## Test plan

- [ ] From your phone, send a WhatsApp message to your business number
- [ ] Open CRM → Inbox → click the conversation
- [ ] **Message should now appear in the thread**
- [ ] 24-hour session timer should show remaining time (not \"expired\")
- [ ] Reply from CRM — roundtrip works
- [ ] Subsequent messages (and delivery/read receipts) continue to show up via realtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)