### PR TITLE
fix(pipelines): column sizing + senior-review pass

### DIFF
--- a/src/components/pipelines/deal-form.tsx
+++ b/src/components/pipelines/deal-form.tsx
@@ -69,10 +69,12 @@ export function DealForm({
   const [saving, setSaving] = useState(false);
   const [statusAction, setStatusAction] = useState<DealStatus | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   // Reset when opening
   useEffect(() => {
     if (!open) return;
+    setConfirmDelete(false);
     if (deal) {
       setTitle(deal.title);
       setValue(String(deal.value ?? ""));
@@ -211,10 +213,6 @@ export function DealForm({
 
   async function handleDelete() {
     if (!deal) return;
-    const confirmed = window.confirm(
-      "Delete this deal? This cannot be undone.",
-    );
-    if (!confirmed) return;
     setDeleting(true);
     const { error } = await supabase.from("deals").delete().eq("id", deal.id);
     setDeleting(false);
@@ -223,6 +221,7 @@ export function DealForm({
       return;
     }
     toast.success("Deal deleted");
+    setConfirmDelete(false);
     onOpenChange(false);
     onSaved();
   }
@@ -426,17 +425,39 @@ export function DealForm({
               </Button>
             </div>
 
-            {deal && (
-              <button
-                type="button"
-                onClick={handleDelete}
-                disabled={deleting}
-                className="mt-3 flex w-full items-center justify-center gap-1 text-xs text-red-400 hover:text-red-300"
-              >
-                <Trash2 className="h-3 w-3" />
-                {deleting ? "Deleting..." : "Delete Deal"}
-              </button>
-            )}
+            {deal &&
+              (confirmDelete ? (
+                <div className="mt-3 flex items-center justify-between gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs">
+                  <span className="text-red-300">Delete this deal?</span>
+                  <div className="flex gap-1">
+                    <button
+                      type="button"
+                      onClick={() => setConfirmDelete(false)}
+                      disabled={deleting}
+                      className="rounded px-2 py-1 text-slate-300 hover:bg-slate-800"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      disabled={deleting}
+                      className="rounded bg-red-600 px-2 py-1 font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                    >
+                      {deleting ? "Deleting..." : "Confirm"}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(true)}
+                  className="mt-3 flex w-full items-center justify-center gap-1 text-xs text-red-400 hover:text-red-300"
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Delete Deal
+                </button>
+              ))}
           </div>
         </div>
       </SheetContent>

--- a/src/components/pipelines/pipeline-analytics.tsx
+++ b/src/components/pipelines/pipeline-analytics.tsx
@@ -99,7 +99,7 @@ export function PipelineAnalytics({ stages, deals }: PipelineAnalyticsProps) {
 
   return (
     <TooltipProvider>
-      <div className="grid grid-cols-2 gap-3 rounded-xl border border-slate-800 bg-slate-900/60 p-4 sm:grid-cols-3 lg:grid-cols-6">
+      <div className="grid grid-cols-2 gap-3 rounded-xl border border-slate-800 bg-slate-900/60 p-4 sm:grid-cols-3 xl:grid-cols-6">
         <Metric
           icon={<BarChart3 className="h-4 w-4 text-slate-400" />}
           label="Total Deals"

--- a/src/components/pipelines/pipeline-board.tsx
+++ b/src/components/pipelines/pipeline-board.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import {
   DndContext,
   DragOverlay,
+  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
@@ -62,6 +63,9 @@ export function PipelineBoard({
   const sensors = useSensors(
     // 5px activation distance avoids clicks being interpreted as drags.
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    // Keyboard drag support: focus a card, Space to pick up, arrows to move,
+    // Space to drop, Escape to cancel.
+    useSensor(KeyboardSensor),
   );
 
   const activeDeal = activeDealId
@@ -172,7 +176,7 @@ function StageColumn({
   const { setNodeRef, isOver } = useDroppable({ id: stage.id });
 
   return (
-    <div className="flex min-w-[280px] max-w-[300px] shrink-0 flex-col rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+    <div className="flex min-w-[260px] flex-1 basis-[260px] flex-col rounded-xl border border-slate-800 bg-slate-900/60 p-4">
       {/* 3px colored top border — sits above the column's padding */}
       <div
         className="-mx-4 -mt-4 h-[3px] rounded-t-xl"

--- a/src/components/pipelines/pipeline-settings.tsx
+++ b/src/components/pipelines/pipeline-settings.tsx
@@ -100,26 +100,33 @@ export function PipelineSettings({
 
   async function handleSave() {
     setSaving(true);
-    const { error: renameErr } = await supabase
-      .from("pipelines")
-      .update({ name: name.trim() })
-      .eq("id", pipeline.id);
-    if (renameErr) {
-      toast.error("Failed to rename pipeline");
-      setSaving(false);
+
+    // One upsert for all stages — batches N stage writes into a single
+    // round-trip. Previous implementation did N sequential UPDATEs which
+    // latency-scaled linearly with stage count.
+    const stageRows = localStages.map((s, i) => ({
+      id: s.id,
+      pipeline_id: s.pipeline_id,
+      name: s.name,
+      color: s.color,
+      position: i,
+    }));
+
+    const [renameRes, stagesRes] = await Promise.all([
+      supabase
+        .from("pipelines")
+        .update({ name: name.trim() })
+        .eq("id", pipeline.id),
+      supabase.from("pipeline_stages").upsert(stageRows, { onConflict: "id" }),
+    ]);
+
+    setSaving(false);
+
+    if (renameRes.error || stagesRes.error) {
+      toast.error("Failed to save pipeline");
       return;
     }
 
-    // Persist each stage's name/color/position
-    for (let i = 0; i < localStages.length; i++) {
-      const s = localStages[i];
-      await supabase
-        .from("pipeline_stages")
-        .update({ name: s.name, color: s.color, position: i })
-        .eq("id", s.id);
-    }
-
-    setSaving(false);
     onOpenChange(false);
     onPipelinesChanged();
     onStagesChanged();


### PR DESCRIPTION
## Summary

### Sizing
- **Board columns** now grow to fill wide viewports (`flex-1 basis-[260px]`) instead of being capped at 300px and leaving dead space to the right. Still overflow-scrolls on narrow screens.
- **Analytics grid** breakpoints tightened: 2 cols mobile → 3 cols sm → 6 cols xl (was `lg`, which cramped labels between 1024–1280px).

### Senior-review pass
- **Batched stage saves**. `pipeline-settings.handleSave` was doing N sequential `UPDATE` round-trips in a `for` loop — latency scaled linearly with stage count. Now a single `upsert(..., { onConflict: \"id\" })` round-trip, parallelized with the pipeline rename via `Promise.all`.
- **Inline delete confirm**. `deal-form` was using `window.confirm` for delete — jarring vs. the rest of the app. Swapped for an inline confirm row matching the pattern already used in `pipeline-settings` for pipeline deletion.
- **Keyboard drag support**. Added `KeyboardSensor` alongside `PointerSensor` in `pipeline-board`. Deal cards are now draggable via keyboard (Space to pick up, arrows to move, Space to drop, Escape to cancel) — a11y baseline.

## Open review notes (not in this PR)
- **Contact/profile selectors** in the deal form are native `<select>` elements, so they don't support search. With large contact lists this will get painful — should become a combobox (shadcn Command or similar). Left for a follow-up.
- **\"Link to Conversation\"** currently just links to `/inbox`. For true deep-link behavior the inbox page would need to read a `?conversation=<id>` query param and auto-select — an inbox change, not pipelines.
- **Seeding race on concurrent tabs**: two tabs hitting `/pipelines` with zero pipelines at the same moment could double-create \"Sales Pipeline\". Low risk; would need a `UNIQUE(user_id, name)` constraint to fully guard.
- **\"This month\" won/lost counts** use `updated_at ?? created_at` as a proxy for when the deal was closed. A dedicated `closed_at` column would be more accurate, but requires schema + write-site changes.

## Test plan
- [ ] Desktop: 5 columns spread evenly across the viewport, no dead space on the right
- [ ] Narrow window (< ~1500px): columns still at ≥260px, horizontal scroll kicks in
- [ ] Mobile (~375px): one column visible at a time, scrolls smoothly; analytics tiles in 2-up grid
- [ ] Pipeline settings → drag to reorder 5 stages + rename → Save once → only one request group hits Supabase (check Network tab)
- [ ] Open an existing deal → click \"Delete Deal\" → inline confirm appears → Cancel restores the button; Confirm deletes + closes sheet
- [ ] Tab to a deal card → Space → arrow keys move the overlay between stages → Space drops it (keyboard DnD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)