### PR TITLE
security: baseline response headers (CSP report-only + OWASP set)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,58 @@
 import type { NextConfig } from "next";
 
+/**
+ * Baseline security headers applied to every response.
+ *
+ * CSP ships as `Content-Security-Policy-Report-Only` so the browser
+ * surfaces violations in the console without blocking anything — once
+ * we have confidence nothing legit trips it (two deploys, a pass on
+ * every route), flip the key to `Content-Security-Policy` to enforce.
+ *
+ * The rest of the headers are straight blocks, safe to enforce today:
+ *   - HSTS: only meaningful on HTTPS (no-op on http://localhost).
+ *   - X-Content-Type-Options / X-Frame-Options / Referrer-Policy:
+ *     baseline OWASP hardening, no behavioural cost.
+ *   - Permissions-Policy: we don't use camera / microphone / etc, so
+ *     deny them. A supply-chain compromise or a forgotten plugin
+ *     can't silently opt back in.
+ */
+const SECURITY_HEADERS = [
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+  },
+  {
+    key: "Content-Security-Policy-Report-Only",
+    value: [
+      "default-src 'self'",
+      // Next.js needs 'unsafe-inline' for its inline hydration script
+      // and 'unsafe-eval' in dev + some production optimisations.
+      // Nonce-based CSP is a later project.
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      // Tailwind + inline style attributes on lots of components.
+      "style-src 'self' 'unsafe-inline'",
+      // Supabase public-bucket avatars, contact avatars (arbitrary
+      // https URLs paste-able from the UI), OG images, data URLs for
+      // tiny inline assets.
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      // Supabase REST + realtime (WSS). All Meta API calls happen
+      // server-side, so graph.facebook.com does not belong here.
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join("; "),
+  },
+] as const;
+
 const nextConfig: NextConfig = {
   /**
    * Cache-Control policy.
@@ -32,6 +85,11 @@ const nextConfig: NextConfig = {
    *   from a shared cache. The s-maxage here is a ceiling; Next.js
    *   and auth middleware still set `private` / `no-store` for
    *   per-user responses.
+   *
+   * Security headers are appended via a separate catch-all rule
+   * below — Next.js merges headers from every matching rule, so
+   * they apply to every response regardless of which cache rule
+   * matched.
    */
   async headers() {
     return [
@@ -57,6 +115,13 @@ const nextConfig: NextConfig = {
               "public, max-age=0, s-maxage=300, stale-while-revalidate=86400",
           },
         ],
+      },
+      {
+        // Security headers on every response, including /_next/static
+        // assets (nosniff matters there) and /api/* (HSTS + referrer-
+        // policy don't hurt).
+        source: "/:path*",
+        headers: [...SECURITY_HEADERS],
       },
     ];
   },


### PR DESCRIPTION
## Summary
Adds a baseline set of security headers to every response from the Next.js app. CSP ships as **report-only** so we learn what (if anything) it would catch before enforcing; the rest are straight blocks that are safe to turn on today.

## What's set

**Enforced:**
| Header | Value | Why |
|---|---|---|
| \`Strict-Transport-Security\` | \`max-age=63072000; includeSubDomains; preload\` | 2-year HTTPS lock. No-op on \`http://localhost\`. |
| \`X-Content-Type-Options\` | \`nosniff\` | Blocks MIME sniffing on static JS/CSS and uploaded media. |
| \`X-Frame-Options\` | \`DENY\` | Clickjacking defense for older browsers. |
| \`Referrer-Policy\` | \`strict-origin-when-cross-origin\` | Don't leak URLs on cross-origin navigation / HTTPS→HTTP downgrade. |
| \`Permissions-Policy\` | \`camera=(), microphone=(), geolocation=(), payment=(), usb=()\` | Deny APIs we don't use so a supply-chain compromise can't silently opt back in. |

**Report-only:**
\`\`\`
Content-Security-Policy-Report-Only:
  default-src 'self';
  script-src 'self' 'unsafe-inline' 'unsafe-eval';
  style-src 'self' 'unsafe-inline';
  img-src 'self' data: blob: https:;
  font-src 'self' data:;
  connect-src 'self' https://*.supabase.co wss://*.supabase.co;
  frame-ancestors 'none';
  base-uri 'self';
  form-action 'self';
\`\`\`

\`'unsafe-inline'\` / \`'unsafe-eval'\` are there because Next.js's hydration script is inlined and dev/Turbopack need eval. Nonce-based CSP is a separate, larger project. The \`img-src https:\` allowance covers user-pasted contact avatars, Supabase-bucket avatars, and OG images. Supabase realtime needs \`wss:\`.

## Why report-only?
Enforcing CSP out of the gate risks breaking the app for forkers whose integrations (analytics, fonts, OAuth redirects) I can't anticipate. Report-only gives a two-deploy window to surface violations in the browser console and in server logs before flipping the header key to \`Content-Security-Policy\` to enforce. That flip is a one-line diff in a follow-up PR.

## Verified locally
- \`curl -I\` on \`/\`, \`/docs\`, \`/login\`, \`/api/whatsapp/webhook\`, and \`/_next/static/*\` returns all six headers.
- Navigating to \`/\` and \`/docs\` in the browser — zero CSP violations in the console.

## Test plan
- [ ] After merge + deploy, visit the production site in a browser with DevTools open. Watch Console → look for any \`[Report Only]\` CSP messages. If there are any, adjust the allowlist before flipping to enforced.
- [ ] \`curl -sI https://<your-domain>/\` shows all six headers.
- [ ] Meta webhook still verifies and delivers successfully (no CSP/header interference; webhooks are server→server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)