### PR TITLE
ci: typecheck + build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel older CI runs for the same branch when a new commit arrives —
+# saves minutes when someone pushes a stack of fixes to one PR.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, typecheck, build
+    runs-on: ubuntu-latest
+    # Dummy env vars so `next build` doesn't fail when it reads the
+    # public Supabase config at build time. These never leave CI and
+    # never hit a real service — they just satisfy the `!` non-null
+    # assertions in the client factories.
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://ci.example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-dummy-anon-key
+      ENCRYPTION_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Lint is non-blocking for now — the repo has pre-existing
+      # `react-hooks/set-state-in-effect` errors surfaced by the React
+      # 19 rule set. The step still runs so regressions are visible,
+      # but a failure here doesn't block merges until the backlog is
+      # cleared in a follow-up PR.
+      - name: Lint
+        continue-on-error: true
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",


### PR DESCRIPTION
## Summary
Adds \`.github/workflows/ci.yml\` so every PR against \`main\` gets a health signal automatically. Runs **lint**, **typecheck**, and **build** on Node 20 with npm caching.

Also adds \`"typecheck": "tsc --noEmit"\` to \`package.json\`. Next runs its own TypeScript check during \`build\`, but exposing \`typecheck\` as a script lets editors, pre-commit hooks, and CI surface type errors separately from build errors.

## Lint is non-blocking — for now
The repo has **14 pre-existing lint errors** across 8 files, nearly all from React 19's new \`react-hooks/set-state-in-effect\` rule catching legitimate code smells in pages that predate this cleanup pass. Fixing them in this PR would mix concerns; fixing them here and now would also inflate the diff beyond the CI-plumbing change.

Compromise: the workflow runs \`npm run lint\` with \`continue-on-error: true\` so errors are visible in the CI logs (regressions get caught) but don't block merges until the backlog is cleaned up. A follow-up PR should fix the errors and drop the flag.

## Verification
- \`npm run typecheck\` — clean.
- \`npm run build\` — clean locally with \`.env.local\` aside and only the three dummy env vars set in CI (\`NEXT_PUBLIC_SUPABASE_URL\`, \`NEXT_PUBLIC_SUPABASE_ANON_KEY\`, \`ENCRYPTION_KEY\`).
- \`npm run lint\` — 14 errors + 23 warnings, pre-existing.

## Concurrency
Workflow cancels in-progress runs when a new commit arrives on the same branch — saves minutes when you push a stack of fixes to one PR.

## Test plan
- [ ] This PR's own CI run goes green (lint shows red in logs but doesn't fail the job; typecheck + build pass).
- [ ] Future PRs that introduce type errors or break the build fail the check.
- [ ] Merging to \`main\` triggers a run (push trigger), so \`main\` has a status too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)