### PR TITLE
fix(automations): atomic execution_count via SQL function (migration 007)

### DIFF
--- a/src/lib/automations/engine.ts
+++ b/src/lib/automations/engine.ts
@@ -159,13 +159,16 @@ async function executeAutomation(automation: Automation, input: DispatchInput) {
     triggerEvent: input.triggerType,
   })
 
-  await db
-    .from('automations')
-    .update({
-      execution_count: (automation.execution_count ?? 0) + 1,
-      last_executed_at: new Date().toISOString(),
-    })
-    .eq('id', automation.id)
+  // Atomic counter update via the SQL function from migration 007.
+  // Doing this with a client-side read-modify-write raced when the
+  // same automation fired for two contacts simultaneously — both
+  // would read N and both write N+1, losing one count permanently.
+  const { error: rpcErr } = await db.rpc('increment_automation_execution_count', {
+    p_automation_id: automation.id,
+  })
+  if (rpcErr) {
+    console.error('[automations] increment counter failed:', rpcErr)
+  }
 }
 
 interface ExecuteArgs {

--- a/supabase/migrations/007_automations_increment_counter.sql
+++ b/supabase/migrations/007_automations_increment_counter.sql
@@ -1,0 +1,35 @@
+-- ============================================================
+-- 007_automations_increment_counter.sql
+--
+-- Atomic increment of automations.execution_count + refresh of
+-- last_executed_at. Called via PostgREST RPC from the engine.
+--
+-- Before this, the engine did a read-modify-write:
+--   UPDATE automations SET execution_count = <cached + 1> WHERE id = ...
+-- so two concurrent dispatches (e.g. the same automation firing for
+-- two different contacts in the same second) could both read N and
+-- both write N+1, permanently losing one count.
+--
+-- Idempotent — safe to re-run.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION increment_automation_execution_count(p_automation_id UUID)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE automations
+  SET
+    execution_count = execution_count + 1,
+    last_executed_at = NOW()
+  WHERE id = p_automation_id;
+$$;
+
+-- Only the service role needs to call this (engine uses the
+-- service-role client). Explicitly lock anon / authenticated out so
+-- an authenticated user can't juice someone else's counter via RPC.
+REVOKE ALL ON FUNCTION increment_automation_execution_count(UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION increment_automation_execution_count(UUID) FROM anon;
+REVOKE ALL ON FUNCTION increment_automation_execution_count(UUID) FROM authenticated;
+GRANT EXECUTE ON FUNCTION increment_automation_execution_count(UUID) TO service_role;


### PR DESCRIPTION
## Summary

The engine did a client-side read-modify-write on `automations.execution_count`:

\`\`\`ts
await db.from('automations').update({
  execution_count: (automation.execution_count ?? 0) + 1,
  last_executed_at: new Date().toISOString(),
}).eq('id', automation.id)
\`\`\`

Two concurrent dispatches of the same automation (e.g. fired for two different contacts within the same second) could both read `N` and both write `N + 1`, permanently losing one count. Same risk on `last_executed_at` clobbering.

## Fix

- **Migration 007** adds `increment_automation_execution_count(p_automation_id UUID)` — a `SECURITY DEFINER` `sql` function that does the work atomically:
  ```sql
  UPDATE automations
  SET execution_count = execution_count + 1,
      last_executed_at = NOW()
  WHERE id = p_automation_id;
  ```
  Only `service_role` can EXECUTE it; `anon` and `authenticated` are explicitly `REVOKE`d, so an authenticated user can't juice another tenant's counter by calling the RPC directly (even though the existing RLS on `automations` would already block the final UPDATE).
- **Engine** now calls this via `db.rpc('increment_automation_execution_count', { p_automation_id: automation.id })` instead of reading the cached count and adding 1.

## Test plan

1. Apply migration 007 (\`supabase db push\`).
2. In SQL editor, confirm the function exists: \`\\df increment_automation_execution_count\`.
3. Active an automation with a `send_message` step. Trigger it from two different contacts within the same second (two simulated webhooks). Confirm `execution_count` increments by 2, not 1.
4. As an `authenticated` user, try `SELECT increment_automation_execution_count('<uuid>')` from the SQL editor — should error with "permission denied for function".
5. Normal single-trigger paths continue to work (counter +=1 per dispatch, `last_executed_at` refreshed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)