### PR TITLE
fix(whatsapp): prevent silent inbound-message drop on duplicate phone_number_id

### DIFF
--- a/src/app/api/whatsapp/config/route.ts
+++ b/src/app/api/whatsapp/config/route.ts
@@ -1,7 +1,24 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { createClient as createAdminClient } from '@supabase/supabase-js'
 import { verifyPhoneNumber } from '@/lib/whatsapp/meta-api'
 import { encrypt, decrypt } from '@/lib/whatsapp/encryption'
+
+// Lazy-initialised service-role client. We need it to detect a
+// phone_number_id already claimed by a *different* user — under RLS,
+// the user's own session can't see other users' rows, so the conflict
+// would be invisible without the service role.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _adminClient: any = null
+function supabaseAdmin() {
+  if (!_adminClient) {
+    _adminClient = createAdminClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    )
+  }
+  return _adminClient
+}
 
 /**
  * GET /api/whatsapp/config
@@ -127,6 +144,36 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { error: 'access_token and phone_number_id are required' },
         { status: 400 }
+      )
+    }
+
+    // Reject if another user has already claimed this phone_number_id.
+    // wacrm is single-tenant-per-WhatsApp-number — letting two users
+    // bind the same number causes the webhook's `.single()` lookup to
+    // throw PGRST116 ("multiple rows"), silently dropping every
+    // inbound message. See issue #136.
+    const { data: claimed, error: claimedError } = await supabaseAdmin()
+      .from('whatsapp_config')
+      .select('user_id')
+      .eq('phone_number_id', phone_number_id)
+      .neq('user_id', user.id)
+      .maybeSingle()
+
+    if (claimedError) {
+      console.error('Error checking phone_number_id ownership:', claimedError)
+      return NextResponse.json(
+        { error: 'Failed to validate configuration' },
+        { status: 500 }
+      )
+    }
+
+    if (claimed) {
+      return NextResponse.json(
+        {
+          error:
+            'This WhatsApp phone number is already linked to another account on this instance. Each phone number can only be connected to one wacrm user.',
+        },
+        { status: 409 }
       )
     }
 

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -204,17 +204,42 @@ async function processWebhook(body: { entry?: WhatsAppWebhookEntry[] }) {
 
       const phoneNumberId = value.metadata.phone_number_id
 
-      // Find user's config by phone_number_id
-      const { data: config, error: configError } = await supabaseAdmin()
+      // Find user's config by phone_number_id. `.single()` returns
+      // PGRST116 for both 0 rows AND ≥2 rows — distinguish them so
+      // operators see the real cause in logs. ≥2 rows shouldn't happen
+      // post-migration 013 (UNIQUE constraint), but a row created
+      // before the constraint, or a race, would still surface here.
+      const { data: configRows, error: configError } = await supabaseAdmin()
         .from('whatsapp_config')
         .select('*')
         .eq('phone_number_id', phoneNumberId)
-        .single()
 
-      if (configError || !config) {
+      if (configError) {
+        console.error(
+          'Error fetching whatsapp_config for phone_number_id:',
+          phoneNumberId,
+          configError
+        )
+        continue
+      }
+
+      if (!configRows || configRows.length === 0) {
         console.error('No config found for phone_number_id:', phoneNumberId)
         continue
       }
+
+      if (configRows.length > 1) {
+        console.error(
+          `Multiple configs (${configRows.length}) found for phone_number_id:`,
+          phoneNumberId,
+          '— inbound message dropped. Resolve duplicates so each number maps to a single user.',
+          'Owners:',
+          configRows.map((r: { user_id: string }) => r.user_id)
+        )
+        continue
+      }
+
+      const config = configRows[0]
 
       const decryptedAccessToken = decrypt(config.access_token)
 

--- a/supabase/migrations/013_whatsapp_config_phone_number_id_unique.sql
+++ b/supabase/migrations/013_whatsapp_config_phone_number_id_unique.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- whatsapp_config: enforce one user per phone_number_id
+--
+-- The webhook routes inbound messages by `phone_number_id` and uses
+-- `.single()` to find the owning config row. If two users have saved
+-- the same `phone_number_id`, `.single()` errors PGRST116 ("multiple
+-- rows returned") and the webhook silently drops every inbound
+-- message — see issue #136.
+--
+-- wacrm is single-tenant per WhatsApp number by design (RLS on
+-- conversations / messages is `auth.uid() = user_id`, so another user
+-- physically cannot read a conversation routed to a different owner).
+-- A UNIQUE constraint at the DB level makes that intent enforceable
+-- and stops races between the app-level check and the insert.
+--
+-- ─── On existing data ───────────────────────────────────────────
+-- If duplicates already exist in production, this migration FAILS
+-- LOUDLY rather than silently dropping rows. Auto-deduping would
+-- destroy user data (encrypted tokens, connection state) — the
+-- operator has to choose which user keeps the number. To resolve:
+--
+--   SELECT phone_number_id, array_agg(user_id) AS owners
+--   FROM whatsapp_config
+--   GROUP BY phone_number_id
+--   HAVING count(*) > 1;
+--
+-- Then DELETE the duplicate rows you don't want to keep and re-run
+-- migrations.
+--
+-- Idempotent — safe to run multiple times once the constraint is in
+-- place.
+-- ============================================================
+
+-- 1. Fail loudly if duplicates exist. Spelling out the conflicting
+--    phone_number_id and the user_ids that own it gives the operator
+--    a copy-pasteable starting point.
+DO $$
+DECLARE
+  conflict_count INT;
+  sample TEXT;
+BEGIN
+  SELECT count(*) INTO conflict_count
+  FROM (
+    SELECT phone_number_id
+    FROM whatsapp_config
+    GROUP BY phone_number_id
+    HAVING count(*) > 1
+  ) dupes;
+
+  IF conflict_count > 0 THEN
+    SELECT string_agg(
+      phone_number_id || ' -> [' || array_to_string(owners, ', ') || ']',
+      E'\n  '
+    )
+    INTO sample
+    FROM (
+      SELECT phone_number_id, array_agg(user_id::text) AS owners
+      FROM whatsapp_config
+      GROUP BY phone_number_id
+      HAVING count(*) > 1
+    ) dupe_detail;
+
+    RAISE EXCEPTION
+      E'Cannot add UNIQUE(phone_number_id) on whatsapp_config — % phone_number_id value(s) are claimed by more than one user:\n  %\nDelete the duplicate rows you do not want to keep (see migration comment), then re-run migrations.',
+      conflict_count,
+      sample;
+  END IF;
+END $$;
+
+-- 2. Add the UNIQUE constraint. PostgreSQL has no "ADD CONSTRAINT IF
+--    NOT EXISTS", so guard via pg_constraint.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'whatsapp_config_phone_number_id_key'
+      AND conrelid = 'whatsapp_config'::regclass
+  ) THEN
+    ALTER TABLE whatsapp_config
+      ADD CONSTRAINT whatsapp_config_phone_number_id_key
+      UNIQUE (phone_number_id);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Closes #136.

Two users could save the same `phone_number_id` to their `whatsapp_config`. After that, every inbound WhatsApp message for that number was silently dropped — the webhook's `.single()` lookup errored `PGRST116` ("multiple rows") and the log misleadingly said *"No config found for phone_number_id"*.

wacrm is single-tenant per WhatsApp number by design (RLS on `conversations`/`messages` is `auth.uid() = user_id`, so a second user physically cannot read messages routed to a different owner). The bug is that the system silently accepted a corrupted state instead of refusing it.

The original reporter also asked whether multiple users sharing one number is supported. It is not — that's a feature, not a bug. The dead `assigned_agent_id` / `sender_type='agent'` fields point at a multi-agent feature the schema never implemented; I'll address those separately if we want to clean them up.

## What changed

Three layers, in one commit:

- **`POST /api/whatsapp/config`** — added a 409 guard. Before Meta verification, query `whatsapp_config` via a service-role client for any row with the same `phone_number_id` belonging to a different user. If found, return *"This WhatsApp phone number is already linked to another account…"*. Service-role is required — under RLS the saving user can't see the conflicting row.
- **`src/app/api/whatsapp/webhook/route.ts`** — dropped `.single()`. Now distinguishes 0 rows (true "no config") from ≥2 rows (duplicate claim), logging the conflicting `user_id`s in the latter case so operators see the real cause.
- **`supabase/migrations/013_whatsapp_config_phone_number_id_unique.sql`** — adds `UNIQUE(phone_number_id)` to `whatsapp_config` so the same can't happen via direct DB writes or a race between the app-level check and the insert. If duplicates already exist, the migration **fails loudly with a copy-pasteable resolution hint** instead of auto-deduping — auto-deletion would destroy encrypted tokens and connection state, which is the operator's call.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new warnings in changed files (the existing 23 are pre-existing).
- [x] `npm test` — 162 / 162 passing.
- [x] `npm run build` — succeeds.
- [ ] Manual verification of the 409 path on a staging DB with two users (not done in this PR — happy to add a follow-up if useful, but the behaviour is observable in the logs above).

## Notes for the reviewer

- No new route-test infra added — the repo only tests `src/lib/*` utilities, and adding a Next route harness for one route is out of scope.
- The migration is idempotent and safe to re-run.
- I did not add `assigned_agent_id` cleanup here — keeping this PR single-purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)