### PR TITLE
fix(inbox): re-clicking active conversation no longer clears messages

### DIFF
--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -139,11 +139,19 @@ export default function InboxPage() {
     []
   );
 
-  const handleSelectConversation = useCallback((conv: Conversation) => {
-    setActiveConversation(conv);
-    setActiveContact(conv.contact ?? null);
-    setMessages([]);
-  }, []);
+  const handleSelectConversation = useCallback(
+    (conv: Conversation) => {
+      // Re-clicking the already-active conversation would clear the
+      // messages array, but the fetch effect in MessageThread only re-runs
+      // when conversationId changes — so messages would stay empty until
+      // the user navigated away and back. Bail out early instead.
+      if (activeConversation?.id === conv.id) return;
+      setActiveConversation(conv);
+      setActiveContact(conv.contact ?? null);
+      setMessages([]);
+    },
+    [activeConversation?.id]
+  );
 
   const handleMessagesLoaded = useCallback((loaded: Message[]) => {
     setMessages(loaded);


### PR DESCRIPTION
## Summary
- Fixes: opening a conversation, then clicking the same conversation again wiped the message thread until the user navigated away and came back.
- Root cause: `handleSelectConversation` always called `setMessages([])`, but `MessageThread`'s fetch effect only re-runs when `conversationId` changes — so re-selecting the active conversation cleared state without triggering a refetch.
- Fix: early-return from `handleSelectConversation` when the clicked conversation is already active.

## Test plan
- [ ] Open Inbox, select a conversation — messages render.
- [ ] Click the same conversation again — messages stay visible (previously disappeared).
- [ ] Switch to a different conversation — messages load for the new one.
- [ ] Unread count still clears when opening a conversation with unread messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)