### PR TITLE
fix(mobile + seo): broadcasts table responsive + opengraph-image render

### DIFF
--- a/src/app/(dashboard)/broadcasts/page.tsx
+++ b/src/app/(dashboard)/broadcasts/page.tsx
@@ -211,14 +211,14 @@ export default function BroadcastsPage() {
             <TableHeader>
               <TableRow className="border-slate-800 hover:bg-transparent">
                 <TableHead className="text-slate-400">Name</TableHead>
-                <TableHead className="text-slate-400">Template</TableHead>
-                <TableHead className="text-slate-400 text-right">
+                <TableHead className="hidden text-slate-400 md:table-cell">Template</TableHead>
+                <TableHead className="hidden text-right text-slate-400 sm:table-cell">
                   Recipients
                 </TableHead>
-                <TableHead className="text-slate-400">Delivery</TableHead>
-                <TableHead className="text-slate-400">Read</TableHead>
+                <TableHead className="hidden text-slate-400 lg:table-cell">Delivery</TableHead>
+                <TableHead className="hidden text-slate-400 lg:table-cell">Read</TableHead>
                 <TableHead className="text-slate-400">Status</TableHead>
-                <TableHead className="text-slate-400">Date</TableHead>
+                <TableHead className="hidden text-slate-400 sm:table-cell">Date</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -233,20 +233,20 @@ export default function BroadcastsPage() {
                     <TableCell className="font-medium text-white">
                       {broadcast.name}
                     </TableCell>
-                    <TableCell className="text-slate-300">
+                    <TableCell className="hidden text-slate-300 md:table-cell">
                       {broadcast.template_name}
                     </TableCell>
-                    <TableCell className="text-right text-slate-300 tabular-nums">
+                    <TableCell className="hidden text-right text-slate-300 tabular-nums sm:table-cell">
                       {broadcast.total_recipients}
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="hidden lg:table-cell">
                       <RateCell
                         value={broadcast.delivered_count}
                         total={broadcast.total_recipients}
                         color="bg-emerald-500"
                       />
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="hidden lg:table-cell">
                       <RateCell
                         value={broadcast.read_count}
                         total={broadcast.total_recipients}
@@ -266,7 +266,7 @@ export default function BroadcastsPage() {
                         {status.label}
                       </span>
                     </TableCell>
-                    <TableCell className="text-slate-400">
+                    <TableCell className="hidden text-slate-400 sm:table-cell">
                       {new Date(broadcast.created_at).toLocaleDateString()}
                     </TableCell>
                   </TableRow>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -17,6 +17,14 @@ export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
 
 export default async function Image() {
+  // Satori (the renderer behind next/og) has two strict requirements
+  // that the previous version violated at runtime:
+  //   1. Every <div> with more than one child must explicitly declare
+  //      display: flex / contents / none.
+  //   2. Unicode glyphs outside the embedded font's coverage cause a
+  //      "Failed to download dynamic font" warning and the image
+  //      falls back to a missing-glyph tofu. ✓ was the worst
+  //      offender; replaced with a plain text dot.
   return new ImageResponse(
     (
       <div
@@ -50,13 +58,15 @@ export default async function Image() {
           >
             W
           </div>
-          <div style={{ fontSize: 36, fontWeight: 700, letterSpacing: -0.5 }}>
+          <div style={{ display: 'flex', fontSize: 36, fontWeight: 700, letterSpacing: -0.5 }}>
             {SITE_NAME}
           </div>
         </div>
 
         <div
           style={{
+            display: 'flex',
+            flexWrap: 'wrap',
             marginTop: 60,
             fontSize: 84,
             fontWeight: 800,
@@ -65,12 +75,13 @@ export default async function Image() {
             maxWidth: 1000,
           }}
         >
-          Run your WhatsApp business from{' '}
+          <span>Run your WhatsApp business from&nbsp;</span>
           <span style={{ color: '#34d399' }}>one inbox.</span>
         </div>
 
         <div
           style={{
+            display: 'flex',
             marginTop: 28,
             fontSize: 28,
             color: '#94a3b8',
@@ -78,8 +89,7 @@ export default async function Image() {
             lineHeight: 1.3,
           }}
         >
-          Shared inbox, sales pipelines, broadcasts, and no-code automations —
-          built on the official WhatsApp Business API.
+          Shared inbox, sales pipelines, broadcasts, and no-code automations — built on the official WhatsApp Business API.
         </div>
 
         <div
@@ -91,10 +101,13 @@ export default async function Image() {
             color: '#cbd5e1',
           }}
         >
-          <span>✓ Shared inbox</span>
-          <span>✓ Automations</span>
-          <span>✓ Pipelines</span>
-          <span>✓ Analytics</span>
+          <span>Shared inbox</span>
+          <span>·</span>
+          <span>Automations</span>
+          <span>·</span>
+          <span>Pipelines</span>
+          <span>·</span>
+          <span>Analytics</span>
         </div>
       </div>
     ),


### PR DESCRIPTION
## Summary

Last of the mobile-friendly series (following #48/#49/#50/#51), plus a latent production bug in the OG image endpoint that was throwing 500s on every request.

## Fixes

### Broadcasts table — responsive column tiers

The table rendered every column at every width, so a 375px phone had to swipe sideways just to read a name. Now it matches the tiering the contacts table already uses:

| Column | `<sm` | `sm+` | `md+` | `lg+` |
|---|---|---|---|---|
| Name | ✓ | ✓ | ✓ | ✓ |
| Status | ✓ | ✓ | ✓ | ✓ |
| Recipients | — | ✓ | ✓ | ✓ |
| Date | — | ✓ | ✓ | ✓ |
| Template | — | — | ✓ | ✓ |
| Delivery | — | — | — | ✓ |
| Read | — | — | — | ✓ |

### OG image endpoint — fixed 500 crashes

`/opengraph-image` was throwing on every request with two errors that Satori (the renderer behind `next/og`) is strict about:

1. `Expected <div> to have explicit "display: flex" if it has more than one child node.`
2. `Failed to download dynamic font for ✓` — the default font Satori loads doesn't cover the ✓ glyph.

Result: WhatsApp / LinkedIn / Slack shares of wacrm.tech were getting no link preview.

Fix:
- Every `<div>` with more than one child now has explicit `display: 'flex'`.
- The headline's inline `<span>` is now two `<span>`s inside a `display: flex; flex-wrap: wrap` parent.
- ✓ glyphs in the feature list → plain text dot separators.

Verified: `curl -sI http://localhost:3000/opengraph-image` → `HTTP/1.1 200 OK`, `content-type: image/png`.

## Test plan

- [ ] Broadcasts page on mobile (375px): only Name + Status columns visible, no horizontal scroll.
- [ ] Broadcasts page on a tablet (~768px): Name + Template + Recipients + Date + Status.
- [ ] Broadcasts page on desktop (≥1024px): all seven columns as before.
- [ ] `GET /opengraph-image` returns 200 `image/png` (no 500s in server logs).
- [ ] Paste the production URL into WhatsApp / LinkedIn / Slack after deploy → branded 1200×630 preview appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)