### PR TITLE
fix(contacts): allow deletion — SET NULL on broadcast_recipients + deals FKs

### DIFF
--- a/src/components/pipelines/deal-form.tsx
+++ b/src/components/pipelines/deal-form.tsx
@@ -79,7 +79,9 @@ export function DealForm({
       setTitle(deal.title);
       setValue(String(deal.value ?? ""));
       setCurrency(deal.currency || "USD");
-      setContactId(deal.contact_id);
+      // contact_id is nullable when the contact has been deleted
+      // (migration 004: ON DELETE SET NULL). "" means "no selection".
+      setContactId(deal.contact_id ?? "");
       setStageId(deal.stage_id);
       setAssignedTo(deal.assigned_to ?? "");
       setExpectedCloseDate(deal.expected_close_date ?? "");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,7 +141,11 @@ export interface Deal {
   user_id: string;
   pipeline_id: string;
   stage_id: string;
-  contact_id: string;
+  /**
+   * Nullable after migration 004 — becomes NULL when the referenced
+   * contact is deleted (ON DELETE SET NULL). History preserved.
+   */
+  contact_id: string | null;
   conversation_id?: string;
   assigned_to?: string;
   title: string;
@@ -182,7 +186,12 @@ export interface Broadcast {
 export interface BroadcastRecipient {
   id: string;
   broadcast_id: string;
-  contact_id: string;
+  /**
+   * Nullable after migration 004 — becomes NULL when the referenced
+   * contact is deleted (ON DELETE SET NULL). History preserved; the
+   * UI renders "Unknown" for orphaned rows.
+   */
+  contact_id: string | null;
   status: RecipientStatus;
   sent_at?: string;
   delivered_at?: string;

--- a/supabase/migrations/004_contact_delete_set_null.sql
+++ b/supabase/migrations/004_contact_delete_set_null.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- Allow contact deletion without wiping history.
+--
+-- broadcast_recipients.contact_id and deals.contact_id were declared
+-- NOT NULL REFERENCES contacts(id) with no ON DELETE action, so
+-- Postgres defaults to NO ACTION. The first time a user tried to
+-- delete a contact that had ever received a broadcast or been
+-- attached to a deal, the delete failed with:
+--
+--   ERROR 23503: update or delete on table "contacts" violates
+--   foreign key constraint ... on table <other>
+--
+-- CASCADE is the wrong fix — it would silently wipe historical
+-- broadcast recipient rows (breaking audit + retroactively moving
+-- broadcasts.sent_count / delivered_count / read_count etc. via the
+-- aggregate trigger) and deal rows.
+--
+-- SET NULL is the right fix: history rows survive with a NULL
+-- contact_id. The UI is already null-safe (contact?.name ?? 'Unknown',
+-- contact?.phone, etc.).
+--
+-- Idempotent — safe to run multiple times.
+-- ============================================================
+
+-- ── broadcast_recipients.contact_id ────────────────────────────
+ALTER TABLE broadcast_recipients
+  ALTER COLUMN contact_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'broadcast_recipients_contact_id_fkey'
+      AND conrelid = 'broadcast_recipients'::regclass
+  ) THEN
+    ALTER TABLE broadcast_recipients
+      DROP CONSTRAINT broadcast_recipients_contact_id_fkey;
+  END IF;
+END $$;
+
+ALTER TABLE broadcast_recipients
+  ADD CONSTRAINT broadcast_recipients_contact_id_fkey
+    FOREIGN KEY (contact_id) REFERENCES contacts(id)
+    ON DELETE SET NULL;
+
+-- ── deals.contact_id ───────────────────────────────────────────
+ALTER TABLE deals
+  ALTER COLUMN contact_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'deals_contact_id_fkey'
+      AND conrelid = 'deals'::regclass
+  ) THEN
+    ALTER TABLE deals
+      DROP CONSTRAINT deals_contact_id_fkey;
+  END IF;
+END $$;
+
+ALTER TABLE deals
+  ADD CONSTRAINT deals_contact_id_fkey
+    FOREIGN KEY (contact_id) REFERENCES contacts(id)
+    ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Deleting a contact failed with Postgres error 23503:
\`\`\`
update or delete on table \"contacts\" violates foreign key constraint
\"broadcast_recipients_contact_id_fkey\" on table ...
\`\`\`

### Root cause
Migration 001 declared both \`broadcast_recipients.contact_id\` and \`deals.contact_id\` as \`NOT NULL REFERENCES contacts(id)\` with **no \`ON DELETE\` clause**, so Postgres defaults to \`NO ACTION\`. Any contact who'd ever been a broadcast recipient or attached to a deal became un-deletable.

### Fix — migration 004
Both FKs relaxed to \`ON DELETE SET NULL\` + drop NOT NULL. History rows survive with \`contact_id = NULL\`. The UI is already null-safe:
- broadcast detail → \`contact?.name ?? 'Unknown'\`
- deal card → \`contact?.name || contact?.phone || 'No contact'\`
- CSV export → \`contact?.name ?? ''\`

### Why not CASCADE
Would wipe broadcast recipient rows and trigger the aggregate recount from migration 003, **retroactively changing \`sent_count\` / \`delivered_count\` / \`read_count\` on historical broadcasts**. Also wipes deal history. \`SET NULL\` preserves both counts and audit trail.

### Type changes
- \`Deal.contact_id\` and \`BroadcastRecipient.contact_id\` widen from \`string\` to \`string | null\`
- \`DealForm\`: \`setContactId(deal.contact_id ?? \"\")\` — the picker treats \`\"\"\` as unselected

## Apply before testing
\`\`\`sh
# supabase/migrations/004_contact_delete_set_null.sql
\`\`\`
Idempotent — safe to re-run.

## Test plan
- [ ] Apply migration 004 in Supabase.
- [ ] Delete a contact that has broadcast history + a deal → succeeds.
- [ ] Broadcast detail page for that broadcast → the deleted contact renders as \"Unknown\", their recipient timestamps + status are preserved, aggregate counts unchanged.
- [ ] Pipeline board → any deal that pointed at the deleted contact renders as \"No contact\".
- [ ] Deleting a contact with no broadcast / deal history still works (regression check).

## Heads-up (out of scope)
The \`next build\` output shows a warning from Next.js 16 about my \`/_next/static/:path*\` Cache-Control override in \`next.config.ts\`:
> Setting a custom Cache-Control header can break Next.js development behavior.

Next.js 16 already sets \`immutable\` on \`/_next/static/*\` by default. My rule from PR #26 is redundant. Happy to open a follow-up that removes just that rule and keeps the HTML + API ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)