### PR TITLE
fix(dashboard): pipeline card stretches to match the chart row height

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -177,8 +177,14 @@ export default function DashboardPage() {
       <QuickActions />
 
       {/* Charts row */}
+      {/* items-stretch (the grid default) stretches the two columns to
+          match the tallest sibling; adding h-full on each wrapper and
+          on the inner panels makes both cards actually fill that
+          stretched height so their rounded borders line up. Without
+          this, the pipeline card rendered at its natural (shorter)
+          height while the line chart drove the row height. */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
-        <div className="lg:col-span-3">
+        <div className="h-full lg:col-span-3">
           <ConversationsChart
             series={series}
             loading={seriesLoading}
@@ -186,7 +192,7 @@ export default function DashboardPage() {
             onRangeChange={handleRangeChange}
           />
         </div>
-        <div className="lg:col-span-2">
+        <div className="h-full lg:col-span-2">
           <PipelineDonut data={pipeline} loading={pipelineLoading} />
         </div>
       </div>

--- a/src/components/dashboard/conversations-chart.tsx
+++ b/src/components/dashboard/conversations-chart.tsx
@@ -46,7 +46,7 @@ export function ConversationsChart({ series, loading, range, onRangeChange }: Co
   }, [data])
 
   return (
-    <section className="rounded-xl border border-slate-800 bg-slate-900">
+    <section className="flex h-full flex-col rounded-xl border border-slate-800 bg-slate-900">
       <header className="flex items-center justify-between border-b border-slate-800 px-5 py-4">
         <div>
           <h2 className="text-sm font-semibold text-white">Conversations Over Time</h2>

--- a/src/components/dashboard/pipeline-donut.tsx
+++ b/src/components/dashboard/pipeline-donut.tsx
@@ -12,7 +12,7 @@ interface PipelineDonutProps {
 
 export function PipelineDonut({ data, loading }: PipelineDonutProps) {
   return (
-    <section className="flex flex-col rounded-xl border border-slate-800 bg-slate-900">
+    <section className="flex h-full flex-col rounded-xl border border-slate-800 bg-slate-900">
       <header className="border-b border-slate-800 px-5 py-4">
         <h2 className="text-sm font-semibold text-white">Pipeline Value</h2>
         <p className="mt-0.5 text-xs text-slate-500">


### PR DESCRIPTION
## Summary

In the dashboard charts row, the Pipeline Value card rendered at its natural (shorter) content height while the Conversations Over Time card drove the row's stretched height — leaving the pipeline card's rounded border floating above a block of empty space instead of aligning to the neighbour's bottom edge.

## Fix

Grid's default `items-stretch` already tells children to share the tallest sibling's height, but only if each child actually fills its given space. Added `h-full` on:

1. Both `<div>` column wrappers around the two cards in [`dashboard/page.tsx`](src/app/(dashboard)/dashboard/page.tsx).
2. The inner `<section>` of [`conversations-chart.tsx`](src/components/dashboard/conversations-chart.tsx) (added `flex h-full flex-col`).
3. The inner `<section>` of [`pipeline-donut.tsx`](src/components/dashboard/pipeline-donut.tsx) (changed existing `flex flex-col` to `flex h-full flex-col`).

Pipeline donut's existing `flex-1` content wrapper now has a defined height to stretch against, so the empty state (and the populated donut + legend) span the card cleanly.

## Test plan

- [ ] Load `/dashboard` with no deals → Pipeline Value card's bottom edge lines up with the Conversations Over Time card's bottom edge.
- [ ] Load `/dashboard` with enough deals that the donut + legend is taller than the line chart — the line chart now stretches down to match (instead of the pipeline card overflowing).
- [ ] Mobile breakpoint (single column) — no regression; cards stack at natural heights as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)