### PR TITLE
fix(flows): constant-time compare for cron secret

### DIFF
--- a/src/app/api/flows/cron/route.ts
+++ b/src/app/api/flows/cron/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/flows/admin-client'
 import { resolveFallbackPolicy } from '@/lib/flows/fallback'
@@ -30,8 +31,17 @@ export async function GET(request: Request) {
   if (!expected) {
     return NextResponse.json({ error: 'cron not configured' }, { status: 503 })
   }
-  const supplied = request.headers.get('x-cron-secret')
-  if (supplied !== expected) {
+  // Constant-time compare so an attacker who can hit the endpoint
+  // can't recover the secret byte-by-byte from response-time deltas.
+  // Length pre-check is required by timingSafeEqual (throws otherwise)
+  // and leaks only the length itself, which isn't sensitive.
+  const supplied = request.headers.get('x-cron-secret') ?? ''
+  const suppliedBuf = Buffer.from(supplied)
+  const expectedBuf = Buffer.from(expected)
+  if (
+    suppliedBuf.length !== expectedBuf.length ||
+    !timingSafeEqual(suppliedBuf, expectedBuf)
+  ) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 


### PR DESCRIPTION
## Summary
\`/api/flows/cron\` gated on \`supplied !== expected\` — compares strings byte-by-byte with early exit on first mismatch. An attacker who can hit the endpoint could in principle recover the secret one byte at a time by measuring response-time deltas.

With a high-entropy 64-char random secret this is mostly theoretical (the noise floor on network latency dwarfs the per-comparison difference). But the upgrade is a one-liner — \`crypto.timingSafeEqual\` with a length pre-check.

## What changed
- \`/api/flows/cron\`: \`supplied !== expected\` → \`timingSafeEqual(Buffer.from(supplied), Buffer.from(expected))\` with a length-equality guard (the function throws on length mismatch; the length itself isn't sensitive).

## Scope note
\`/api/automations/cron\` has the same pattern. Not touching it in this PR — one fix per branch. Happy to follow up if you want it.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 173/173 pass
- [x] \`npm run lint\` no new warnings
- [x] \`npm run build\` clean
- [ ] Smoke: hit \`/api/flows/cron\` with the correct \`x-cron-secret\`, confirm 200; hit with a wrong secret, confirm 401; hit with a same-length wrong secret + a different-length wrong secret, confirm both 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)