### PR TITLE
fix(flows): atomic execution_count increment via SECURITY DEFINER RPC

### DIFF
--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -1004,13 +1004,19 @@ async function startNewRun(
   });
   // Bump the flow's execution counter — used by the builder UI to
   // surface "X runs since activation" on the flow card.
-  await db
-    .from("flows")
-    .update({
-      execution_count: flow.execution_count + 1,
-      last_executed_at: new Date().toISOString(),
-    })
-    .eq("id", flow.id);
+  //
+  // Atomic RPC (migration 012) rather than read-modify-write: two
+  // concurrent webhooks starting runs for different contacts on the
+  // same flow would otherwise both read N and both write N+1, losing
+  // a count. Mirrors the automations engine's use of
+  // `increment_automation_execution_count` (migration 007).
+  const { error: incErr } = await db.rpc("increment_flow_execution_count", {
+    p_flow_id: flow.id,
+  });
+  if (incErr) {
+    // Non-fatal — the run itself succeeded; only the counter is off.
+    console.error("[flows] execution_count rpc error:", incErr.message);
+  }
 
   // Run the advance loop starting from the entry node.
   const outcome = await advanceFromNodeKey(db, run, flow.entry_node_id!);

--- a/supabase/migrations/012_flows_increment_counter.sql
+++ b/supabase/migrations/012_flows_increment_counter.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- 012_flows_increment_counter.sql
+--
+-- Atomic increment of flows.execution_count + refresh of
+-- last_executed_at. Called via PostgREST RPC from the engine.
+--
+-- Before this, startNewRun did a read-modify-write:
+--   UPDATE flows SET execution_count = <cached + 1> WHERE id = ...
+-- so two concurrent dispatches (e.g. two webhooks for the same flow
+-- starting runs for different contacts in the same second) could both
+-- read N and both write N+1, permanently losing one count.
+--
+-- Mirrors migration 007 for automations — same shape, same security
+-- posture. Idempotent: safe to re-run.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION increment_flow_execution_count(p_flow_id UUID)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE flows
+  SET
+    execution_count = execution_count + 1,
+    last_executed_at = NOW()
+  WHERE id = p_flow_id;
+$$;
+
+-- Only the service role needs to call this (engine uses the
+-- service-role client). Explicitly lock anon / authenticated out so
+-- an authenticated user can't juice someone else's counter via RPC.
+REVOKE ALL ON FUNCTION increment_flow_execution_count(UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION increment_flow_execution_count(UUID) FROM anon;
+REVOKE ALL ON FUNCTION increment_flow_execution_count(UUID) FROM authenticated;
+GRANT EXECUTE ON FUNCTION increment_flow_execution_count(UUID) TO service_role;


### PR DESCRIPTION
## Summary
Race condition. \`startNewRun\` did a read-modify-write on \`flows.execution_count\`. Two concurrent webhooks starting runs on the same flow for different contacts both read N and both write N+1 — one count permanently lost.

Mirrors the [automations engine's solution](src/lib/automations/engine.ts#L166) from [migration 007](supabase/migrations/007_automations_increment_counter.sql). The fix has been validated there since automations shipped.

## What changed
- **New migration** \`012_flows_increment_counter.sql\` — \`increment_flow_execution_count(UUID)\` SECURITY DEFINER function, granted to \`service_role\` only.
- **engine.ts startNewRun** — replaces \`UPDATE flows SET execution_count = <cached + 1>\` with \`db.rpc('increment_flow_execution_count', ...)\`.
- RPC failure is logged but non-fatal — the run already succeeded, only the stat is off.

## Deployment
1. Run migration 012 in Supabase.
2. Merge this PR.

If the migration is missed the engine still works (RPC returns error, logged, run continues) but the counter stays racy. Order matters slightly.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 173/173 pass
- [x] \`npm run lint\` no new warnings
- [x] \`npm run build\` clean
- [ ] After deploying migration: trigger two flows concurrently (curl two inbounds in parallel for the same active flow), confirm \`execution_count\` increments by exactly 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)