### PR TITLE
feat(flows): add multi-section support to send_list builder

### DIFF
--- a/src/components/flows/flow-builder.tsx
+++ b/src/components/flows/flow-builder.tsx
@@ -1171,6 +1171,24 @@ function SendListForm({
       ),
     });
   };
+  const addSection = () =>
+    onUpdateConfig({
+      sections: [
+        ...sections,
+        {
+          title: "",
+          rows: [
+            {
+              reply_id: `row_${totalRows + 1}`,
+              title: `Option ${totalRows + 1}`,
+              next_node_key: "",
+            },
+          ],
+        },
+      ],
+    });
+  const removeSection = (sIdx: number) =>
+    onUpdateConfig({ sections: sections.filter((_, i) => i !== sIdx) });
   const updateRow = (
     sIdx: number,
     rIdx: number,
@@ -1244,14 +1262,27 @@ function SendListForm({
             key={sIdx}
             className="mb-3 rounded-md border border-slate-800 bg-slate-800/40 p-3"
           >
-            <Input
-              value={section.title ?? ""}
-              onChange={(e) =>
-                updateSection(sIdx, { title: e.target.value })
-              }
-              placeholder="Section title (optional)"
-              className="mb-2 bg-slate-800 text-xs"
-            />
+            <div className="mb-2 flex items-center gap-2">
+              <Input
+                value={section.title ?? ""}
+                onChange={(e) =>
+                  updateSection(sIdx, { title: e.target.value })
+                }
+                placeholder={`Section ${sIdx + 1} title (optional)`}
+                className="bg-slate-800 text-xs"
+              />
+              {sections.length > 1 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeSection(sIdx)}
+                  className="shrink-0 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+                  aria-label="Remove section"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
             {section.rows.map((row, rIdx) => (
               <div
                 key={rIdx}
@@ -1311,6 +1342,19 @@ function SendListForm({
             )}
           </div>
         ))}
+        {/* WhatsApp's interactive-list spec caps sections at 10. Group rows
+            by category (Billing / Support / Sales etc.) to give customers a
+            scannable menu. */}
+        {sections.length < 10 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addSection}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add section
+          </Button>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- The data model + runner have always supported multiple sections in a \`send_list\` node, but the builder UI exposed no way to add one — only \"Add row\" within the default single section.
- Blocks the categorized-menu use case (e.g. FAQ with Billing / Support / Sales sections) unless you edit the DB directly.
- Adds an \"Add section\" button and a per-section remove button.

## What changed
- \`SendListForm\`: new \`addSection\` / \`removeSection\` handlers.
- \"Add section\" button below the sections list (outline variant so it's distinct from the inline \"Add row\" ghost). Capped at 10 per WhatsApp's spec.
- Per-section remove (trash icon) shown only when \`sections.length > 1\` so you can't accidentally remove the last one.
- Section title input now displays \"Section N title (optional)\" so it's clear which one you're editing.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 173/173 pass
- [x] \`npm run lint\` no new warnings
- [x] \`npm run build\` clean
- [ ] Smoke test: open a flow, add a \`send_list\` node, click \"Add section\", confirm new section appears with a default row; remove a section and confirm the rows go with it; verify the runner still routes correctly to next nodes from rows in the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)