### PR TITLE
chore: add WhatsApp® on first mention across user-facing surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WaCRM
 
-> Self-hostable WhatsApp CRM template — shared inbox, contacts, sales
+> Self-hostable WhatsApp® CRM template — shared inbox, contacts, sales
 > pipelines, broadcasts, and no-code automations. Fork it, brand it,
 > host it.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # WaCRM documentation
 
-WaCRM is a self-hostable WhatsApp CRM built on Next.js and Supabase. These
+WaCRM is a self-hostable WhatsApp® CRM built on Next.js and Supabase. These
 docs walk you from a freshly forked repo to a production deploy.
 
 ## Reading order

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ want to change something in your fork.
 | Rendering | **Next.js 16** (App Router) | Server components for data-fetch pages; client components where interactivity's needed. React 19. |
 | UI | **Tailwind v4** + **shadcn/base-ui** primitives | Tailwind's zero-runtime styling, shadcn patterns for composable, dark-theme-first components. |
 | Data + Auth | **Supabase** | Postgres with Row-Level Security, built-in email/password auth, Storage for avatars, Realtime for the inbox. |
-| WhatsApp | **Meta Cloud API** | Official Business API. No third-party gateway. |
+| WhatsApp® | **Meta Cloud API** | Official Business API. No third-party gateway. |
 | Encryption | `node:crypto` AES-256-GCM | Per-user WhatsApp access + verify tokens at rest. |
 | Scheduler | External HTTP pinger | Hits `GET /api/automations/cron` to drain Wait-step executions. |
 

--- a/docs/automations-and-cron.md
+++ b/docs/automations-and-cron.md
@@ -1,6 +1,6 @@
 # Automations cron
 
-WaCRM's **Automations** module lets you build flows that react to WhatsApp
+WaCRM's **Automations** module lets you build flows that react to WhatsApp®
 events (new message, new contact, keyword match, schedule, etc.). Most
 steps run inline — the exception is the **Wait** step, which parks the
 execution in `automation_pending_executions` until its due time.

--- a/docs/deployment-hostinger.md
+++ b/docs/deployment-hostinger.md
@@ -101,7 +101,7 @@ plain-HTTP version.
 
 ## 7. Update the Meta webhook
 
-Back in **Meta for Developers → WhatsApp → Configuration**, change the
+Back in **Meta for Developers → WhatsApp® → Configuration**, change the
 callback URL to `https://<your-domain>/api/whatsapp/webhook` and re-verify.
 
 ## 8. Schedule the automations cron

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -56,7 +56,7 @@ AUTOMATION_CRON_SECRET=generate-a-long-random-string
 - Rotate `SUPABASE_SERVICE_ROLE_KEY` if it leaks — Supabase lets you
   regenerate it under Project Settings → API.
 - Treat `ENCRYPTION_KEY` like a database master key. Losing it means
-  connected WhatsApp accounts must reconnect; rotating it means the same.
+  connected WhatsApp® accounts must reconnect; rotating it means the same.
 
 ## Next step
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ cp .env.local.example .env.local
 
 You cannot run `npm run dev` until **at least** `NEXT_PUBLIC_SUPABASE_URL`
 and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set. You need the full Supabase
-setup before WhatsApp features will work, so do that next.
+setup before WhatsApp® features will work, so do that next.
 
 ## 4. Set up Supabase
 

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -75,7 +75,7 @@ emails link back correctly.
 
 ## 6. (Optional) Storage
 
-WaCRM downloads WhatsApp media through Meta's `/download` endpoint and
+WaCRM downloads WhatsApp® media through Meta's `/download` endpoint and
 currently relays it on demand rather than caching it in Supabase Storage.
 No bucket setup is required for a default install.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,7 +41,7 @@ In Supabase → **Authentication → Providers → Email**, either:
 Set `NEXT_PUBLIC_SITE_URL` **and** add the same origin to Supabase →
 **Authentication → URL Configuration → Redirect URLs**.
 
-## WhatsApp
+## WhatsApp®
 
 ### Webhook verification fails in Meta
 

--- a/docs/whatsapp-setup.md
+++ b/docs/whatsapp-setup.md
@@ -1,6 +1,6 @@
 # WhatsApp setup
 
-WaCRM talks to the official **WhatsApp Business Cloud API** (Meta). Each
+WaCRM talks to the official **WhatsApp® Business Cloud API** (Meta). Each
 account stores its own `phone_number_id`, `waba_id`, and encrypted
 `access_token` — there is no shared app-level token. This page walks
 through getting those values and wiring the webhook.

