### PR TITLE
fix(flows): widen create-flow dialog so template cards are readable

### DIFF
--- a/src/app/(dashboard)/flows/page.tsx
+++ b/src/app/(dashboard)/flows/page.tsx
@@ -245,7 +245,7 @@ export default function FlowsPage() {
       )}
 
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="max-w-2xl bg-slate-900 text-slate-100">
+        <DialogContent className="max-w-3xl bg-slate-900 text-slate-100">
           <DialogHeader>
             <DialogTitle>Create a new flow</DialogTitle>
             <DialogDescription className="text-slate-400">
@@ -254,11 +254,11 @@ export default function FlowsPage() {
           </DialogHeader>
 
           {templates.length > 0 && (
-            <div className="space-y-2">
+            <div className="space-y-3">
               <p className="text-xs uppercase tracking-wide text-slate-500">
                 Start from a template
               </p>
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {templates.map((t) => {
                   const Icon = TEMPLATE_ICONS[t.icon] ?? FileText;
                   return (
@@ -267,17 +267,17 @@ export default function FlowsPage() {
                       type="button"
                       onClick={() => handleUseTemplate(t.slug)}
                       disabled={creating}
-                      className="flex flex-col gap-2 rounded-lg border border-slate-800 bg-slate-950 p-3 text-left transition-colors hover:border-violet-500/40 hover:bg-slate-800 disabled:opacity-50"
+                      className="flex flex-col gap-2.5 rounded-lg border border-slate-800 bg-slate-950 p-4 text-left transition-colors hover:border-violet-500/40 hover:bg-slate-800 disabled:opacity-50"
                     >
-                      <Icon className="h-4 w-4 text-violet-400" />
-                      <span className="text-sm font-medium text-white">
+                      <Icon className="h-5 w-5 text-violet-400" />
+                      <span className="text-sm font-semibold text-white">
                         {t.name}
                       </span>
-                      <span className="line-clamp-3 text-xs text-slate-400">
+                      <span className="text-xs leading-relaxed text-slate-400">
                         {t.description}
                       </span>
-                      <span className="mt-auto text-[10px] text-slate-500">
-                        {t.node_count} nodes
+                      <span className="mt-auto border-t border-slate-800 pt-2 text-[11px] text-slate-500">
+                        {t.node_count} {t.node_count === 1 ? "node" : "nodes"}
                       </span>
                     </button>
                   );
@@ -286,7 +286,7 @@ export default function FlowsPage() {
             </div>
           )}
 
-          <div className="space-y-2">
+          <div className="space-y-2 border-t border-slate-800 pt-4">
             <p className="text-xs uppercase tracking-wide text-slate-500">
               Or start blank
             </p>


### PR DESCRIPTION
## The bug
Dialog was \`max-w-2xl\` with \`sm:grid-cols-3\` → each template card was about 150px wide. Combined with \`p-3\` and \`line-clamp-3\`, descriptions truncated to four-word fragments. The gallery looked squished even on desktop.

## What changed
\`src/app/(dashboard)/flows/page.tsx\`:
- Dialog: \`max-w-2xl\` → \`max-w-3xl\` (~256px more horizontal room).
- Grid breakpoints: \`grid-cols-1 sm:grid-cols-3\` → \`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3\`. Matches the flow-card grid lower on the page; cards stack on phones, pair on tablets, triple on laptops.
- Card sizing: \`p-3\` → \`p-4\`, gaps \`gap-2\` → \`gap-2.5\`, icon \`h-4\` → \`h-5\`.
- Dropped the \`line-clamp-3\` — at the new width descriptions fit naturally.
- \"X nodes\" lives above a top-border now so it reads as a metadata footer rather than part of the description.
- Added a divider above \"Or start blank\" so the two creation paths feel like distinct choices instead of stacked siblings.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 173/173 pass
- [x] \`npm run lint\` no new warnings
- [x] \`npm run build\` clean
- [ ] Smoke: open the New-flow dialog, verify cards are readable; resize to phone width and confirm stacked layout; click each template + the blank input, verify both paths still create flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)