### PR TITLE
fix(automations): order send_template params numerically, not lexicographically

### DIFF
--- a/src/lib/automations/engine.ts
+++ b/src/lib/automations/engine.ts
@@ -315,9 +315,22 @@ async function runStep(step: AutomationStep, args: ExecuteArgs): Promise<string>
       if (!args.contactId) throw new Error('send_template needs a contact')
       if (!cfg.template_name) throw new Error('send_template needs template_name')
       const conversationId = await resolveConversationId(args)
+      // Meta templates use positional {{1}}, {{2}}, … placeholders, so
+      // we MUST emit params in strict numeric order. Lexicographic sort
+      // of "1", "2", …, "10" yields "1", "10", "2", … which silently
+      // scrambles every template with ≥10 variables.
       const params = cfg.variables
         ? Object.keys(cfg.variables)
-            .sort()
+            .sort((a, b) => {
+              const na = Number(a)
+              const nb = Number(b)
+              const aNum = Number.isFinite(na)
+              const bNum = Number.isFinite(nb)
+              if (aNum && bNum) return na - nb
+              if (aNum) return -1
+              if (bNum) return 1
+              return a.localeCompare(b)
+            })
             .map((k) => String(cfg.variables![k]))
         : []
       const { whatsapp_message_id } = await engineSendTemplate({


### PR DESCRIPTION
## Summary

Meta's template placeholders are positional (`{{1}}`, `{{2}}`, …). The engine's `send_template` step was sorting the keys of `step_config.variables` with a default string sort, so for a template with ≥10 variables the params emitted to Meta were in the order `"1", "10", "2", …`, silently scrambling every placeholder past the 9th.

## Fix

Sort numeric-looking keys by numeric value, with a locale-compare fallback for any non-numeric keys. One tiny comparator in [`engine.ts`](src/lib/automations/engine.ts) `case 'send_template'`.

## Test plan

- [ ] Build a template with 11 body variables (`{{1}}`–`{{11}}`).
- [ ] Create an automation with a `send_template` step and populate `step_config.variables = { "1": "one", …, "11": "eleven" }`.
- [ ] Activate + trigger it. Message delivered to the phone has `one`/`two`/…/`eleven` substituted in the right positions, not `one`/`ten`/`two`/…
- [ ] Existing templates with ≤9 variables continue to work identically (ordering is already correct by either sort for 1–9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)