### PR TITLE
chore: add Meta trademark / non-affiliation disclaimer to public footers

### DIFF
--- a/src/components/docs/shell.tsx
+++ b/src/components/docs/shell.tsx
@@ -89,6 +89,14 @@ export function DocsShell({ pages, children }: DocsShellProps) {
 
         <main className="min-w-0 flex-1 py-10">{children}</main>
       </div>
+
+      <footer className="mt-10 border-t border-slate-800 bg-slate-950">
+        <div className="mx-auto w-full max-w-7xl px-4 py-6 text-xs leading-relaxed text-slate-600 sm:px-6">
+          WhatsApp® is a registered trademark of Meta Platforms, Inc.
+          Hostinger is not affiliated with, endorsed by, or sponsored by
+          Meta Platforms, Inc.
+        </div>
+      </footer>
     </div>
   )
 }

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -61,6 +61,11 @@ export function Footer() {
           <span>© {year} WaCRM. All rights reserved.</span>
           <span>Built on the official WhatsApp Business API.</span>
         </div>
+        <div className="mx-auto w-full max-w-7xl px-6 pb-5 text-xs leading-relaxed text-slate-600">
+          WhatsApp® is a registered trademark of Meta Platforms, Inc.
+          Hostinger is not affiliated with, endorsed by, or sponsored by
+          Meta Platforms, Inc.
+        </div>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary

- Adds the legal-required non-affiliation disclaimer to every public
  surface that mentions WhatsApp:

  > "WhatsApp® is a registered trademark of Meta Platforms, Inc.
  > Hostinger is not affiliated with, endorsed by, or sponsored by
  > Meta Platforms, Inc."

- Placed in:
  - `src/components/landing/footer.tsx` (marketing footer — every
    public landing page).
  - `src/components/docs/shell.tsx` — docs pages had **no footer at
    all**, so this PR also adds a slim footer there carrying the same
    disclaimer.

## Out of scope

- The authed dashboard doesn't have a footer (full-screen workspace
  layout). The trademark-fair-use risk is concentrated on public
  surfaces — crawlers, prospective visitors, social shares — so adding
  a footer just to put a legal line on the inbox/automations workspace
  would compromise the layout for marginal compliance benefit. Can
  revisit if legal pushes for it.

## Test plan

- [ ] `npm run typecheck` passes (verified locally).
- [ ] `npm run lint` reports no new errors (verified locally).
- [ ] Open `/`, scroll to the bottom: marketing footer shows the
      disclaimer below the existing copyright + "Built on the official
      WhatsApp Business API" line.
- [ ] Open `/docs` and any `/docs/*` page, scroll to the bottom:
      docs shell now ends with a slim footer carrying the same
      disclaimer.
- [ ] Spot check responsive layout — disclaimer wraps gracefully on
      mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)