### PR TITLE
feat(inbox): add a refresh button to the conversation header

### DIFF
--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -310,6 +310,16 @@ export default function InboxPage() {
     };
   }, []);
 
+  /**
+   * Manual refresh trigger for the thread-header refresh button.
+   * Bumps the same resyncToken the reconnect / visibility paths use,
+   * so it goes through the existing dedupe & refetch plumbing — no
+   * separate code path to keep in sync.
+   */
+  const handleManualRefresh = useCallback(() => {
+    setResyncToken((n) => n + 1);
+  }, []);
+
   const handleConversationsLoaded = useCallback(
     (loaded: Conversation[]) => {
       setConversations(loaded);
@@ -497,6 +507,7 @@ export default function InboxPage() {
             onAssignChange={handleAssignChange}
             onBack={handleCloseConversation}
             resyncToken={resyncToken}
+            onRefresh={handleManualRefresh}
           />
         </div>
 

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -20,6 +20,7 @@ import {
   Check,
   Clock,
   ArrowLeft,
+  RefreshCw,
 } from "lucide-react";
 import { format, isToday, isYesterday, differenceInHours } from "date-fns";
 import { Badge } from "@/components/ui/badge";
@@ -78,6 +79,14 @@ interface MessageThreadProps {
    * keep working.
    */
   resyncToken?: number;
+  /**
+   * Fired by the manual-refresh button in the thread header. The parent
+   * typically bumps the same `resyncToken` it controls — this gives the
+   * user a way to force a refetch when they suspect realtime missed an
+   * event (or they're impatient). Optional so existing callers keep
+   * working; the button is only rendered when this is provided.
+   */
+  onRefresh?: () => void;
 }
 
 function formatDateSeparator(dateStr: string): string {
@@ -121,6 +130,7 @@ export function MessageThread({
   onAssignChange,
   onBack,
   resyncToken = 0,
+  onRefresh,
 }: MessageThreadProps) {
   const { user } = useAuth();
   const [loading, setLoading] = useState(false);
@@ -128,6 +138,28 @@ export function MessageThread({
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [reactions, setReactions] = useState<MessageReaction[]>([]);
+  // Purely visual spin state for the manual-refresh button. The actual
+  // refetch is fire-and-forget through `onRefresh` (which bumps the
+  // parent's resyncToken); the 700ms spin is just feedback so the click
+  // doesn't feel like a no-op. Cleared via the timer ref on unmount.
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current !== null) {
+        clearTimeout(refreshTimerRef.current);
+      }
+    };
+  }, []);
+  const handleRefreshClick = useCallback(() => {
+    if (isRefreshing || !onRefresh) return;
+    setIsRefreshing(true);
+    onRefresh();
+    refreshTimerRef.current = setTimeout(() => {
+      setIsRefreshing(false);
+      refreshTimerRef.current = null;
+    }, 700);
+  }, [isRefreshing, onRefresh]);
   const [replyTo, setReplyTo] = useState<ReplyDraft | null>(null);
 
   // Profiles are bounded by RLS to rows the current user is allowed to
@@ -696,6 +728,28 @@ export function MessageThread({
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Manual refresh — forces a refetch of the messages + the
+              conversation list (the parent bumps its resyncToken). Useful
+              when realtime missed an event or the agent just wants to be
+              sure nothing's stale. Only rendered when the parent wires
+              up `onRefresh`. */}
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={handleRefreshClick}
+              disabled={isRefreshing}
+              aria-label="Refresh conversation"
+              title="Refresh"
+              className={cn(
+                "inline-flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-800 hover:text-white disabled:opacity-60",
+              )}
+            >
+              <RefreshCw
+                className={cn("h-3.5 w-3.5", isRefreshing && "animate-spin")}
+              />
+            </button>
+          )}
+
           {/* Status dropdown */}
           <DropdownMenu>
             <DropdownMenuTrigger className={cn(


### PR DESCRIPTION
## Summary

Adds a small refresh icon button (lucide \`RefreshCw\`) to the message-thread header, sitting just left of the existing Status dropdown. Clicking it forces a refetch of both the open thread and the conversation list.

## How it works

The button is wired into the same \`resyncToken\` mechanism added in #107 — the one that already drives refetches on WS reconnect and on tab visibility → visible. Clicking the button bumps the token, which:

- Refires \`ConversationList\`'s fetch effect (re-pulls the conversation list with contacts joined)
- Refires \`MessageThread\`'s messages fetch effect (re-pulls messages for the open thread)
- Refires \`MessageThread\`'s reactions fetch effect (no channel resubscribe — that effect was split in #107)

So this slots into the existing plumbing without a parallel code path.

The icon spins for 700ms as click feedback (the actual refetch is async — the spin is purely visual so the click doesn't feel like a no-op).

## What it's for

The fix in #107 makes the inbox eventually consistent via reconnect + visibility refetches, but there's no way to *force* it — and sometimes the agent just wants to be sure nothing's stale. Manual control is the cleanest answer; it surfaces the resync mechanism we already have rather than building a new one.

## What changed

| File | Change |
|---|---|
| [\`src/components/inbox/message-thread.tsx\`](src/components/inbox/message-thread.tsx) | New \`onRefresh\` prop; button rendered in the header when wired; local \`isRefreshing\` spin state with a 700ms timer (cleaned up on unmount). |
| [\`src/app/(dashboard)/inbox/page.tsx\`](src/app/(dashboard)/inbox/page.tsx) | New \`handleManualRefresh\` callback that bumps \`resyncToken\`; passed to \`MessageThread\` as \`onRefresh\`. |

\`onRefresh\` is optional — the button only renders when the parent wires it up, so any other caller of \`MessageThread\` (or future test setups) keep working unchanged.

## Test plan
- [x] \`npm test\` — 89/89 pass
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\`
- [x] \`npm run build\`
- [ ] Manual: open any conversation, click the refresh icon in the header. Confirm the icon spins briefly, messages refetch (network panel shows a fresh SELECT), and the conversation list refetches.
- [ ] Manual: rapid-clicking the button doesn't multi-fire (button is disabled during the 700ms spin window).
- [ ] Manual: navigate to another conv while a refresh is in flight — no console errors, the in-flight spin doesn't leak across conversations.
- [ ] Manual: on mobile (single-pane), the button is visible in the thread header alongside the back arrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)