### PR TITLE
fix(inbox): clear unread badge instantly when opening a conversation

### DIFF
--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -235,8 +235,22 @@ export default function InboxPage() {
 
       if (event.eventType === "UPDATE") {
         if (knownConvIdsRef.current.has(conv.id)) {
+          // If this UPDATE is for the conv the user is currently viewing,
+          // suppress the incoming unread_count — the user is reading it
+          // RIGHT NOW, so any positive value would just flicker the badge
+          // back on for the ~100ms it takes for the reset effect's server
+          // UPDATE to round-trip. Non-active convs take the value as-is.
+          const isActive = activeConversation?.id === conv.id;
           setConversations((prev) =>
-            prev.map((c) => (c.id === conv.id ? { ...c, ...conv } : c)),
+            prev.map((c) =>
+              c.id === conv.id
+                ? {
+                    ...c,
+                    ...conv,
+                    unread_count: isActive ? 0 : conv.unread_count,
+                  }
+                : c,
+            ),
           );
         } else {
           // UPDATE arrived before the INSERT (or after a missed INSERT)
@@ -339,6 +353,17 @@ export default function InboxPage() {
           setActiveConversation(match);
           setActiveContact(match.contact ?? null);
           setMessages([]);
+          // Mirror the optimistic unread reset that handleSelectConversation
+          // does — the user just deep-linked into this conv, treat that the
+          // same as a click. Leaves activeConversation.unread_count alone so
+          // the MessageThread reset effect still fires the server UPDATE.
+          if (match.unread_count > 0) {
+            setConversations((prev) =>
+              prev.map((c) =>
+                c.id === match.id ? { ...c, unread_count: 0 } : c,
+              ),
+            );
+          }
         }
       }
     },
@@ -355,6 +380,22 @@ export default function InboxPage() {
       setActiveConversation(conv);
       setActiveContact(conv.contact ?? null);
       setMessages([]);
+      // Optimistically clear the unread badge for this conv. The
+      // server-side reset is fired by the unread-reset effect inside
+      // MessageThread (which reads activeConversation.unread_count, not
+      // the list copy — so we deliberately leave that intact below to
+      // keep the effect firing), and the realtime UPDATE that comes
+      // back will sync to 0 again as a no-op. Zeroing the list copy
+      // here means the user sees the badge disappear the instant they
+      // click instead of waiting for the round-trip — and it persists
+      // even if the realtime UPDATE is dropped.
+      setConversations((prev) =>
+        prev.map((c) =>
+          c.id === conv.id && c.unread_count > 0
+            ? { ...c, unread_count: 0 }
+            : c,
+        ),
+      );
       // Record the selection on the deep-link ref BEFORE we change the
       // URL. The router.replace below flips `deepLinkConvId`, which can
       // in turn cause ConversationList to refetch and eventually call


### PR DESCRIPTION
## Summary

The purple unread badge in the conversation list used to linger for a noticeable beat after opening a thread — and stayed indefinitely if the realtime UPDATE that confirms the server-side reset was ever dropped. There was also a brief flicker when a new message arrived while the user was already viewing the thread.

## Why it happened

The unread badge in the list is driven by \`conversation.unread_count\`. The reset flow was:

1. User clicks the conv.
2. \`MessageThread\` mounts, its unread-reset effect fires \`UPDATE conversations SET unread_count = 0\`.
3. Postgres processes, realtime publishes the UPDATE.
4. \`handleConversationEvent\` UPDATE patches local state.
5. \`ConversationList\` re-renders, badge disappears.

Steps 2–5 are ~100–500ms on a good connection, and unbounded if any realtime event is lost. The user sees the badge in that window — and indefinitely if a drop happens.

The flicker case: when a customer sends a message *while* the user is viewing the thread, the webhook bumps server \`unread_count\`, the realtime UPDATE arrives and overwrites the local 0, and the reset effect re-zeros it after another round-trip — visible as the badge popping on and back off.

## The fix

Two changes in [\`src/app/(dashboard)/inbox/page.tsx\`](src/app/(dashboard)/inbox/page.tsx):

1. **Optimistic zero on select** — \`handleSelectConversation\` (and the deep-link auto-select inside \`handleConversationsLoaded\`) zero the list copy of \`unread_count\` immediately on click. \`activeConversation.unread_count\` is deliberately left intact so the existing reset effect in \`MessageThread\` still fires the server UPDATE.

2. **Suppress the bump-back for the active conv** — \`handleConversationEvent\` UPDATE forces \`unread_count = 0\` in the list whenever the incoming UPDATE is for the conv the user is currently viewing. Non-active convs take the server value as-is. The reset effect still re-runs (\`activeConversation.unread_count\` is patched by the same handler with the original server value before the merge), so eventual consistency is preserved.

## Test plan
- [x] \`npm test\` — 89/89 pass
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\`
- [ ] Manual: receive 3 unread messages on a closed conv. Open the conv — badge disappears the instant you click, with no round-trip delay.
- [ ] Manual: open a conv, ask the customer to send a message while it's open — preview text updates but the badge does *not* flash on then off.
- [ ] Manual: click off to another conv after reading — the badge stays gone (no resurrection from a delayed realtime UPDATE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)