### PR TITLE
chore: OSS metadata + LICENSE + SECURITY + complete env example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,16 +1,44 @@
-# Supabase
+# ============================================================
+# REQUIRED — the app won't start without these.
+# ============================================================
+
+# Supabase (Project Settings → API)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
-# Supabase Service Role (for server-side operations like webhook handling)
+# Supabase service-role key. Bypasses RLS; used only by server-side
+# routes (the webhook and automation engine). Keep this secret —
+# never paste it into client code.
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
-# WhatsApp Token Encryption (64 hex chars = 32 bytes for AES-256-CBC)
-# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# WhatsApp token encryption (64 hex chars = 32 bytes, AES-256-GCM).
+# Generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# Rotating this value orphans every token encrypted under the previous
+# key — users have to re-save their WhatsApp settings to reconnect.
 ENCRYPTION_KEY=your-64-char-hex-key-here
 
-# Meta App Secret — REQUIRED. Used to verify the HMAC-SHA256 signature
-# Meta attaches to inbound webhook POSTs. Without it, the webhook
-# rejects every request. Find it at:
-#   Meta for Developers → your app → App Settings → Basic → App Secret
+# Meta App Secret (Meta for Developers → App Settings → Basic).
+# Verifies the HMAC-SHA256 signature on every inbound webhook POST.
+# Required — without it the webhook rejects every request.
 META_APP_SECRET=your-meta-app-secret
+
+# ============================================================
+# RECOMMENDED — safe defaults exist but you'll want to set these.
+# ============================================================
+
+# Canonical public URL of this deployment (scheme + host, no trailing
+# slash). Used for the sitemap, OG images, and any email the app
+# sends. Defaults to https://wacrm.tech if unset.
+NEXT_PUBLIC_SITE_URL=https://crm.example.com
+
+# ============================================================
+# OPTIONAL — only needed if you use the feature.
+# ============================================================
+
+# Shared secret protecting GET /api/automations/cron. Required if you
+# use Wait steps in automations (a scheduled pinger drains pending
+# executions). Generate any long random string:
+#   openssl rand -hex 32
+# See docs/automations-and-cron.md.
+# AUTOMATION_CRON_SECRET=generate-a-long-random-string

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+Thanks for taking the time to look into WaCRM's security.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security bugs.** Public issues are
+indexed by search engines and seen by every fork long before the upstream fix
+lands.
+
+Instead, please report privately via one of:
+
+- [GitHub Security Advisories](https://github.com/ArnasDon/wacrm/security/advisories/new)
+  (preferred — keeps the disclosure, fix, and CVE all in one place).
+- Email: `a.donauskas@hostinger.com` with `[WaCRM security]` in the subject.
+
+Include, if you can:
+
+- A description of the issue and the impact.
+- Reproduction steps or a proof-of-concept.
+- The commit or release you're testing against.
+- Whether you'd like credit in the eventual disclosure (we default to
+  crediting by the name or handle you give us, unless you prefer anonymous).
+
+## What to expect
+
+- **Acknowledgement** within 72 hours.
+- **Initial assessment** (severity, affected versions, whether a workaround
+  exists) within one week.
+- **Fix + coordinated disclosure** on a timeline proportional to severity.
+  Critical issues ship a patch as soon as one's ready; medium issues bundle
+  with the next release.
+
+## Scope
+
+In scope:
+- Anything in this repository (`ArnasDon/wacrm`), including webhook and auth
+  flows, token encryption, RLS policies, and the built-in cron endpoints.
+- Default configurations shipped in `docs/` — e.g. if the setup guide leaves
+  an unsafe default.
+
+Out of scope:
+- Vulnerabilities in Supabase, Next.js, Node.js, or other upstream
+  dependencies — please report those to their maintainers. We'll happily
+  bump versions on request.
+- Issues that require a pre-compromised deployment (e.g. a leaked
+  service-role key) unless they widen the blast radius beyond the initial
+  compromise.
+- Social engineering, physical attacks, or third-party services your fork
+  adds after deploy.
+
+## Safe harbor
+
+Research conducted under this policy is authorized. We won't pursue legal
+action against anyone who:
+
+- Makes a good-faith effort to avoid data destruction, privacy violations,
+  or service disruption.
+- Gives us reasonable time to respond before any public disclosure.
+- Doesn't exploit the issue beyond what's necessary to demonstrate it.
+
+Thanks for helping keep WaCRM (and its forks) safe.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arnas Donauskas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "wacrm",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.4.0",
         "@dnd-kit/core": "^6.3.1",
@@ -36,6 +37,9 @@
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,31 @@
   "name": "wacrm",
   "version": "0.1.0",
   "private": true,
+  "description": "Self-hostable WhatsApp CRM built on Next.js and Supabase — shared inbox, contacts, sales pipelines, broadcasts, and no-code automations.",
+  "license": "MIT",
+  "author": "Arnas Donauskas",
+  "homepage": "https://wacrm.tech",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ArnasDon/wacrm.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ArnasDon/wacrm/issues"
+  },
+  "keywords": [
+    "crm",
+    "whatsapp",
+    "whatsapp-business-api",
+    "nextjs",
+    "supabase",
+    "automation",
+    "broadcast",
+    "self-hosted",
+    "template"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
Five small files, no runtime code. Makes the repo look like a legitimate OSS project the moment it goes public, and unblocks GitHub features (license badge, security-advisory button, Dependabot) that need these files to activate.

## Changes

- **\`LICENSE\`** — MIT at repo root. README has been claiming MIT for a while but GitHub won't render the license badge without the actual file.

- **\`.github/SECURITY.md\`** — private disclosure path via GitHub Security Advisories or email, explicit scope, and safe-harbor language so a researcher has a clear path before they reach for a public issue.

- **\`.env.local.example\`** — filled out with the three vars that were missing: \`META_APP_SECRET\` (required, from PR #65), \`NEXT_PUBLIC_SITE_URL\` (recommended), \`AUTOMATION_CRON_SECRET\` (optional). Grouped Required / Recommended / Optional with a one-line comment per entry plus the \`openssl rand\` / \`node crypto.randomBytes\` generators for the secrets.

- **\`package.json\`** — added \`description\`, \`repository\`, \`bugs\`, \`homepage\`, \`keywords\`, \`license\`, \`author\`, \`engines.node >=20\`. Feeds GitHub's sidebar, npm registry metadata (even though the package stays \`private: true\`), and — most importantly — prevents forkers from silently installing on Node <20 (Next 16's floor).

- **\`package-lock.json\`** — refreshed by \`npm install\` to include the new \`engines\` field. No dependency changes.

## Verification
- \`npm install\` clean (0 vulnerabilities).
- \`npm run typecheck\` clean.
- GitHub will render the license badge and the \"Report a vulnerability\" button once this lands.

## Test plan
- [ ] After merge, check the repo home — a \"MIT\" badge appears under the description.
- [ ] GitHub → Security tab shows the new policy, and \"Report a vulnerability\" opens a private advisory form.
- [ ] A fresh \`npm install\` on Node 18 prints a clear \`engines\` warning (wasn't the case before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)