### PR TITLE
fix(dashboard): open the clicked conversation when deep-linking from dashboard

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -261,7 +261,7 @@ export default function DashboardPage() {
             recentConversations.map((conv) => (
               <button
                 key={conv.id}
-                onClick={() => router.push("/inbox")}
+                onClick={() => router.push(`/inbox?c=${conv.id}`)}
                 className="flex w-full items-center gap-3 px-5 py-3 text-left transition-colors hover:bg-slate-800/50"
               >
                 <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-sm font-medium text-emerald-500">

--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { Conversation, Message, Contact, ConversationStatus } from "@/types";
 import { useRealtime } from "@/hooks/use-realtime";
@@ -11,6 +12,15 @@ import { toast } from "sonner";
 import { WifiOff } from "lucide-react";
 
 export default function InboxPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  /**
+   * `?c=<id>` deep-link support. Used when landing here from the
+   * dashboard's recent-conversations list so the right thread opens
+   * automatically instead of showing the empty center panel.
+   */
+  const deepLinkConvId = searchParams.get("c");
+
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeConversation, setActiveConversation] =
     useState<Conversation | null>(null);
@@ -19,6 +29,12 @@ export default function InboxPage() {
   const [whatsappConnected, setWhatsappConnected] = useState<boolean | null>(
     null
   );
+
+  // Fire the deep-link auto-select exactly once per URL — subsequent
+  // list refreshes (realtime, manual refetch) must not snap the user
+  // back to the deep-linked conversation if they've already clicked
+  // elsewhere.
+  const autoSelectedForDeepLinkRef = useRef<string | null>(null);
 
   // Check WhatsApp connection status on mount
   useEffect(() => {
@@ -135,8 +151,26 @@ export default function InboxPage() {
   const handleConversationsLoaded = useCallback(
     (loaded: Conversation[]) => {
       setConversations(loaded);
+      // Resolve a pending deep-link here rather than in an effect — this
+      // is an event handler, so the setState calls below are allowed by
+      // react-hooks/set-state-in-effect. Runs once per ?c=<id> URL value
+      // via the ref, so realtime refreshes of the list can't snap the
+      // user back to the deep-linked thread after they've navigated.
+      if (
+        deepLinkConvId &&
+        autoSelectedForDeepLinkRef.current !== deepLinkConvId &&
+        loaded.length > 0
+      ) {
+        autoSelectedForDeepLinkRef.current = deepLinkConvId;
+        const match = loaded.find((c) => c.id === deepLinkConvId);
+        if (match) {
+          setActiveConversation(match);
+          setActiveContact(match.contact ?? null);
+          setMessages([]);
+        }
+      }
     },
-    []
+    [deepLinkConvId]
   );
 
   const handleSelectConversation = useCallback(
@@ -149,9 +183,14 @@ export default function InboxPage() {
       setActiveConversation(conv);
       setActiveContact(conv.contact ?? null);
       setMessages([]);
+      // Reflect the selection in the URL so a refresh lands the user
+      // back in the same thread, and so copy-paste links work. Use
+      // replace() to avoid polluting browser history with every click.
+      router.replace(`/inbox?c=${conv.id}`, { scroll: false });
     },
-    [activeConversation?.id]
+    [activeConversation?.id, router]
   );
+
 
   const handleMessagesLoaded = useCallback((loaded: Message[]) => {
     setMessages(loaded);


### PR DESCRIPTION
## Summary

Clicking a conversation in the dashboard's "Recent Conversations" section routed to `/inbox` with no hint about which conversation to open — the user landed on the empty center panel and had to find the thread again in the list.

## Fix

- **Dashboard** ([dashboard/page.tsx](src/app/(dashboard)/dashboard/page.tsx)): per-row clicks now route to `/inbox?c=<conversation_id>`. The "View all" button still goes to plain `/inbox` (it's a "show me the list" action).
- **Inbox** ([inbox/page.tsx](src/app/(dashboard)/inbox/page.tsx)):
  - Reads `?c=<id>` and auto-selects the matching conversation the first time the list loads. Uses a `useRef` guard so later realtime updates to the list can't snap the selection back after the user has clicked elsewhere.
  - Logic lives inside `handleConversationsLoaded` (an event callback) rather than a `useEffect`, to satisfy `react-hooks/set-state-in-effect` which Next 16 enforces.
  - Also replaces the URL with `?c=<id>` when the user picks a conversation, so a page refresh or shared link lands on the same thread.

## Test plan

- [ ] From the dashboard, click a row in "Recent Conversations" → land in `/inbox?c=<id>` with that thread open.
- [ ] "View all" still routes to plain `/inbox` with no forced selection.
- [ ] Refresh with `?c=<id>` → the same thread reopens.
- [ ] `?c=<unknown-id>` → list loads normally, center panel empty (no crash, no stuck state).
- [ ] Open inbox, click around — URL updates, but browser back button isn't spammed (using `router.replace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)