### PR TITLE
Pin transitive vulns: postcss / ip-address / fast-uri / hono

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5685,9 +5685,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -6274,9 +6274,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6406,9 +6406,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7870,34 +7870,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -69,5 +69,11 @@
     "tailwindcss": "^4",
     "typescript": "^6",
     "vitest": "^4.1.6"
+  },
+  "overrides": {
+    "postcss": "^8.5.10",
+    "ip-address": "^10.1.1",
+    "fast-uri": "^3.1.2",
+    "hono": "^4.12.18"
   }
 }


### PR DESCRIPTION
## Summary
Patches the remaining **11 open Dependabot alerts** that aren't in our direct dependencies — they're pulled in through the \`shadcn\` CLI's dep tree (\`shadcn\` → \`@modelcontextprotocol/sdk\` → various). The running Next.js app never imports these packages; they only execute when you invoke the shadcn CLI to scaffold a component. Pinning them anyway so the alerts list goes to zero.

Uses npm \`overrides\` so we don't have to wait for the MCP SDK to upgrade.

| Pkg | Was | Now | Severity | Issue |
|---|---|---|---|---|
| postcss | 8.4.31 (nested in next) + 8.5.14 (top) | **8.5.14** | Med | XSS via unescaped \`</style>\` (GHSA-qx2v-qp2m-jg93) |
| ip-address | 10.1.0 | **10.2.0** | Med | XSS in Address6 HTML emitters (GHSA-v2v4-37r5-5v8g) |
| fast-uri | 3.1.0 | **3.1.2** | High × 2 | Path traversal + host confusion (GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc) |
| hono | 4.12.14 | **4.12.19** | Med × 5 + Low × 1 | JSX HTML injection, bodyLimit bypass, Vary leak in cache mw, CSS injection in JSX SSR, JWT NumericDate validation |

## Test plan
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 89/89 passed
- [x] \`npm run build\` — succeeded
- [ ] CI green on this branch

## Pairs with
[#93](https://github.com/ArnasDon/wacrm/pull/93) — bumps \`next\` 16.2.4 → 16.2.6 (the other 11 alerts). Either order is fine; they touch different parts of \`package.json\`.

## Note
\`npm audit\` will still flag one separate \`brace-expansion\` moderate-severity DoS pulled in via \`@typescript-eslint\` — that one wasn't in the original Dependabot list, so it's left for a follow-up. Easy add to the \`overrides\` block if/when Dependabot raises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)