### PR TITLE
fix(flows): redact customer text from reply_received event payload

### DIFF
--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -822,11 +822,18 @@ async function handleReplyForActiveRun(
   run: FlowRunRow,
   message: ParsedInbound,
 ): Promise<DispatchInboundResult> {
+  // Note: we intentionally do NOT persist the raw customer text. A
+  // `collect_input` prompt that asks "what's your card number?" would
+  // otherwise leave the PAN sitting in flow_run_events.payload forever,
+  // visible to anyone with access to the runs viewer or the events
+  // table. Length is enough for "did they actually reply?" debugging;
+  // for the captured value itself, the `node_entered` event already
+  // records `captured_key` + `captured_length` after the var is stored.
   await logEvent(db, run.id, "reply_received", run.current_node_key, {
     meta_message_id: message.meta_message_id,
     reply_kind: message.kind,
     reply_id: message.kind === "interactive_reply" ? message.reply_id : null,
-    text: message.kind === "text" ? message.text : null,
+    text_length: message.kind === "text" ? message.text.length : null,
   });
 
   if (!run.current_node_key) {


### PR DESCRIPTION
## Summary
PII leak. The \`reply_received\` event persists \`text: message.text\` verbatim into \`flow_run_events.payload\`. A \`collect_input\` prompt asking \"what's your card number?\" leaves the PAN in the events table forever, surfaced via the runs viewer to anyone with access.

## What changed
- \`engine.ts\` handleReplyForActiveRun: \`text\` → \`text_length\`.
- Added a comment justifying the redaction so it doesn't get reverted casually.

The \`node_entered\` event already records \`captured_length\` (not the value) when collect_input captures successfully — this fix makes \`reply_received\` symmetric with that.

The runs viewer's \`summarizePayload\` ([page.tsx:340-349](src/app/\\(dashboard\\)/flows/\\[id\\]/runs/page.tsx#L340-L349)) only inspects \`reply_id / captured_key / reason / advancing_to\` — no UI change needed.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 173/173 pass
- [x] \`npm run lint\` no new warnings
- [x] \`npm run build\` clean
- [ ] Smoke: trigger a flow with a collect_input node, reply via WhatsApp, open the runs viewer, expand the run, confirm the \`reply_received\` event shows no raw text

## Backwards compat
Old events (already in the DB with raw \`text\` field) are unaffected — the runs viewer doesn't surface that key anyway. New events use the redacted shape. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)