### PR TITLE
feat(mobile): snap-scroll kanban with viewport-sized columns

### DIFF
--- a/src/components/pipelines/pipeline-board.tsx
+++ b/src/components/pipelines/pipeline-board.tsx
@@ -102,7 +102,11 @@ export function PipelineBoard({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div className="pipeline-scroll flex gap-3 overflow-x-auto pb-4">
+      {/* snap-x + snap-mandatory on mobile so swipes land the next
+          stage cleanly at the viewport edge instead of mid-column.
+          Disabled on lg+ because the full board fits without scroll
+          there and snapping would interfere with the natural layout. */}
+      <div className="pipeline-scroll flex snap-x snap-mandatory gap-3 overflow-x-auto pb-4 lg:snap-none">
         {sortedStages.map((stage) => {
           const stageDeals = dealsByStage.get(stage.id) ?? [];
           const totalValue = stageDeals.reduce(
@@ -176,7 +180,13 @@ function StageColumn({
   const { setNodeRef, isOver } = useDroppable({ id: stage.id });
 
   return (
-    <div className="flex min-w-[260px] flex-1 basis-[260px] flex-col rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+    // On mobile each column is `w-[85vw]` (with a reasonable min/max)
+    // so the next column's edge peeks in — a "there's more here" hint.
+    // snap-start lands each column cleanly when swiping. On lg+ we
+    // restore the flex-1 share-the-row behavior. The droppable ref is
+    // on the inner messages region below — intentionally NOT here, so
+    // a drag over the column header doesn't highlight the whole column.
+    <div className="flex w-[85vw] min-w-[260px] max-w-[320px] shrink-0 snap-start flex-col rounded-xl border border-slate-800 bg-slate-900/60 p-4 lg:w-auto lg:max-w-none lg:flex-1 lg:basis-[260px] lg:shrink lg:snap-none">
       {/* 3px colored top border — sits above the column's padding */}
       <div
         className="-mx-4 -mt-4 h-[3px] rounded-t-xl"


### PR DESCRIPTION
## Summary

The pipelines board was already horizontally scrollable, but on a phone it felt imprecise — swipes landed mid-column, there was no visual hint that more columns existed off-screen, and 260px columns felt cramped at 375px width.

## What changed

- Each `StageColumn` is now `w-[85vw]` (clamped between `min-w-[260px]` and `max-w-[320px]`) on mobile. The next column's edge peeks in as a "there's more here" affordance.
- Scroll container gets `snap-x snap-mandatory` on mobile, `snap-none` on `lg+`. Each column has `snap-start`, so swipes always land cleanly at the left edge of the next column.
- `shrink-0` on mobile prevents flex from compressing columns when space is tight.

## Desktop

Unchanged. All mobile-specific classes are overridden by their `lg:` counterparts — `lg:w-auto lg:max-w-none lg:flex-1 lg:basis-[260px] lg:shrink lg:snap-none` restores the original share-the-row layout above `lg`.

## Test plan

- [ ] On mobile: swipe horizontally across the board → each stage snaps into place; the next column's edge is always partially visible.
- [ ] First swipe from stage 1 to stage 2 doesn't "miss" the snap target.
- [ ] On desktop (≥`lg`): board fills the available width with all columns visible, same as before. No snap behavior.
- [ ] Drag-and-drop of deal cards between stages still works on both mobile and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)