### PR TITLE
fix(flows): pin validation panel to viewport bottom while editing

### DIFF
--- a/src/components/flows/flow-builder.tsx
+++ b/src/components/flows/flow-builder.tsx
@@ -657,7 +657,14 @@ export function FlowBuilder({ initialFlow, initialNodes }: FlowBuilderProps) {
         )}
       </section>
 
-      <ValidationPanel issues={issues} onJump={jumpToNode} />
+      {/* Sticky-bottom so the activate-readiness status follows the
+          user as they scroll through nodes. The parent <main> in the
+          dashboard shell is the scroll container; this stays pinned
+          to the viewport bottom (with a 1rem gap) until the page
+          naturally ends, at which point it falls back into flow. */}
+      <div className="sticky bottom-4 z-10 shadow-xl shadow-slate-950/60">
+        <ValidationPanel issues={issues} onJump={jumpToNode} />
+      </div>
     </div>
   );
 }
@@ -2041,9 +2048,12 @@ function ValidationPanel({
   onJump: (key: string) => void;
 }) {
   if (issues.length === 0) {
+    // Slate-950 base + emerald accents so the panel stays readable when
+    // sticky-positioned over scrolled-behind node cards (a translucent
+    // bg-emerald-500/10 would bleed through ugly).
     return (
-      <div className="flex items-center gap-2 rounded-lg border border-emerald-600/40 bg-emerald-500/10 p-3 text-xs text-emerald-300">
-        <CircleCheck className="h-4 w-4" />
+      <div className="flex items-center gap-2 rounded-lg border border-emerald-600/50 bg-slate-950 p-3 text-sm font-medium text-emerald-300">
+        <CircleCheck className="h-4 w-4 shrink-0" />
         No issues. Ready to activate.
       </div>
     );
@@ -2051,7 +2061,12 @@ function ValidationPanel({
   const errors = issues.filter((i) => i.severity === "error");
   const warnings = issues.filter((i) => i.severity === "warning");
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900 p-3">
+    <div
+      className={cn(
+        "rounded-lg border bg-slate-950 p-3",
+        errors.length > 0 ? "border-red-500/40" : "border-amber-500/40",
+      )}
+    >
       <div className="mb-2 flex items-center gap-2 text-xs text-slate-400">
         {errors.length > 0 ? (
           <CircleAlert className="h-4 w-4 text-red-400" />


### PR DESCRIPTION
## The bug
\"No issues. Ready to activate.\" (and the equivalent error count) sat at the very bottom of the editor below the node list. With even a handful of nodes the panel was below the fold — the user had to scroll past every node card to know whether they could activate, then scroll back up to hit the button in the header.

## What changed
\`src/components/flows/flow-builder.tsx\`:
1. **Wrap \`<ValidationPanel>\` in a \`sticky bottom-4 z-10\` container** with \`shadow-xl shadow-slate-950/60\`. The parent \`<main>\` in the dashboard shell is the scroll container, so this stays pinned to the viewport bottom (1rem gap) as the user scrolls; falls back into flow when the page naturally ends.
2. **Background fix on the panel itself.** The success state used \`bg-emerald-500/10\` (10% emerald). Fine when nothing's behind it, but sticky-positioned over a \`slate-900\` node card the tint bled through ugly. Switched both success and error/warning states to a solid \`bg-slate-950\` base with the severity carried by the border + text colour only — readable on any backdrop.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 173/173 pass
- [x] \`npm run lint\` no new warnings
- [x] \`npm run build\` clean
- [ ] Smoke: open a flow with many nodes, scroll through; confirm the validation panel stays pinned to the bottom and remains readable over scrolled-behind node cards
- [ ] Smoke: introduce an error, confirm the red panel is visible without scrolling; click a node-scoped issue, confirm jump-to-node still works
- [ ] Smoke: on a short flow (1-2 nodes) where the page doesn't scroll, confirm the panel sits at its natural bottom position without weird floating

🤖 Generated with [Claude Code](https://claude.com/claude-code)