### PR TITLE
fix(flows): create-flow dialog was still clamped to 384px — override sm: variant

### DIFF
--- a/src/app/(dashboard)/flows/page.tsx
+++ b/src/app/(dashboard)/flows/page.tsx
@@ -245,7 +245,11 @@ export default function FlowsPage() {
       )}
 
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="max-w-3xl bg-slate-900 text-slate-100">
+        {/* `sm:max-w-4xl` not `max-w-4xl` — shadcn's DialogContent has
+            `sm:max-w-sm` baked into its default classes. Without the
+            sm: prefix our override applies at base only and the
+            sm-scoped 384px wins at every real desktop breakpoint. */}
+        <DialogContent className="sm:max-w-4xl bg-slate-900 text-slate-100">
           <DialogHeader>
             <DialogTitle>Create a new flow</DialogTitle>
             <DialogDescription className="text-slate-400">


### PR DESCRIPTION
## What happened
[PR #129](https://github.com/ArnasDon/wacrm/pull/129) added \`max-w-3xl\` to the create-flow \`DialogContent\` thinking it would widen the modal. It was a no-op — the modal kept rendering at the cramped shadcn default (384px) and the template cards stayed squished.

## Root cause
shadcn's [\`DialogContent\`](src/components/ui/dialog.tsx) has \`sm:max-w-sm\` baked into its default classes:

\`\`\`
w-full max-w-[calc(100%-2rem)] ... sm:max-w-sm
\`\`\`

Tailwind-merge treats \`max-w-*\` (base variant) and \`sm:max-w-*\` (sm-prefixed) as different keys, so both survive. At every real desktop breakpoint the sm-scoped 384px wins; PR #129's unprefixed \`max-w-3xl\` only applied below sm (640px).

## Fix
Override at the sm: variant itself. \`sm:max-w-4xl\` (896px) gives each of the three template cards roughly 270px — descriptions wrap to 4–5 lines instead of 10+.

Left a code comment at the call site so the next person doesn't repeat the same mistake.

## Scope
Only touching the flows New-flow dialog. Other dialogs in the app might be relying on the narrow default; fixing the shadcn component itself would change all of them. One-off override is the conservative move.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 173/173 pass
- [x] \`npm run lint\` no new warnings
- [x] \`npm run build\` clean
- [ ] Smoke: open the New-flow dialog on a desktop viewport, confirm it's roughly 900px wide and the three template cards each have ~270px of width; resize to phone width, confirm cards stack and dialog remains within viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)