### PR TITLE
fix(deploy): Cache-Control headers so CDN stops serving stale HTML

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,65 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  /**
+   * Cache-Control policy.
+   *
+   * Why this exists:
+   *   Hostinger's CDN was applying `s-maxage=31536000` (1 year) to
+   *   prerendered HTML pages by default. When a new deploy shipped
+   *   fresh Turbopack chunk hashes, the edge kept serving year-old
+   *   HTML referencing chunk filenames that no longer existed on
+   *   disk — result: HTML 200, every /_next/static/*.js and .css
+   *   came back 404, the page rendered unstyled. Private/incognito
+   *   did nothing because the cache is server-side.
+   *
+   * Strategy:
+   *   - /_next/static/* — immutable for a year. Filenames are
+   *     content-hashed, so a new build produces new filenames; the
+   *     old ones are safe to keep indefinitely in caches.
+   *   - /api/*          — no-store. API responses are per-user and
+   *     must never be shared across requests at the edge.
+   *   - Everything else — public, brief s-maxage + generous
+   *     stale-while-revalidate. The edge serves instantly from cache
+   *     for the first 5 min, then returns cached content while
+   *     refreshing in the background for up to 24 h. A deploy's
+   *     chunk-hash drift self-heals within ~5 min with no user-
+   *     visible latency.
+   *
+   *   Note: dynamic dashboard routes (/inbox, /contacts, /pipelines,
+   *   /broadcasts, etc.) are server-rendered per request — Next.js
+   *   and Supabase auth already prevent them from being served
+   *   from a shared cache. The s-maxage here is a ceiling; Next.js
+   *   and auth middleware still set `private` / `no-store` for
+   *   per-user responses.
+   */
+  async headers() {
+    return [
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/api/:path*",
+        headers: [{ key: "Cache-Control", value: "no-store" }],
+      },
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value:
+              "public, max-age=0, s-maxage=300, stale-while-revalidate=86400",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Stops the \"site loads unstyled after a deploy\" issue by taking explicit control of \`Cache-Control\`.

### Root cause
Hostinger's CDN was defaulting prerendered HTML responses to \`s-maxage=31536000\` (1 year). A new deploy ships fresh Turbopack chunk hashes; the edge keeps serving year-old HTML referencing chunks the new build no longer has on disk. Result: HTML 200 + every \`/_next/static/*.{js,css}\` 404, page rendered unstyled. Private/incognito doesn't help — the cache is at the edge.

### Fix
Three explicit rules in \`next.config.ts\` via \`headers()\`:

| Path | Cache-Control | Why |
|------|---------------|-----|
| \`/_next/static/*\` | \`public, max-age=31536000, immutable\` | Content-hashed filenames — safe forever |
| \`/api/*\` | \`no-store\` | Per-user, must never be shared at the edge |
| everything else | \`public, max-age=0, s-maxage=300, stale-while-revalidate=86400\` | Instant from cache for 5 min; then still-instant with background refresh for 24 h. Chunk-hash drift self-heals in ~5 min with no user-visible latency. |

Next.js's own middleware + Supabase auth still mark per-user dashboard responses \`private\` / \`no-store\`, so the permissive rule above is a ceiling, not a forced cache for sensitive routes.

### Why this over \"just purge the CDN on every deploy\"?
- Self-healing instead of ritual — teammates (and future-you) don't have to remember anything
- Platform-agnostic — most CDNs respect \`Cache-Control\`; manual purge is Hostinger-specific
- Fails open — if Hostinger ignores the headers, behaviour is at worst equivalent to today; no regression risk

## Test plan
- [ ] Merge → wait for deploy to finish
- [ ] \`curl -I https://<host>/login | grep -i cache-control\` → should show \`public, max-age=0, s-maxage=300, stale-while-revalidate=86400\` (NOT \`s-maxage=31536000\`)
- [ ] \`curl -I https://<host>/_next/static/chunks/<any>.js | grep -i cache-control\` → \`public, max-age=31536000, immutable\`
- [ ] Deploy a no-op commit afterwards → site should stay styled throughout the rollout (no 5-10 min unstyled window)
- [ ] If Hostinger's CDN strips / overwrites these headers (visible in \`curl -I\`), report back — fallback is to configure purge-on-deploy at the platform layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)