### PR TITLE
fix(inbox): don't drop messages when ?c= URL param updates

### DIFF
--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -163,6 +163,16 @@ export default function InboxPage() {
         loaded.length > 0
       ) {
         autoSelectedForDeepLinkRef.current = deepLinkConvId;
+        // If the deep-linked conversation is already the active one
+        // (e.g. because the user clicked it in the list and we
+        // router.replace()'d the URL, which made the ConversationList
+        // refetch and land us back here), do NOT re-apply it. Doing so
+        // would setMessages([]) on a thread whose messages have
+        // already been loaded by MessageThread — and because
+        // conversationId didn't change, MessageThread wouldn't
+        // refetch. The thread would read "No messages yet" until a
+        // full page reload rehydrated state from scratch.
+        if (activeConversation?.id === deepLinkConvId) return;
         const match = loaded.find((c) => c.id === deepLinkConvId);
         if (match) {
           setActiveConversation(match);
@@ -171,7 +181,7 @@ export default function InboxPage() {
         }
       }
     },
-    [deepLinkConvId]
+    [deepLinkConvId, activeConversation?.id]
   );
 
   const handleSelectConversation = useCallback(
@@ -184,6 +194,14 @@ export default function InboxPage() {
       setActiveConversation(conv);
       setActiveContact(conv.contact ?? null);
       setMessages([]);
+      // Record the selection on the deep-link ref BEFORE we change the
+      // URL. The router.replace below flips `deepLinkConvId`, which can
+      // in turn cause ConversationList to refetch and eventually call
+      // handleConversationsLoaded again. Without this line, the ref
+      // still points at the previous value, the auto-select block
+      // sees `ref !== deepLinkConvId`, fires a second time, and
+      // clobbers the messages MessageThread just fetched.
+      autoSelectedForDeepLinkRef.current = conv.id;
       // Reflect the selection in the URL so a refresh lands the user
       // back in the same thread, and so copy-paste links work. Use
       // replace() to avoid polluting browser history with every click.

--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 import type { Conversation, ConversationStatus } from "@/types";
@@ -46,32 +46,49 @@ export function ConversationList({
   const [filter, setFilter] = useState<ConversationStatus | "all">("all");
   const [loading, setLoading] = useState(true);
 
-  const fetchConversations = useCallback(async () => {
-    const supabase = createClient();
-    const { data, error } = await supabase
-      .from("conversations")
-      .select("*, contact:contacts(*)")
-      .order("last_message_at", { ascending: false });
-
-    if (error) {
-      // Supabase errors have non-enumerable properties — log fields explicitly
-      console.error("Failed to fetch conversations:", {
-        message: error.message,
-        details: error.details,
-        hint: error.hint,
-        code: error.code,
-      });
-      setLoading(false);
-      return;
-    }
-
-    onConversationsLoaded(data ?? []);
-    setLoading(false);
-  }, [onConversationsLoaded]);
+  // Keep the latest callback in a ref so the fetch effect below can
+  // have a stable, empty-dep identity. Previously the fetch useCallback
+  // depended on `onConversationsLoaded`, which depends on the parent's
+  // `deepLinkConvId` — so every URL change (including one the parent
+  // triggered via router.replace after a click) caused a fresh
+  // conversations fetch. That extra refetch was the trigger for the
+  // deep-link auto-select running a second time and wiping the active
+  // thread's messages.
+  const onConversationsLoadedRef = useRef(onConversationsLoaded);
+  onConversationsLoadedRef.current = onConversationsLoaded;
 
   useEffect(() => {
-    fetchConversations();
-  }, [fetchConversations]);
+    const supabase = createClient();
+    let cancelled = false;
+
+    (async () => {
+      const { data, error } = await supabase
+        .from("conversations")
+        .select("*, contact:contacts(*)")
+        .order("last_message_at", { ascending: false });
+
+      if (cancelled) return;
+
+      if (error) {
+        // Supabase errors have non-enumerable properties — log fields explicitly
+        console.error("Failed to fetch conversations:", {
+          message: error.message,
+          details: error.details,
+          hint: error.hint,
+          code: error.code,
+        });
+        setLoading(false);
+        return;
+      }
+
+      onConversationsLoadedRef.current(data ?? []);
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const filtered = useMemo(() => {
     let result = conversations;


### PR DESCRIPTION
## Summary
Reports: clicking a conversation in the inbox sometimes left the thread stuck on \"No messages yet\" until the user hit browser refresh.

## Root cause — URL-driven refetch races the message fetch
When you click a conversation in the list:

1. [inbox/page.tsx](src/app/(dashboard)/inbox/page.tsx) \`handleSelectConversation\` runs: \`setActiveConversation(B)\`, \`setMessages([])\`, then \`router.replace(\"/inbox?c=B\")\`.
2. The URL change flips \`deepLinkConvId\` (from \`useSearchParams\`). \`handleConversationsLoaded\` has \`[deepLinkConvId]\` in its deps, so its identity changes. That cascades into [conversation-list.tsx](src/components/inbox/conversation-list.tsx), whose \`fetchConversations\` depended on \`onConversationsLoaded\`, whose \`useEffect\` depended on \`fetchConversations\` — so the list refetches conversations **purely because the URL changed**.
3. When the refetch lands, \`handleConversationsLoaded\` runs its deep-link auto-select branch. \`autoSelectedForDeepLinkRef\` still points at its previous value (\`null\`, or the old deep-link), so the guard \`ref !== deepLinkConvId\` passes and the branch re-applies B:
   \`\`\`
   setActiveConversation(B)   // no-op, same id
   setMessages([])            // blows away what MessageThread just fetched
   \`\`\`
4. MessageThread's fetch effect only re-runs when \`conversationId\` changes. B is still B. It does **not** refetch. Messages stay at \`[]\`.

A hard reload unsticks things because state is rebuilt from scratch and the initial deep-link flow is the one path where the auto-select is supposed to fire.

## Three defense-in-depth fixes

1. **\`handleSelectConversation\` updates \`autoSelectedForDeepLinkRef\`** before calling \`router.replace\`. By the time any downstream refetch lands, the auto-select branch sees \`ref === deepLinkConvId\` and skips.
2. **\`handleConversationsLoaded\` early-returns** if the deep-linked conversation is already the active one. Redundant with #1 but protects against any other code path we don't foresee triggering a refetch.
3. **\`ConversationList\` fetch is now a plain \`useEffect\` with \`[]\` deps**, using a ref for the latest \`onConversationsLoaded\`. URL changes no longer trigger a conversations refetch. Matches the same stabilisation pattern already used in \`use-auth.tsx\` and \`message-thread.tsx\`.

Any one of these alone would fix the bug; together they make sure a future refactor doesn't reintroduce it.

## Verification
- \`npm run typecheck\` — clean.
- \`npm run lint\` — 37 problems, unchanged from main (all pre-existing).
- Couldn't exercise the rendered inbox from the preview sandbox — it's auth-gated and I don't have test credentials here.

## Test plan
- [ ] Click back and forth between two conversations that have different message histories; messages populate every time, never stuck on \"No messages yet\".
- [ ] Open \`/inbox?c=<id>\` directly from a new tab; thread opens with messages.
- [ ] Switch conversations after a deep-link landing; still works.
- [ ] Realtime messages arriving on the active thread still append without page refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)