### PR TITLE
docs(changelog): 0.2.2 — send_media flow node + migration 016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ Versions follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Pre-1.0, `MINOR` bumps cover new modules; `PATCH` bumps cover bug fixes
 and polish.
 
+## [0.2.2] — 2026-05-29
+
+Flow nodes can now send media. Closes the most-requested gap from user
+feedback after the v0.2.0 Flows launch — flows were text-only and
+couldn't deliver an invoice, receipt, product photo, or short demo
+video mid-conversation.
+
+### Added
+
+- **`send_media` flow node.** Send an image (PNG / JPEG / WebP), video
+  (MP4 / 3GP), or document (PDF, Word, Excel, PowerPoint, TXT) to the
+  customer from any point in a flow. Pick a file in the builder, it
+  uploads to the new `flow-media` Supabase Storage bucket, and Meta
+  fetches the public URL at send time. Optional caption (1024 char cap,
+  supports `{{vars.X}}` interpolation); documents also take an optional
+  filename shown in the recipient's chat. Auto-advances after send —
+  same suspend semantics as `send_message`.
+  ([#156](https://github.com/ArnasDon/wacrm/pull/156))
+
+### Migration required
+
+Apply against your Supabase project before deploying this version:
+
+- `supabase/migrations/016_flow_media.sql` — does two things:
+  1. Adds `'send_media'` to the `flow_nodes.node_type` CHECK
+     constraint. Without this the `send_media` node fails to save with
+     a constraint violation.
+  2. Creates the public `flow-media` Supabase Storage bucket (16 MB
+     file-size cap, image / video / document MIME allowlist) plus
+     per-user RLS policies (path prefix = `auth.uid()`). Without this
+     the builder's file picker fails on upload. Same shape as the
+     `avatars` bucket from migration 008 — the bucket is **public** so
+     Meta can fetch the URL without credentials.
+
+The migration is idempotent and safe to re-run.
+
 ## [0.2.1] — 2026-05-26
 
 Bug-fix release. Plugs a silent inbound-message drop that triggered

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wacrm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wacrm",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wacrm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Self-hostable CRM template for WhatsApp built on Next.js and Supabase — shared inbox, contacts, sales pipelines, broadcasts, and no-code automations.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Documents the v0.2.2 release shipped in [#156](https://github.com/ArnasDon/wacrm/pull/156): new `send_media` flow node.
- Adds a **Migration required** callout for `016_flow_media.sql` so self-hosters know to run it before deploying — without the CHECK update, saving a `send_media` node fails with a constraint violation; without the storage bucket, the builder's file picker fails on upload.
- Bumps `package.json` + `package-lock.json` from `0.2.1` → `0.2.2` (PATCH-style extension to the existing Flows module — follows the same convention as the `0.2.1` bug-fix bump).

## Test plan
- [ ] Skim the new `[0.2.2]` section — make sure the "Migration required" note matches what `016_flow_media.sql` actually does
- [ ] Confirm the version bump in both `package.json` and `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)