### PR TITLE
fix(automations): widen step-picker dropdown so labels don't wrap

### DIFF
--- a/src/components/automations/automation-builder.tsx
+++ b/src/components/automations/automation-builder.tsx
@@ -651,7 +651,10 @@ function AddButton({ onPick }: { onPick: (t: AutomationStepType) => void }) {
         >
           <Plus className="h-4 w-4" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="max-h-80 overflow-y-auto border-slate-700 bg-slate-900">
+        <DropdownMenuContent
+          align="start"
+          className="max-h-80 min-w-56 overflow-y-auto border-slate-700 bg-slate-900"
+        >
           {ADDABLE_STEPS.map((t) => {
             const Icon = STEP_META[t].icon
             return (


### PR DESCRIPTION
## Summary

The add-step dropdown in the automation flow builder was wrapping every multi-word label onto multiple lines ("Send\nMessage", "Update\nContact\nField", etc.) — see the screenshot in the issue.

Root cause: the dropdown inherits its width from the trigger ("+" button, ~32px), which falls back to the base Menu `min-w-32` (128px). Far too narrow for the labels.

Fix: set `min-w-56` on the DropdownMenuContent and anchor it with `align="start"` so it drops down from the button's left edge instead of centering under a 32px button.

## Test plan

- [ ] Open an automation in the builder.
- [ ] Click any "+" between cards.
- [ ] Every label appears on a single line; the list is comfortably wide.
- [ ] Still renders inside the viewport when the button is near the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)