### PR TITLE
fix(automations): scope meta-send contact lookup by user_id

### DIFF
--- a/src/lib/automations/meta-send.ts
+++ b/src/lib/automations/meta-send.ts
@@ -52,13 +52,22 @@ type SendInput =
 async function sendViaMeta(input: SendInput): Promise<{ whatsapp_message_id: string }> {
   const db = supabaseAdmin()
 
+  // Scope the contact lookup by user_id. The engine uses the
+  // service-role client (bypassing RLS), and the public
+  // /api/automations/engine endpoint accepts contact_id from the
+  // request body — without this filter, an authenticated user could
+  // fire their own automations against another tenant's contact UUID
+  // and send via their own WhatsApp config to that contact's phone.
+  // Practical risk is low (UUIDs are unguessable) but the check is
+  // cheap defense-in-depth.
   const { data: contact, error: contactErr } = await db
     .from('contacts')
     .select('id, phone')
     .eq('id', input.contactId)
+    .eq('user_id', input.userId)
     .maybeSingle()
   if (contactErr || !contact?.phone) {
-    throw new Error('contact phone missing')
+    throw new Error('contact not found for this user')
   }
 
   const sanitized = sanitizePhoneForMeta(contact.phone)


### PR DESCRIPTION
## Summary

The engine's [`sendViaMeta`](src/lib/automations/meta-send.ts) looked up the contact by `id` only. Because the engine runs with the service-role client (bypasses RLS) and the public `POST /api/automations/engine` endpoint accepts `contact_id` from the request body, an authenticated user could fire their own automations against another tenant's contact UUID and send via their own WhatsApp config to that contact's phone number.

UUIDs are unguessable so practical risk is low, but this is cheap defense-in-depth. Found during a security-focused pass on the automations code.

## Fix

Add `.eq('user_id', input.userId)` to the contact lookup. If the UUID belongs to a different tenant, the query returns no row and the helper throws "contact not found for this user" — which the engine records as a failed step in `automation_logs`.

## Test plan

- [ ] Normal path unchanged — automation sends a message to your own contact as before.
- [ ] Craft a manual `POST /api/automations/engine` with a contact_id that belongs to another tenant (simulate by swapping the id in DevTools). Response still 200 (fire-and-forget), but the `automation_logs` row now records `status: 'failed'` with `error_message: 'contact not found for this user'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)