--- a/src/app/(dashboard)/automations/page.tsx
+++ b/src/app/(dashboard)/automations/page.tsx
@@ -159,7 +159,7 @@ export default function AutomationsPage() {
         <div>
           <h1 className="text-2xl font-bold text-white">Automations</h1>
           <p className="mt-1 text-sm text-slate-400">
-            Build workflows that react to WhatsApp events automatically.
+            Build workflows that react to WhatsApp® events automatically.
           </p>
         </div>
         <Button

--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -271,7 +271,7 @@ export default function InboxPage() {
         <div className="flex shrink-0 items-center justify-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-4 py-2">
           <WifiOff className="h-4 w-4 text-amber-400" />
           <p className="text-xs text-amber-400">
-            WhatsApp is not connected. Go to Settings to connect your account.
+            WhatsApp® is not connected. Go to Settings to connect your account.
           </p>
         </div>
       )}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -39,7 +39,7 @@ export default function SettingsPage() {
       <div>
         <h1 className="text-2xl font-bold text-white">Settings</h1>
         <p className="text-sm text-slate-400 mt-1">
-          Manage your profile, WhatsApp integration, message templates, and
+          Manage your profile, WhatsApp® integration, message templates, and
           tags.
         </p>
       </div>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -77,7 +77,7 @@ export default async function Image() {
             maxWidth: 1000,
           }}
         >
-          <span>Run your WhatsApp business from&nbsp;</span>
+          <span>Run your WhatsApp® business from&nbsp;</span>
           <span style={{ color: '#34d399' }}>one inbox.</span>
         </div>
 

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -25,7 +25,7 @@ export function Hero() {
         <div>
           <div className="inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/60 px-3 py-1 text-xs text-slate-300">
             <ShieldCheck className="h-3.5 w-3.5 text-emerald-400" />
-            Built on the official WhatsApp Business API
+            Built on the official WhatsApp® Business API
           </div>
 
           <h1 className="mt-5 text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">

--- a/src/lib/seo/site-config.ts
+++ b/src/lib/seo/site-config.ts
@@ -11,11 +11,11 @@ export const SITE_URL =
 
 export const SITE_NAME = 'WaCRM'
 
-export const SITE_TAGLINE = 'Run your WhatsApp business from one inbox'
+export const SITE_TAGLINE = 'Run your WhatsApp® business from one inbox'
 
 /** Default description — reused by layout metadata and structured data. */
 export const SITE_DESCRIPTION =
-  'WaCRM is a WhatsApp CRM for small teams: shared inbox, contact hub, sales pipelines, broadcasts, and no-code automations — built on the official WhatsApp Business API.'
+  'WaCRM is a WhatsApp® CRM for small teams: shared inbox, contact hub, sales pipelines, broadcasts, and no-code automations — built on the official WhatsApp Business API.'
 
 /**
  * Keyword targets. Search engines largely ignore the meta keywords


### PR DESCRIPTION
## Summary

- Adds the registered trademark symbol (®) to the **first** mention of
  "WhatsApp" on each user-facing surface, per Meta's brand-use guidance
  for third-party products. Subsequent mentions on the same page stay
  plain — that's the conventional treatment.

## Surfaces touched

**Public site**
- `src/components/landing/hero.tsx`: "Built on the official WhatsApp®
  Business API" — first body mention on `/`.
- `src/lib/seo/site-config.ts`: `SITE_TAGLINE` and `SITE_DESCRIPTION`
  (these render into `<title>` and `<meta description>` site-wide).
- `src/app/opengraph-image.tsx`: "Run your WhatsApp® business" in the
  social-share PNG.
- `README.md` tagline.

**Authed dashboard**
- `src/app/(dashboard)/settings/page.tsx` subtitle.
- `src/app/(dashboard)/inbox/page.tsx` "WhatsApp® is not connected"
  banner.
- `src/app/(dashboard)/automations/page.tsx` subtitle.

**Docs**
- First mention added in: `docs/README.md`, `docs/whatsapp-setup.md`,
  `docs/getting-started.md`, `docs/supabase-setup.md`,
  `docs/environment-variables.md`, `docs/deployment-hostinger.md`,
  `docs/automations-and-cron.md`, `docs/architecture.md`,
  `docs/troubleshooting.md`.

## Out of scope

- `SITE_KEYWORDS` — the meta-keywords array isn't user-rendered text,
  and putting ® on every entry would look broken in the resulting
  `<meta>` tag. Search engines also largely ignore that field.

## Test plan

- [ ] `npm run typecheck` passes (verified locally).
- [ ] `npm run lint` reports no new errors (verified locally).
- [ ] Visit `/`, `/docs`, `/docs/whatsapp-setup`, `/settings`,
      `/inbox` (with disconnected WhatsApp), `/automations` and
      confirm the first "WhatsApp" on each page reads as
      "WhatsApp®".
- [ ] Hit `/opengraph-image` directly and confirm the rendered hero
      text shows "WhatsApp®".

🤖 Generated with [Claude Code](https://claude.com/claude-code)