### PR TITLE
fix(inbox): align composer send and template buttons with the textarea

### DIFF
--- a/src/components/inbox/message-composer.tsx
+++ b/src/components/inbox/message-composer.tsx
@@ -94,28 +94,23 @@ export function MessageComposer({
           <LayoutTemplate className="h-4 w-4" />
         </Button>
 
-        <div className="relative flex-1">
-          <textarea
-            ref={textareaRef}
-            value={text}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            placeholder={
-              sessionExpired
-                ? "Session expired - use a template"
-                : "Type a message... (Shift+Enter for new line)"
-            }
-            disabled={sessionExpired}
-            rows={1}
-            className={cn(
-              "w-full resize-none rounded-xl border border-slate-700 bg-slate-800 px-4 py-2.5 text-sm text-white placeholder-slate-500 outline-none transition-colors focus:border-emerald-500/50",
-              sessionExpired && "cursor-not-allowed opacity-50"
-            )}
-          />
-          <p className="mt-1 text-[10px] text-slate-600">
-            Type &apos;/&apos; for quick replies
-          </p>
-        </div>
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            sessionExpired
+              ? "Session expired - use a template"
+              : "Type a message... (Shift+Enter for new line)"
+          }
+          disabled={sessionExpired}
+          rows={1}
+          className={cn(
+            "flex-1 resize-none rounded-xl border border-slate-700 bg-slate-800 px-4 py-2.5 text-sm text-white placeholder-slate-500 outline-none transition-colors focus:border-emerald-500/50",
+            sessionExpired && "cursor-not-allowed opacity-50"
+          )}
+        />
 
         <Button
           size="sm"
@@ -126,6 +121,13 @@ export function MessageComposer({
           <Send className="h-4 w-4" />
         </Button>
       </div>
+
+      {/* Hint sits outside the flex row so its height doesn't push
+          `items-end` buttons below the textarea. Indented to line up
+          under the textarea left edge (w-9 button + gap-2 = 44px). */}
+      <p className="mt-1 pl-11 text-[10px] text-slate-600">
+        Type &apos;/&apos; for quick replies
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
The inbox message composer was rendering its template (left) and send (right) buttons a row below the textarea instead of level with it. Screenshot showed the paper-plane + template icons floating under the input bar.

## Root cause
[src/components/inbox/message-composer.tsx](src/components/inbox/message-composer.tsx) wrapped the textarea and its \"Type '/' for quick replies\" hint inside the same \`flex-1\` column. The flex row used \`items-end\`, which aligns children to the tallest child's bottom. Because the middle column measured textarea-height + hint-height, the buttons were pushed down to sit level with the hint instead of the textarea.

## Fix
Pull the hint out of the row — it's now a sibling of the \`flex items-end\` row, indented with \`pl-11\` so it still lines up under the textarea's left edge (w-9 button + gap-2 = 44px). The row now measures only the textarea, so \`items-end\` correctly aligns both buttons with the textarea's bottom edge.

## Verification
Structural only — the \`/inbox\` route requires auth and I couldn't exercise the rendered UI from the preview environment. Typecheck passes. Please confirm in the authenticated inbox after merge:

- [ ] Template button (left) sits level with the textarea bottom.
- [ ] Send button (right) sits level with the textarea bottom.
- [ ] \"Type '/' for quick replies\" hint appears below the row, indented under the textarea.
- [ ] Multi-line expansion (Shift+Enter for 2–4 lines) still keeps both buttons pinned to the bottom.
- [ ] Session-expired banner (shown when a 24h session elapses) still renders and closes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)