### PR TITLE
fix(inbox): scope hover to bubble; fix stale-closure reactions

### DIFF
--- a/src/components/inbox/message-actions.tsx
+++ b/src/components/inbox/message-actions.tsx
@@ -73,13 +73,20 @@ export function MessageActions({
     setTouchOpen(false);
   };
 
+  // Row alignment lives here (not in MessageBubble) so the `group/actions`
+  // hover region matches the bubble's content width — hovering empty space
+  // in the row no longer reveals the toolbar.
   return (
     <div
-      className="group/actions relative"
+      className={cn(
+        "flex w-full",
+        isAgent ? "justify-end" : "justify-start",
+      )}
       onContextMenu={handleContextMenu}
       onBlur={() => setTouchOpen(false)}
     >
-      {children}
+      <div className="group/actions relative max-w-[75%]">
+        {children}
       <div
         data-touch-open={touchOpen || pickerOpen ? "true" : undefined}
         className={cn(
@@ -129,6 +136,7 @@ export function MessageActions({
         >
           <Copy className="h-3.5 w-3.5" />
         </button>
+      </div>
       </div>
     </div>
   );

--- a/src/components/inbox/message-bubble.tsx
+++ b/src/components/inbox/message-bubble.tsx
@@ -231,46 +231,44 @@ export function MessageBubble({
   const isAgent = message.sender_type === "agent" || message.sender_type === "bot";
   const time = format(new Date(message.created_at), "HH:mm");
 
+  // Row alignment + width cap are owned by <MessageActions> so its hover
+  // group matches the bubble's content area, not the full row.
   return (
     <div
-      className={cn("flex w-full", isAgent ? "justify-end" : "justify-start")}
+      className={cn(
+        "flex flex-col",
+        isAgent ? "items-end" : "items-start",
+      )}
     >
       <div
         className={cn(
-          "flex max-w-[75%] flex-col",
-          isAgent ? "items-end" : "items-start",
+          "relative rounded-2xl px-3 py-2",
+          isAgent
+            ? "rounded-br-md bg-violet-600 text-white"
+            : "rounded-bl-md bg-slate-800 text-slate-100",
         )}
       >
+        {reply && (
+          <ReplyQuote authorLabel={reply.authorLabel} preview={reply.preview} />
+        )}
+        <MessageContent message={message} />
         <div
           className={cn(
-            "relative rounded-2xl px-3 py-2",
-            isAgent
-              ? "rounded-br-md bg-violet-600 text-white"
-              : "rounded-bl-md bg-slate-800 text-slate-100",
+            "mt-1 flex items-center gap-1",
+            isAgent ? "justify-end" : "justify-start",
           )}
         >
-          {reply && (
-            <ReplyQuote authorLabel={reply.authorLabel} preview={reply.preview} />
-          )}
-          <MessageContent message={message} />
-          <div
-            className={cn(
-              "mt-1 flex items-center gap-1",
-              isAgent ? "justify-end" : "justify-start",
-            )}
-          >
-            <span className="text-[10px] text-white/60">{time}</span>
-            {isAgent && <StatusIcon status={message.status} />}
-          </div>
+          <span className="text-[10px] text-white/60">{time}</span>
+          {isAgent && <StatusIcon status={message.status} />}
         </div>
-        {reactions && reactions.length > 0 && onToggleReaction && (
-          <MessageReactions
-            reactions={reactions}
-            currentUserId={currentUserId}
-            onToggle={onToggleReaction}
-          />
-        )}
       </div>
+      {reactions && reactions.length > 0 && onToggleReaction && (
+        <MessageReactions
+          reactions={reactions}
+          currentUserId={currentUserId}
+          onToggle={onToggleReaction}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -258,9 +258,24 @@ export function MessageThread({
         },
         (payload) => {
           const row = payload.new as MessageReaction;
-          setReactions((prev) =>
-            prev.some((r) => r.id === row.id) ? prev : [...prev, row],
-          );
+          setReactions((prev) => {
+            if (prev.some((r) => r.id === row.id)) return prev;
+            // Swap any matching optimistic temp row for the real one so
+            // the pill doesn't double up after a successful POST.
+            const tempIdx = prev.findIndex(
+              (r) =>
+                r.id.startsWith("temp-") &&
+                r.message_id === row.message_id &&
+                r.actor_type === row.actor_type &&
+                r.actor_id === row.actor_id,
+            );
+            if (tempIdx >= 0) {
+              const copy = prev.slice();
+              copy[tempIdx] = row;
+              return copy;
+            }
+            return [...prev, row];
+          });
         },
       )
       .on(
@@ -505,69 +520,50 @@ export function MessageThread({
     [authorLabelFor],
   );
 
-  // Toggle (called from a reaction pill click). If the user already reacted
-  // with `emoji` → send "" to remove. Otherwise send `emoji` to add/swap.
-  const handleToggleReaction = useCallback(
-    async (messageId: string, emoji: string) => {
-      if (!user?.id) return;
-      const current = reactions.find(
-        (r) =>
-          r.message_id === messageId &&
-          r.actor_type === "agent" &&
-          r.actor_id === user.id,
-      );
-      const nextEmoji = current?.emoji === emoji ? "" : emoji;
-      await postReaction(messageId, nextEmoji);
-    },
-    // postReaction is defined below; React only needs the closure refs.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [reactions, user?.id],
-  );
-
-  // Add or swap to a specific emoji (called from the emoji picker bar).
-  const handleAddReaction = useCallback(
-    async (messageId: string, emoji: string) => {
-      if (!emoji) return;
-      await postReaction(messageId, emoji);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-
+  // Single reaction-set primitive. emoji === "" removes; otherwise adds/swaps.
+  // The "toggle" semantic (pill click) is computed at the call site where the
+  // current reactions for the bubble are already in scope — keeps this
+  // function dependency-free w.r.t. the reaction list.
   const postReaction = useCallback(
     async (messageId: string, emoji: string) => {
-      if (!user?.id || !conversation) return;
+      if (!user?.id || !conversation) {
+        console.warn("[reactions] missing user or conversation");
+        return;
+      }
+      if (messageId.startsWith("temp-")) {
+        toast.error("Wait for the message to finish sending");
+        return;
+      }
 
-      // Snapshot for rollback. Optimistically update local state so the
-      // pill flips immediately.
-      const prev = reactions;
-      const own = prev.find(
-        (r) =>
-          r.message_id === messageId &&
-          r.actor_type === "agent" &&
-          r.actor_id === user.id,
-      );
+      const convId = conversation.id;
+      const userId = user.id;
+      let snapshot: MessageReaction[] = [];
 
-      let next: MessageReaction[];
-      if (emoji === "") {
-        next = prev.filter((r) => r !== own);
-      } else if (own) {
-        next = prev.map((r) => (r === own ? { ...own, emoji } : r));
-      } else {
-        next = [
+      // Functional updater — captures the freshest reactions list, never a
+      // stale closure. Snapshot stored for rollback on POST failure.
+      setReactions((prev) => {
+        snapshot = prev;
+        const own = prev.find(
+          (r) =>
+            r.message_id === messageId &&
+            r.actor_type === "agent" &&
+            r.actor_id === userId,
+        );
+        if (emoji === "") return own ? prev.filter((r) => r !== own) : prev;
+        if (own) return prev.map((r) => (r === own ? { ...own, emoji } : r));
+        return [
           ...prev,
           {
             id: `temp-${Date.now()}`,
             message_id: messageId,
-            conversation_id: conversation.id,
+            conversation_id: convId,
             actor_type: "agent",
-            actor_id: user.id,
+            actor_id: userId,
             emoji,
             created_at: new Date().toISOString(),
           },
         ];
-      }
-      setReactions(next);
+      });
 
       try {
         const res = await fetch("/api/whatsapp/react", {
@@ -582,10 +578,10 @@ export function MessageThread({
       } catch (err) {
         const reason = err instanceof Error ? err.message : "network error";
         toast.error(`Reaction failed: ${reason}`);
-        setReactions(prev);
+        setReactions(snapshot);
       }
     },
-    [reactions, conversation, user?.id],
+    [conversation, user?.id],
   );
 
   const handleAssignChange = useCallback(
@@ -794,21 +790,32 @@ export function MessageThread({
                         }
                       : null;
                     const msgReactions = reactionsByMessageId.get(msg.id);
+                    // Toggle is computed at the call site — `msgReactions`
+                    // and `user?.id` are already in scope, no extra hook.
+                    const handlePillToggle = (emoji: string) => {
+                      const own = msgReactions?.find(
+                        (r) =>
+                          r.actor_type === "agent" &&
+                          r.actor_id === user?.id,
+                      );
+                      const next = own?.emoji === emoji ? "" : emoji;
+                      void postReaction(msg.id, next);
+                    };
                     return (
                       <MessageActions
                         key={msg.id}
                         message={msg}
                         onReply={() => handleStartReply(msg)}
-                        onReact={(emoji) => handleAddReaction(msg.id, emoji)}
+                        onReact={(emoji) => {
+                          if (emoji) void postReaction(msg.id, emoji);
+                        }}
                       >
                         <MessageBubble
                           message={msg}
                           reply={reply}
                           reactions={msgReactions}
                           currentUserId={user?.id}
-                          onToggleReaction={(emoji) =>
-                            handleToggleReaction(msg.id, emoji)
-                          }
+                          onToggleReaction={handlePillToggle}
                         />
                       </MessageActions>
                     );


### PR DESCRIPTION
Follow-up to #100. Two bugs reported during QA.

## 1. Hover toolbar fires across the whole message row

The `group/actions` wrapper in `MessageActions` was sitting on a div that wrapped the bubble's own full-width `flex w-full justify-end/start` row. As a result, `group-hover` triggered anywhere in the row — even far away from the bubble.

Fix: row alignment + `max-w-[75%]` cap now live on `MessageActions`. `MessageBubble` is reduced to a content-sized stack. The hover area matches the bubble's actual shape.

## 2. Agent reaction never appears locally

Root cause was a stale-closure chain:

- `handleAddReaction` was wrapped in `useCallback([])`, so it captured the first-render `postReaction`.
- That first-render `postReaction` closed over `reactions = []`, `conversation` (possibly null on first render), and `user`.
- Every emoji click overwrote the reactions list with `[justMyTempRow]` and the POST sometimes hit a null conversation, returning silently before the optimistic update reached the screen.

Fix:
- Dropped both `handleAddReaction` and `handleToggleReaction` `useCallback` wrappers.
- `postReaction` is now called directly from JSX. It uses functional `setReactions((prev) => ...)` so every invocation sees the freshest state.
- Toggle semantics for pill-click are computed at the call site where `msgReactions` and `user?.id` are already in scope — no extra hook.
- Realtime INSERT now swaps a matching optimistic temp row instead of stacking a duplicate pill.
- Reject `temp-*` message IDs with a friendly toast (`"Wait for the message to finish sending"`) so users can't react to an in-flight bubble.

## Test plan

- [ ] **Hover scope**: move the cursor along the horizontal row of a message without crossing the bubble — the toolbar stays hidden. Crossing onto the bubble reveals it.
- [ ] **Outbound reaction**: hover an inbound customer message → pick 👍 → pill appears under the bubble within ~100ms (optimistic). The recipient's WhatsApp shows 👍.
- [ ] **Swap reaction**: 👍 → ❤️ on the same message — pill flips, never stacks.
- [ ] **Remove via pill click**: click own pill → pill disappears on both sides.
- [ ] **Race**: react quickly on two different messages in succession — both pills end up on the right bubbles, no cross-contamination.
- [ ] **Premature react**: send a message, click an emoji on its still-`sending` bubble — friendly toast, no console error, no API call.

## Local verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm test` — 89 / 89 pass
- Browser UI still requires login; could not visually verify these specific gestures locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)