### PR TITLE
docs: add Deploy on Hostinger button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 > sales pipelines, broadcasts, and no-code automations. Fork it, brand
 > it, host it.
 
+[![Deploy on Hostinger](https://img.shields.io/badge/Deploy_on-Hostinger-673DE6?style=for-the-badge&logo=hostinger&logoColor=white)](https://www.hostinger.com/web-apps-hosting)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](./LICENSE)
 [![CI](https://github.com/ArnasDon/wacrm/actions/workflows/ci.yml/badge.svg)](https://github.com/ArnasDon/wacrm/actions/workflows/ci.yml)
 [![Next.js 16](https://img.shields.io/badge/Next.js-16-black?logo=nextdotjs)](https://nextjs.org)


### PR DESCRIPTION
## Summary

- Self-host docs already point to Hostinger Managed Node.js as the fastest deploy path (see `## Why fork this?` and the [Deploy on Hostinger](https://wacrm.tech/docs/deployment-hostinger) doc), but the README had no clickable starting point.
- Adds a CTA button right under the tagline: brand purple (`#673DE6`), Hostinger logo via [SimpleIcons](https://simpleicons.org/?q=hostinger), shields.io for-the-badge style for visual weight. Links to `https://www.hostinger.com/web-apps-hosting`.

## Preview

`[![Deploy on Hostinger](https://img.shields.io/badge/Deploy_on-Hostinger-673DE6?style=for-the-badge&logo=hostinger&logoColor=white)](https://www.hostinger.com/web-apps-hosting)`

If we later want the literal Hostinger horizontal logo instead of a shields.io badge, drop an SVG in `public/` and swap the `src` — markdown stays trivial.

## Test plan

- [ ] Open the README on GitHub; button renders as a chunky purple pill with the Hostinger logo.
- [ ] Click → lands on `https://www.hostinger.com/web-apps-hosting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)