### PR TITLE
fix(templates): map "None" header sentinel to null before save

### DIFF
--- a/src/components/settings/template-manager.tsx
+++ b/src/components/settings/template-manager.tsx
@@ -405,7 +405,15 @@ export function TemplateManager() {
               <Label className="text-slate-300">Header Type</Label>
               <Select
                 value={form.header_type}
-                onValueChange={(val) => setForm({ ...form, header_type: val || '' })}
+                onValueChange={(val) =>
+                  // "none" is a sentinel (the Select disallows value="")
+                  // — normalize it back to empty string so the DB CHECK
+                  // constraint (text|image|video|document) doesn't reject it.
+                  setForm({
+                    ...form,
+                    header_type: !val || val === 'none' ? '' : val,
+                  })
+                }
               >
                 <SelectTrigger className="w-full bg-slate-800 border-slate-700 text-white">
                   <SelectValue placeholder="None" />


### PR DESCRIPTION
## Summary

Closes the header-dropdown half of #147.

The Header Type Select in `template-manager.tsx` uses `value="none"` as a sentinel because the Select disallows `value=""`. On save, that literal `"none"` string was passed straight through to Supabase, where the `message_templates.header_type` CHECK constraint only accepts `text|image|video|document` — so picking "None" raised a constraint violation and the template never saved.

This PR normalizes the sentinel at the input boundary (`onValueChange`) so `form.header_type` is always either `''` (→ `null` on save) or a valid type. The save-side `|| null` fallback continues to handle the empty-string case.

## What this does NOT cover

- **Meta submission** (the second half of #147) — templates are still saved to Supabase only and not posted to Meta for approval. That's a much bigger change tracked separately in the comprehensive template-feature overhaul plan.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm test` — 162/162 passing
- [ ] Manual: open Settings → Message Templates → New Template → leave Header Type at default "None" placeholder → Create. Template saves, `header_type` is `null` in DB.
- [ ] Manual: open New Template → pick "None" from the dropdown explicitly → Create. Same result, no CHECK violation.
- [ ] Manual: open New Template → pick "Image" → Create. `header_type = 'image'` in DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)