### PR TITLE
fix(automations): Welcome Message template uses first_inbound_message

### DIFF
--- a/src/lib/automations/templates.ts
+++ b/src/lib/automations/templates.ts
@@ -33,7 +33,12 @@ export const AUTOMATION_TEMPLATES: Record<TemplateSlug, AutomationTemplateDefini
     slug: 'welcome_message',
     name: 'Welcome Message',
     description: 'Auto-reply to first-time contacts with a greeting.',
-    trigger_type: 'new_contact_created',
+    // first_inbound_message (added in PR #33) catches both brand-new
+    // contacts AND manually-added/imported contacts on their first-ever
+    // reply, which is what a user setting up a "welcome" automation
+    // almost always wants. new_contact_created would miss the
+    // manually-imported case.
+    trigger_type: 'first_inbound_message',
     trigger_config: {},
     steps: [
       {


### PR DESCRIPTION
## Summary

The "Welcome Message" quick-start template seeded `trigger_type: 'new_contact_created'`. That trigger only fires when the webhook auto-creates a contact row, so users who added/imported the contact manually never got the welcome flow on the contact's first message.

`first_inbound_message` (added in PR #33) is the superset: fires the first time any contact — auto-created OR pre-existing — sends a customer message. That's the correct semantic for a template explicitly named "Welcome Message".

One-line fix in [`templates.ts`](src/lib/automations/templates.ts).

## Test plan

- [ ] Click the "Welcome Message" quick-start template on the empty /automations list.
- [ ] Builder opens with trigger = "First Message from Contact" instead of "New Contact Created".
- [ ] Existing automations previously created from the template are unaffected — this only changes the seed for new instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)