### PR TITLE
fix: outbound messages silently failing (Meta args + schema + silent errors)

### DIFF
--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -156,6 +156,15 @@ export default function InboxPage() {
     });
   }, []);
 
+  const handleUpdateMessage = useCallback(
+    (id: string, updates: Partial<Message>) => {
+      setMessages((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, ...updates } : m))
+      );
+    },
+    []
+  );
+
   const handleStatusChange = useCallback(
     (conversationId: string, status: ConversationStatus) => {
       setConversations((prev) =>
@@ -197,6 +206,7 @@ export default function InboxPage() {
           messages={messages}
           onMessagesLoaded={handleMessagesLoaded}
           onNewMessage={handleNewMessage}
+          onUpdateMessage={handleUpdateMessage}
           onStatusChange={handleStatusChange}
         />
 

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -100,40 +100,57 @@ export async function POST(request: Request) {
     const accessToken = decrypt(config.access_token)
 
     // Send via Meta API
+    // Function signatures are:
+    //   sendTextMessage(phoneNumberId, accessToken, to, text)
+    //   sendTemplateMessage(phoneNumberId, accessToken, to, templateName, language?, params?)
+    // The args were previously swapped (accessToken before phoneNumberId),
+    // causing Meta to reject every send.
     let waMessageId: string
 
-    if (message_type === 'template') {
-      const result = await sendTemplateMessage(
-        accessToken,
-        config.phone_number_id,
-        sanitizedPhone,
-        template_name,
-        template_params || []
+    try {
+      if (message_type === 'template') {
+        const result = await sendTemplateMessage(
+          config.phone_number_id,
+          accessToken,
+          sanitizedPhone,
+          template_name,
+          undefined, // use default language (en_US)
+          template_params || []
+        )
+        waMessageId = result.messageId
+      } else {
+        const result = await sendTextMessage(
+          config.phone_number_id,
+          accessToken,
+          sanitizedPhone,
+          content_text
+        )
+        waMessageId = result.messageId
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown Meta API error'
+      console.error('Meta API send failed:', message)
+      return NextResponse.json(
+        { error: `Meta API error: ${message}` },
+        { status: 502 }
       )
-      waMessageId = result.messageId
-    } else {
-      const result = await sendTextMessage(
-        accessToken,
-        config.phone_number_id,
-        sanitizedPhone,
-        content_text
-      )
-      waMessageId = result.messageId
     }
 
-    // Insert message into DB
+    // Insert message into DB — field names MUST match the messages schema
+    // (see supabase/migrations/001_initial_schema.sql):
+    //   conversation_id, sender_type, content_type, content_text,
+    //   media_url, template_name, message_id, status, created_at
     const { data: messageRecord, error: msgError } = await supabase
       .from('messages')
       .insert({
         conversation_id,
-        user_id: user.id,
-        whatsapp_message_id: waMessageId,
-        direction: 'outbound',
-        message_type,
+        sender_type: 'agent',
+        content_type: message_type,
         content_text: content_text || null,
         media_url: media_url || null,
+        template_name: template_name || null,
+        message_id: waMessageId,
         status: 'sent',
-        timestamp: new Date().toISOString(),
       })
       .select()
       .single()
@@ -141,7 +158,7 @@ export async function POST(request: Request) {
     if (msgError) {
       console.error('Error inserting sent message:', msgError)
       return NextResponse.json(
-        { error: 'Message sent but failed to save to database' },
+        { error: `Message sent to Meta but failed to save to DB: ${msgError.message}` },
         { status: 500 }
       )
     }

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -22,6 +22,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { MessageBubble } from "./message-bubble";
 import { MessageComposer } from "./message-composer";
+import { toast } from "sonner";
 
 interface MessageThreadProps {
   conversation: Conversation | null;
@@ -29,6 +30,7 @@ interface MessageThreadProps {
   messages: Message[];
   onMessagesLoaded: (messages: Message[]) => void;
   onNewMessage: (message: Message) => void;
+  onUpdateMessage: (id: string, updates: Partial<Message>) => void;
   onStatusChange: (conversationId: string, status: ConversationStatus) => void;
 }
 
@@ -68,6 +70,7 @@ export function MessageThread({
   messages,
   onMessagesLoaded,
   onNewMessage,
+  onUpdateMessage,
   onStatusChange,
 }: MessageThreadProps) {
   const [loading, setLoading] = useState(false);
@@ -169,9 +172,11 @@ export function MessageThread({
     async (text: string) => {
       if (!conversation) return;
 
-      // Optimistic update
+      const tempId = `temp-${Date.now()}`;
+
+      // Optimistic update — shows the message immediately with "sending" status
       const optimisticMsg: Message = {
-        id: `temp-${Date.now()}`,
+        id: tempId,
         conversation_id: conversation.id,
         sender_type: "agent",
         content_type: "text",
@@ -192,14 +197,29 @@ export function MessageThread({
           }),
         });
 
+        const payload = await res.json().catch(() => ({}));
+
         if (!res.ok) {
-          console.error("Failed to send message");
+          const reason = payload?.error || `HTTP ${res.status}`;
+          console.error("Failed to send message:", reason);
+          toast.error(`Failed to send: ${reason}`);
+          // Mark the optimistic bubble as failed so the user sees what happened
+          onUpdateMessage(tempId, { status: "failed" });
+          return;
         }
+
+        // Success — the realtime INSERT event will replace the temp bubble
+        // with the real DB row. If realtime hasn't arrived yet, at least
+        // flip status to 'sent' so the UI stops showing "sending".
+        onUpdateMessage(tempId, { status: "sent" });
       } catch (err) {
         console.error("Failed to send message:", err);
+        const reason = err instanceof Error ? err.message : "network error";
+        toast.error(`Failed to send: ${reason}`);
+        onUpdateMessage(tempId, { status: "failed" });
       }
     },
-    [conversation, onNewMessage]
+    [conversation, onNewMessage, onUpdateMessage]
   );
 
   const handleStatusChange = useCallback(


### PR DESCRIPTION
## Summary

Fixes the problem where typing a reply and hitting Enter:
- Shows the message briefly in the UI (optimistic update)
- But the test phone never receives it
- And the message disappears after navigating away and back

## Three compounding bugs

### 1. Swapped Meta API args (same bug we fixed for \`/config\` in PR #8)
\`/api/whatsapp/send\` was calling \`sendTextMessage(accessToken, phoneNumberId, to, text)\` but the helper signature is \`sendTextMessage(phoneNumberId, accessToken, to, text)\`. So every request went to:

\`\`\`
POST https://graph.facebook.com/v21.0/<ACCESS_TOKEN>/messages
Authorization: Bearer <PHONE_NUMBER_ID>
\`\`\`

Meta rejected every call. The generic \`catch\` returned a meaningless \"Failed to send message\".

### 2. Schema mismatch on messages insert (same class as the webhook bug fixed in PR #10)
Even if Meta had worked, the DB insert wrote columns that don't exist:

| Route wrote | Schema has |
|---|---|
| \`user_id\` | *(doesn't exist)* |
| \`whatsapp_message_id\` | \`message_id\` |
| \`direction: 'outbound'\` | \`sender_type: 'agent'\` |
| \`message_type\` | \`content_type\` |
| \`timestamp\` | \`created_at\` |

So the optimistic bubble never became a real DB row → disappeared on reload.

### 3. Frontend swallowed the errors
\`handleSend\` only did \`console.error\`. No toast, no status update — the UI looked successful even though nothing reached Meta.

## Changes

**\`src/app/api/whatsapp/send/route.ts\`**
- Meta call args reordered to \`(phoneNumberId, accessToken, ...)\`
- Wrapped Meta call in its own try/catch → returns \`502\` with the actual Meta error message
- Fixed messages insert to use schema columns: \`sender_type: 'agent'\`, \`content_type\`, \`content_text\`, \`media_url\`, \`template_name\`, \`message_id\`, \`status\`
- Surfaces the underlying DB error if insert fails

**\`src/components/inbox/message-thread.tsx\`**
- Added \`onUpdateMessage\` prop
- \`handleSend\` parses the error response, shows a toast with the actual reason, and marks the optimistic bubble as \`status: 'failed'\` → red XCircle icon
- On success, flips status to \`'sent'\` immediately (realtime INSERT still replaces the temp bubble)

**\`src/app/(dashboard)/inbox/page.tsx\`**
- Added \`handleUpdateMessage\` that mutates a message by id
- Wired into \`<MessageThread>\` as \`onUpdateMessage\`

## Test plan

- [ ] Open Inbox → select a conversation → type a reply → Enter
- [ ] Message appears with \"sending\" status
- [ ] Test phone **receives** the message
- [ ] Bubble flips to single check (sent), then double check when delivered
- [ ] Navigate away and back → message persists
- [ ] Try with a bad token (intentionally break it) → toast shows Meta's actual error, bubble turns red

🤖 Generated with [Claude Code](https://claude.com/claude-code)