### PR TITLE
fix: WaCRM favicon + template language defaults to en_US

### DIFF
--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,45 @@
+import { ImageResponse } from "next/og";
+
+// Replaces the default Next.js favicon with the WaCRM mark — emerald
+// rounded square + white chat-bubble glyph — matching the sidebar
+// logo in `src/components/layout/sidebar.tsx`. Next.js renders this
+// at build time and auto-injects <link rel="icon"> into <head>.
+//
+// This route takes precedence over src/app/favicon.ico, which is the
+// Next.js default and can stay on disk harmlessly (or be removed).
+
+export const runtime = "edge";
+export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#10b981", // emerald-500
+          borderRadius: 6,
+        }}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#ffffff"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/components/settings/template-manager.tsx
+++ b/src/components/settings/template-manager.tsx
@@ -53,14 +53,42 @@ interface TemplateFormData {
   footer_text: string;
 }
 
+// Meta's language codes are exact — "en" and "en_US" are distinct and a
+// template approved under one will be rejected if you send with the other
+// (Graph API error #132001 "Template name does not exist in the
+// translation"). Default to en_US to match the DB default on
+// message_templates.language and the broadcasts sender's fallback.
 const emptyForm: TemplateFormData = {
   name: '',
   category: 'Marketing',
-  language: 'en',
+  language: 'en_US',
   body_text: '',
   header_type: '',
   footer_text: '',
 };
+
+// Common Meta template language codes. The field still accepts any
+// string — this just offers autocomplete for the usual suspects. Full
+// list: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates#supported-languages
+const COMMON_LANGUAGE_CODES = [
+  'en_US',
+  'en_GB',
+  'en',
+  'es',
+  'es_ES',
+  'es_MX',
+  'fr',
+  'fr_FR',
+  'de',
+  'it',
+  'pt_BR',
+  'pt_PT',
+  'nl',
+  'pl',
+  'ru',
+  'tr',
+  'lt',
+];
 
 export function TemplateManager() {
   const supabase = createClient();
@@ -123,7 +151,7 @@ export function TemplateManager() {
         user_id: user.id,
         name: form.name.trim(),
         category: form.category,
-        language: form.language.trim() || 'en',
+        language: form.language.trim() || 'en_US',
         body_text: form.body_text.trim(),
         header_type: form.header_type || null,
         footer_text: form.footer_text.trim() || null,
@@ -285,11 +313,22 @@ export function TemplateManager() {
               <div className="space-y-2">
                 <Label className="text-slate-300">Language</Label>
                 <Input
-                  placeholder="en"
+                  list="template-language-codes"
+                  placeholder="en_US"
                   value={form.language}
                   onChange={(e) => setForm({ ...form, language: e.target.value })}
                   className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
                 />
+                <datalist id="template-language-codes">
+                  {COMMON_LANGUAGE_CODES.map((code) => (
+                    <option key={code} value={code} />
+                  ))}
+                </datalist>
+                <p className="text-[11px] text-slate-500">
+                  Must match the exact language code the template is approved
+                  under on Meta — e.g. <code>en_US</code> and <code>en</code>{' '}
+                  are distinct.
+                </p>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

### 1. Favicon
Browser tab was showing Next.js's default triangle because \`src/app/favicon.ico\` is the stock placeholder. Added a dynamic icon route at \`src/app/icon.tsx\` that renders the WaCRM sidebar mark (emerald-500 rounded square + white \`MessageSquare\` glyph). Next.js auto-injects \`<link rel=\"icon\">\` at build time.

### 2. Broadcast error #132001
Meta's \`Template name does not exist in the translation\` error = the template isn't approved in the language code you're sending with. The template manager was defaulting new templates to \`language=\"en\"\`, but Meta's WhatsApp templates are typically approved under \`en_US\`. Meta treats these as **distinct** language codes.

Changes:
- Template form default: \`en\` → \`en_US\` (matches the DB default on \`message_templates.language\` and the broadcast sender's fallback).
- Freeform \`<Input>\` → \`<Input list=\"...\">\` with a datalist of ~17 common Meta codes for autocomplete. Still accepts any string (Meta supports ~50 locales).
- Inline hint text under the field warning that \`en_US\` and \`en\` are distinct.

## One-time data fix for the current failing broadcast

The user's existing \`welcome_message\` template has \`language=\"en\"\` (set before this PR's default change). After merging:
1. Settings → Message Templates → edit \`welcome_message\`
2. Open Meta's WhatsApp Manager in another tab; note the exact language code the template is approved under (usually \`en_US\`)
3. Change the Language field in WaCRM to that exact value → Save
4. Retry the broadcast

All future templates created via the UI default to \`en_US\`, so this is a one-off.

## Test plan
- [ ] Browser tab shows green-square favicon instead of Next.js triangle
- [ ] Settings → Message Templates → New Template: Language field pre-filled \`en_US\`, autocomplete dropdown shows common codes
- [ ] Edit existing \`welcome_message\` to \`en_US\` (or whatever Meta reports), re-send broadcast, no #132001 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)