### PR TITLE
fix(broadcasts): set user_id on send, surface errors with a toast

### DIFF
--- a/src/app/(dashboard)/broadcasts/new/page.tsx
+++ b/src/app/(dashboard)/broadcasts/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { MessageTemplate } from '@/types';
 import { Step1ChooseTemplate } from '@/components/broadcasts/step1-choose-template';
 import { Step2SelectAudience } from '@/components/broadcasts/step2-select-audience';
@@ -49,7 +50,12 @@ export default function NewBroadcastPage() {
       });
       router.push(`/broadcasts/${broadcastId}`);
     } catch (err) {
+      // Until now the wizard swallowed errors with a console.error, so
+      // the user just saw "nothing happens" when a send failed. Surface
+      // the actual reason via a toast.
+      const message = err instanceof Error ? err.message : 'Broadcast failed';
       console.error('Broadcast failed:', err);
+      toast.error(message);
     }
   }
 

--- a/src/hooks/use-broadcast-sending.ts
+++ b/src/hooks/use-broadcast-sending.ts
@@ -128,6 +128,18 @@ export function useBroadcastSending(): UseBroadcastSendingReturn {
     const supabase = createClient();
 
     try {
+      // ── Step 0: Resolve current user ──────────────────────────────
+      // broadcasts.user_id is NOT NULL + guarded by an RLS policy
+      // (auth.uid() = user_id). Without this, the INSERT below silently
+      // fails with a 23502/42501 error and the whole wizard no-ops.
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const user = session?.user;
+      if (!user) {
+        throw new Error('You are not signed in.');
+      }
+
       // ── Step 1: Resolve audience contacts ─────────────────────────
       setProgress(5);
       const contacts = await resolveAudience(payload.audience);
@@ -141,6 +153,7 @@ export function useBroadcastSending(): UseBroadcastSendingReturn {
       const { data: broadcast, error: broadcastError } = await supabase
         .from('broadcasts')
         .insert({
+          user_id: user.id,
           name: payload.name,
           template_name: payload.template.name,
           template_language: payload.template.language ?? 'en_US',
@@ -161,7 +174,9 @@ export function useBroadcastSending(): UseBroadcastSendingReturn {
         .single();
 
       if (broadcastError || !broadcast) {
-        throw new Error(`Failed to create broadcast: ${broadcastError?.message}`);
+        throw new Error(
+          `Failed to create broadcast: ${broadcastError?.message ?? 'unknown error'}`,
+        );
       }
 
       // ── Step 3: Insert recipient rows (batched for request size) ──


### PR DESCRIPTION
## Summary

Fixes \"Send Broadcast does nothing\" — the wizard completed all 4 steps, the confirmation modal closed, and the flow silently no-op'd.

## Root cause

\`src/hooks/use-broadcast-sending.ts\`'s INSERT into \`broadcasts\` never set \`user_id\`. But \`broadcasts.user_id\` is \`NOT NULL\` and the RLS policy requires \`auth.uid() = user_id\` — so PostgREST rejected the INSERT (error 23502 / 42501). The hook threw, \`handleSend\` caught it with \`console.error\` only, and the UI had no idea anything happened. \`isProcessing\` flipped on then off in the same tick so the progress bar never even flashed.

The save-as-draft path (added in PR B) already sets \`user_id\` correctly — this is why draft works but send doesn't.

## Fix

- Resolve `session.user` at the start of \`createAndSendBroadcast\` and include \`user_id: user.id\` on the broadcasts INSERT.
- \`new/page.tsx handleSend\` now shows the error via a \`sonner\` toast so future failures surface immediately instead of vanishing.

## Test plan
- [ ] Send a broadcast to ≥1 contact → wizard redirects to \`/broadcasts/:id\` and the row shows up in the list
- [ ] Sign out → attempt send (edge case) → toast says \"You are not signed in.\"
- [ ] Force a Meta API error (invalid template_name) → hook still completes, individual recipients marked failed, broadcast row created (status=failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)