### PR TITLE
feat(flows): canvas / mind-map view, PR 2a of 3 — drag-to-position + side-panel edit

### DIFF
--- a/src/components/flows/flow-builder.tsx
+++ b/src/components/flows/flow-builder.tsx
@@ -15,7 +15,7 @@
  * the same file as small components rather than separate modules.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
@@ -31,16 +31,10 @@ import {
   CornerDownRight,
   PauseCircle,
   PlayCircle,
-  Paperclip,
   Workflow,
-  Upload,
-  X,
 } from "lucide-react";
-import { toast } from "sonner";
-
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import {
   Select,
@@ -56,23 +50,20 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import {
-  validateFlowForActivation,
-  type ValidationIssue,
-} from "@/lib/flows/validate";
-import type { FlowNodeRow, FlowRow } from "@/lib/flows/types";
-import { createClient } from "@/lib/supabase/client";
+import { type ValidationIssue } from "@/lib/flows/validate";
 import {
   NODE_META,
+  slugify,
   summarizeNode,
   type BuilderNode,
   type NodeType,
 } from "./shared";
-
-interface FlowBuilderProps {
-  initialFlow: FlowRow;
-  initialNodes: FlowNodeRow[];
-}
+import { NodeConfigForm } from "./forms/node-config-form";
+import { NodeKeySelect } from "./forms/fields";
+import {
+  useFlowEditor,
+  type BuilderState,
+} from "./flow-editor-state";
 
 // ============================================================
 // Local state shape — mirrors the DB but the configs are typed
@@ -80,319 +71,61 @@ interface FlowBuilderProps {
 // different shape. The sub-form components narrow as needed.
 // ============================================================
 
-interface BuilderState {
-  name: string;
-  description: string;
-  trigger_type: "keyword" | "first_inbound_message" | "manual";
-  trigger_config: Record<string, unknown>;
-  entry_node_id: string | null;
-  status: FlowRow["status"];
-  nodes: BuilderNode[];
-}
-
-// ============================================================
-// Helpers
-// ============================================================
-
-function slugify(s: string, fallback: string): string {
-  const cleaned = s
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
-  return cleaned || fallback;
-}
-
-function uniqueNodeKey(base: string, existing: BuilderNode[]): string {
-  if (!existing.some((n) => n.node_key === base)) return base;
-  let i = 2;
-  while (existing.some((n) => n.node_key === `${base}_${i}`)) i += 1;
-  return `${base}_${i}`;
-}
-
-function defaultConfigFor(type: NodeType): Record<string, unknown> {
-  switch (type) {
-    case "start":
-      return { next_node_key: "" };
-    case "send_message":
-      return { text: "", next_node_key: "" };
-    case "send_buttons":
-      return {
-        text: "",
-        buttons: [{ reply_id: "yes", title: "Yes", next_node_key: "" }],
-      };
-    case "send_list":
-      return {
-        text: "",
-        button_label: "View options",
-        sections: [
-          {
-            title: "",
-            rows: [
-              { reply_id: "row_1", title: "Option 1", next_node_key: "" },
-            ],
-          },
-        ],
-      };
-    case "send_media":
-      return {
-        media_type: "image",
-        media_url: "",
-        caption: "",
-        filename: "",
-        next_node_key: "",
-      };
-    case "collect_input":
-      return {
-        prompt_text: "",
-        var_key: "answer",
-        next_node_key: "",
-      };
-    case "condition":
-      return {
-        subject: "var",
-        subject_key: "",
-        operator: "equals",
-        value: "",
-        true_next: "",
-        false_next: "",
-      };
-    case "set_tag":
-      return { mode: "add", tag_id: "", next_node_key: "" };
-    case "handoff":
-      return { note: "" };
-    case "end":
-      return {};
-  }
-}
-
 // ============================================================
 // Root component
 // ============================================================
 
-export function FlowBuilder({ initialFlow, initialNodes }: FlowBuilderProps) {
+export function FlowBuilder() {
   const router = useRouter();
+  const {
+    flow,
+    state,
+    setState,
+    dirty,
+    saving,
+    activating,
+    issues,
+    canActivate,
+    addNode: addNodeCtx,
+    updateNode,
+    updateNodeConfig,
+    removeNode: removeNodeCtx,
+    save: handleSave,
+    setStatus: handleStatus,
+    deleteFlow: handleDelete,
+  } = useFlowEditor();
 
-  const [state, setState] = useState<BuilderState>(() => ({
-    name: initialFlow.name,
-    description: initialFlow.description ?? "",
-    trigger_type: initialFlow.trigger_type,
-    trigger_config: initialFlow.trigger_config as Record<string, unknown>,
-    entry_node_id: initialFlow.entry_node_id,
-    status: initialFlow.status,
-    nodes: initialNodes.map((n) => ({
-      node_key: n.node_key,
-      node_type: n.node_type as NodeType,
-      config: n.config as Record<string, unknown>,
-    })),
-  }));
-
-  const [saving, setSaving] = useState(false);
-  const [activating, setActivating] = useState(false);
+  // List-only UI state: which cards are expanded, scroll refs for
+  // jump-to-node, and the brief border flash that lands the eye on a
+  // jumped-to node. Canvas-view has its own analogue (selected-node
+  // + side-sheet open).
   const [expanded, setExpanded] = useState<Set<string>>(
-    () => new Set(initialNodes.map((n) => n.node_key)),
+    () => new Set(state.nodes.map((n) => n.node_key)),
   );
-  // Tracks whether the in-memory state has user edits that haven't been
-  // PUT yet. We use a wrapper setState (`setStateDirty`) for user edits;
-  // status-only changes after the activate API succeeds use raw setState
-  // so they don't falsely re-flag the form as dirty.
-  const [dirty, setDirty] = useState(false);
-  const setStateDirty = useCallback<typeof setState>((updaterOrValue) => {
-    setDirty(true);
-    setState(updaterOrValue);
-  }, []);
-
-  // Used by jumpToNode() to scroll the target into view + flash its border.
   const nodeRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const [flashedKey, setFlashedKey] = useState<string | null>(null);
 
-  // Browser-level reload / tab-close / external-link guard. SPA
-  // navigation (sidebar links, back button) isn't covered here — Next 16
-  // routes through the App Router and beforeunload doesn't fire on
-  // client-side route changes. That's a follow-up; this catches the
-  // accidental refresh / closed-window class of data loss.
-  useEffect(() => {
-    if (!dirty) return;
-    const handler = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      // Modern browsers ignore the return value but require something
-      // truthy to actually show the native prompt.
-      e.returnValue = "";
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, [dirty]);
-
-  // ---- Validation ----
-  const issues = useMemo<ValidationIssue[]>(
-    () =>
-      validateFlowForActivation(
-        {
-          name: state.name,
-          trigger_type: state.trigger_type,
-          trigger_config: state.trigger_config,
-          entry_node_id: state.entry_node_id,
-        },
-        state.nodes,
-      ),
-    [state],
-  );
-  const blockers = issues.filter((i) => i.severity === "error");
-  const canActivate = blockers.length === 0;
-
-  // ---- Save (PUT) ----
-  const handleSave = useCallback(async () => {
-    setSaving(true);
-    try {
-      const res = await fetch(`/api/flows/${initialFlow.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: state.name,
-          description: state.description || null,
-          trigger_type: state.trigger_type,
-          trigger_config: state.trigger_config,
-          entry_node_id: state.entry_node_id,
-          nodes: state.nodes,
-        }),
-      });
-      if (!res.ok) {
-        const json = await res.json().catch(() => ({}));
-        throw new Error(json.error ?? `Save failed: ${res.status}`);
-      }
-      setDirty(false);
-      toast.success("Saved.");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Save failed";
-      toast.error(msg);
-    } finally {
-      setSaving(false);
-    }
-  }, [initialFlow.id, state]);
-
-  // ---- Activate / Pause / Archive ----
-  const handleStatus = useCallback(
-    async (next: BuilderState["status"]) => {
-      if (next === "active" && !canActivate) {
-        toast.error("Fix the issues below before activating.");
-        return;
-      }
-      setActivating(true);
-      try {
-        // Always save first so the activation validator sees the
-        // latest state — the user shouldn't have to remember "save
-        // then activate".
-        if (next === "active") {
-          await handleSave();
-        }
-        const res = await fetch(`/api/flows/${initialFlow.id}/activate`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: next }),
-        });
-        if (!res.ok) {
-          const json = await res.json().catch(() => ({}));
-          throw new Error(json.error ?? `Status update failed: ${res.status}`);
-        }
-        setState((s) => ({ ...s, status: next }));
-        toast.success(
-          next === "active"
-            ? "Flow activated."
-            : next === "archived"
-              ? "Archived."
-              : "Saved as draft.",
-        );
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Status update failed";
-        toast.error(msg);
-      } finally {
-        setActivating(false);
-      }
-    },
-    [canActivate, handleSave, initialFlow.id],
-  );
-
-  // ---- Delete ----
-  const handleDelete = useCallback(async () => {
-    const yes = window.confirm(
-      `Delete "${state.name}"? Any active runs end immediately. This can't be undone.`,
-    );
-    if (!yes) return;
-    try {
-      const res = await fetch(`/api/flows/${initialFlow.id}`, {
-        method: "DELETE",
-      });
-      if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
-      router.push("/flows");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Delete failed";
-      toast.error(msg);
-    }
-  }, [initialFlow.id, router, state.name]);
-
-  // ---- Node helpers ----
-  const updateNode = useCallback(
-    (key: string, patch: Partial<BuilderNode>) => {
-      setStateDirty((s) => ({
-        ...s,
-        nodes: s.nodes.map((n) => (n.node_key === key ? { ...n, ...patch } : n)),
-      }));
-    },
-    [setStateDirty],
-  );
-
-  const updateNodeConfig = useCallback(
-    (key: string, configPatch: Record<string, unknown>) => {
-      setStateDirty((s) => ({
-        ...s,
-        nodes: s.nodes.map((n) =>
-          n.node_key === key ? { ...n, config: { ...n.config, ...configPatch } } : n,
-        ),
-      }));
-    },
-    [setStateDirty],
-  );
-
+  // Wrap addNode so the new node opens expanded in the list view
+  // (matches the previous behaviour where adding always revealed the
+  // new card so the user could start editing immediately).
   const addNode = useCallback(
     (type: NodeType) => {
-      const meta = NODE_META[type];
-      const base = slugify(meta.label, type);
-      setStateDirty((s) => {
-        const node_key = uniqueNodeKey(base, s.nodes);
-        const next: BuilderNode = {
-          node_key,
-          node_type: type,
-          config: defaultConfigFor(type),
-        };
-        setExpanded((prev) => new Set([...prev, node_key]));
-        return {
-          ...s,
-          nodes: [...s.nodes, next],
-          // If this is the first node and it's a start, pick it as
-          // the entry automatically. Saves a click.
-          entry_node_id:
-            s.entry_node_id ??
-            (type === "start" ? node_key : s.entry_node_id ?? null),
-        };
-      });
+      const key = addNodeCtx(type);
+      setExpanded((prev) => new Set([...prev, key]));
     },
-    [setStateDirty],
+    [addNodeCtx],
   );
 
   const removeNode = useCallback(
     (key: string) => {
-      setStateDirty((s) => ({
-        ...s,
-        nodes: s.nodes.filter((n) => n.node_key !== key),
-        entry_node_id: s.entry_node_id === key ? null : s.entry_node_id,
-      }));
+      removeNodeCtx(key);
       setExpanded((prev) => {
         const next = new Set(prev);
         next.delete(key);
         return next;
       });
     },
-    [setStateDirty],
+    [removeNodeCtx],
   );
 
   const toggleExpanded = useCallback((key: string) => {
@@ -439,7 +172,7 @@ export function FlowBuilder({ initialFlow, initialNodes }: FlowBuilderProps) {
     <div className="mx-auto flex h-full max-w-4xl flex-col gap-6 p-6">
       <Header
         state={state}
-        setState={setStateDirty}
+        setState={setState}
         dirty={dirty}
         saving={saving}
         activating={activating}
@@ -448,16 +181,16 @@ export function FlowBuilder({ initialFlow, initialNodes }: FlowBuilderProps) {
         onDelete={handleDelete}
         canActivate={canActivate}
         onBack={() => router.push("/flows")}
-        onViewRuns={() => router.push(`/flows/${initialFlow.id}/runs`)}
+        onViewRuns={() => router.push(`/flows/${flow.id}/runs`)}
       />
 
       <TriggerPanel
         state={state}
-        setState={setStateDirty}
+        setState={setState}
         triggerIssues={issues.filter((i) => i.scope === "trigger")}
       />
 
-      <EntryPicker state={state} setState={setStateDirty} />
+      <EntryPicker state={state} setState={setState} />
 
       <section className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
@@ -491,7 +224,7 @@ export function FlowBuilder({ initialFlow, initialNodes }: FlowBuilderProps) {
               onUpdateConfig={(patch) => updateNodeConfig(node.node_key, patch)}
               onRemove={() => removeNode(node.node_key)}
               onSetEntry={() =>
-                setStateDirty((s) => ({ ...s, entry_node_id: node.node_key }))
+                setState((s) => ({ ...s, entry_node_id: node.node_key }))
               }
             />
           ))
@@ -864,7 +597,7 @@ function NodeCard({
       </button>
       {expanded && (
         <div className="border-t border-slate-800 px-4 py-4">
-          <NodeConfigForm
+          <NodeConfigWithAdvanced
             node={node}
             allNodes={allNodes}
             onUpdate={onUpdate}
@@ -902,10 +635,12 @@ function NodeCard({
 }
 
 // ============================================================
-// Per-node-type config form
+// Per-node-type config form — wraps the extracted dispatcher with
+// the list-view's "Show advanced" disclosure (which exposes the
+// internal node_key for stable analytics, hidden by default).
 // ============================================================
 
-function NodeConfigForm({
+function NodeConfigWithAdvanced({
   node,
   allNodes,
   onUpdate,
@@ -916,149 +651,17 @@ function NodeConfigForm({
   onUpdate: (patch: Partial<BuilderNode>) => void;
   onUpdateConfig: (patch: Record<string, unknown>) => void;
 }) {
-  const cfg = node.config;
-  // Internal identifiers (node_key, reply_id columns on buttons/list rows)
-  // are auto-generated and the runner is the only consumer. Hide them by
-  // default so the form reads as plain editing; expose under "Advanced"
-  // for the rare case where someone wants to lock a key for stable
-  // analytics or external integration.
   const [showAdvanced, setShowAdvanced] = useState(false);
   const hasReplyIds =
     node.node_type === "send_buttons" || node.node_type === "send_list";
   return (
     <div className="flex flex-col gap-3">
-      {node.node_type === "start" && (
-        <NextNodeRow
-          value={(cfg as { next_node_key?: string }).next_node_key ?? ""}
-          allNodes={allNodes}
-          currentKey={node.node_key}
-          onChange={(v) => onUpdateConfig({ next_node_key: v })}
-          label="Advances to"
-        />
-      )}
-
-      {node.node_type === "send_message" && (
-        <>
-          <TextRow
-            label="Text sent to the customer"
-            value={(cfg as { text?: string }).text ?? ""}
-            onChange={(v) => onUpdateConfig({ text: v })}
-          />
-          <NextNodeRow
-            value={(cfg as { next_node_key?: string }).next_node_key ?? ""}
-            allNodes={allNodes}
-            currentKey={node.node_key}
-            onChange={(v) => onUpdateConfig({ next_node_key: v })}
-            label="Advances to"
-          />
-        </>
-      )}
-
-      {node.node_type === "send_buttons" && (
-        <SendButtonsForm
-          cfg={cfg as SendButtonsCfg}
-          allNodes={allNodes}
-          currentKey={node.node_key}
-          onUpdateConfig={onUpdateConfig}
-          showAdvanced={showAdvanced}
-        />
-      )}
-
-      {node.node_type === "send_list" && (
-        <SendListForm
-          cfg={cfg as SendListCfg}
-          allNodes={allNodes}
-          currentKey={node.node_key}
-          onUpdateConfig={onUpdateConfig}
-          showAdvanced={showAdvanced}
-        />
-      )}
-
-      {node.node_type === "send_media" && (
-        <SendMediaForm
-          cfg={cfg as SendMediaCfg}
-          allNodes={allNodes}
-          currentKey={node.node_key}
-          onUpdateConfig={onUpdateConfig}
-        />
-      )}
-
-      {node.node_type === "collect_input" && (
-        <>
-          <TextRow
-            label="Prompt sent to the customer"
-            value={(cfg as { prompt_text?: string }).prompt_text ?? ""}
-            onChange={(v) => onUpdateConfig({ prompt_text: v })}
-            rows={2}
-          />
-          <div>
-            <label className="mb-1 block text-xs text-slate-400">
-              Variable key (stored in flow_runs.vars; alphanumeric + underscore)
-            </label>
-            <Input
-              value={(cfg as { var_key?: string }).var_key ?? ""}
-              onChange={(e) =>
-                onUpdateConfig({
-                  var_key: e.target.value.replace(/[^a-zA-Z0-9_]/g, ""),
-                })
-              }
-              placeholder="e.g. name, email, company"
-              className="bg-slate-800 font-mono text-xs"
-            />
-            <p className="mt-1 text-[10px] text-slate-500">
-              Interpolate in downstream prompts and handoff notes with{" "}
-              <code className="rounded bg-slate-800 px-1">
-                {"{{vars."}
-                {(cfg as { var_key?: string }).var_key || "name"}
-                {"}}"}
-              </code>
-              .
-            </p>
-          </div>
-          <NextNodeRow
-            value={(cfg as { next_node_key?: string }).next_node_key ?? ""}
-            allNodes={allNodes}
-            currentKey={node.node_key}
-            onChange={(v) => onUpdateConfig({ next_node_key: v })}
-            label="After capturing, advance to"
-          />
-        </>
-      )}
-
-      {node.node_type === "condition" && (
-        <ConditionForm
-          cfg={cfg as ConditionCfg}
-          allNodes={allNodes}
-          currentKey={node.node_key}
-          onUpdateConfig={onUpdateConfig}
-        />
-      )}
-
-      {node.node_type === "set_tag" && (
-        <SetTagForm
-          cfg={cfg as SetTagCfg}
-          allNodes={allNodes}
-          currentKey={node.node_key}
-          onUpdateConfig={onUpdateConfig}
-        />
-      )}
-
-      {node.node_type === "handoff" && (
-        <TextRow
-          label="Internal note (for the agent picking up)"
-          value={(cfg as { note?: string }).note ?? ""}
-          onChange={(v) => onUpdateConfig({ note: v })}
-          rows={2}
-        />
-      )}
-
-      {node.node_type === "end" && (
-        <p className="text-xs text-slate-500">
-          Terminal node. When the runner reaches this node the run is marked
-          complete. No config needed.
-        </p>
-      )}
-
+      <NodeConfigForm
+        node={node}
+        allNodes={allNodes}
+        showAdvanced={showAdvanced}
+        onUpdateConfig={onUpdateConfig}
+      />
       <div className="border-t border-slate-800 pt-3">
         <button
           type="button"
@@ -1100,975 +703,6 @@ function NodeConfigForm({
   );
 }
 
-// ---- send_buttons form ----
-
-interface SendButtonsCfg {
-  text?: string;
-  footer_text?: string;
-  buttons?: Array<{ reply_id: string; title: string; next_node_key: string }>;
-}
-
-function SendButtonsForm({
-  cfg,
-  allNodes,
-  currentKey,
-  onUpdateConfig,
-  showAdvanced,
-}: {
-  cfg: SendButtonsCfg;
-  allNodes: BuilderNode[];
-  currentKey: string;
-  onUpdateConfig: (patch: Record<string, unknown>) => void;
-  showAdvanced: boolean;
-}) {
-  const buttons = cfg.buttons ?? [];
-  const updateButton = (
-    idx: number,
-    patch: Partial<NonNullable<SendButtonsCfg["buttons"]>[number]>,
-  ) => {
-    onUpdateConfig({
-      buttons: buttons.map((b, i) => (i === idx ? { ...b, ...patch } : b)),
-    });
-  };
-  const addButton = () =>
-    onUpdateConfig({
-      buttons: [
-        ...buttons,
-        {
-          reply_id: `btn_${buttons.length + 1}`,
-          title: "Option",
-          next_node_key: "",
-        },
-      ],
-    });
-  const removeButton = (idx: number) =>
-    onUpdateConfig({ buttons: buttons.filter((_, i) => i !== idx) });
-
-  return (
-    <>
-      <TextRow
-        label="Body text"
-        value={cfg.text ?? ""}
-        onChange={(v) => onUpdateConfig({ text: v })}
-        rows={3}
-      />
-      <TextRow
-        label="Footer (optional, 60 chars)"
-        value={cfg.footer_text ?? ""}
-        onChange={(v) => onUpdateConfig({ footer_text: v })}
-      />
-      <div>
-        <div className="mb-2 flex items-center justify-between">
-          <label className="text-xs text-slate-400">
-            Buttons (1–3) — each one routes to a different next node
-          </label>
-        </div>
-        <div className="flex flex-col gap-3">
-          {buttons.map((b, i) => (
-            <div
-              key={i}
-              className={cn(
-                "grid grid-cols-1 gap-2 rounded-md border border-slate-800 bg-slate-800/40 p-3",
-                showAdvanced
-                  ? "md:grid-cols-[1fr_2fr_2fr_auto]"
-                  : "md:grid-cols-[2fr_2fr_auto]",
-              )}
-            >
-              {showAdvanced && (
-                <Input
-                  value={b.reply_id}
-                  onChange={(e) =>
-                    updateButton(i, {
-                      reply_id: slugify(e.target.value, `btn_${i + 1}`),
-                    })
-                  }
-                  placeholder="reply_id"
-                  className="bg-slate-800 font-mono text-xs"
-                />
-              )}
-              <Input
-                value={b.title}
-                onChange={(e) => updateButton(i, { title: e.target.value })}
-                placeholder="Visible title (≤20 chars)"
-                className="bg-slate-800"
-                maxLength={20}
-              />
-              <NodeKeySelect
-                value={b.next_node_key || null}
-                nodes={allNodes}
-                excludeKey={currentKey}
-                onChange={(v) => updateButton(i, { next_node_key: v ?? "" })}
-                placeholder="Next node…"
-              />
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => removeButton(i)}
-                className="text-red-400 hover:bg-red-500/10 hover:text-red-300"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-          ))}
-        </div>
-        {buttons.length < 3 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={addButton}
-            className="mt-2"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            Add button
-          </Button>
-        )}
-      </div>
-    </>
-  );
-}
-
-// ---- send_list form ----
-
-interface SendListCfg {
-  text?: string;
-  button_label?: string;
-  footer_text?: string;
-  sections?: Array<{
-    title?: string;
-    rows: Array<{
-      reply_id: string;
-      title: string;
-      description?: string;
-      next_node_key: string;
-    }>;
-  }>;
-}
-
-function SendListForm({
-  cfg,
-  allNodes,
-  currentKey,
-  onUpdateConfig,
-  showAdvanced,
-}: {
-  cfg: SendListCfg;
-  allNodes: BuilderNode[];
-  currentKey: string;
-  onUpdateConfig: (patch: Record<string, unknown>) => void;
-  showAdvanced: boolean;
-}) {
-  const sections = cfg.sections ?? [];
-  const totalRows = sections.reduce((sum, s) => sum + s.rows.length, 0);
-
-  const updateSection = (
-    sIdx: number,
-    patch: Partial<NonNullable<SendListCfg["sections"]>[number]>,
-  ) => {
-    onUpdateConfig({
-      sections: sections.map((s, i) =>
-        i === sIdx ? { ...s, ...patch } : s,
-      ),
-    });
-  };
-  const addSection = () =>
-    onUpdateConfig({
-      sections: [
-        ...sections,
-        {
-          title: "",
-          rows: [
-            {
-              reply_id: `row_${totalRows + 1}`,
-              title: `Option ${totalRows + 1}`,
-              next_node_key: "",
-            },
-          ],
-        },
-      ],
-    });
-  const removeSection = (sIdx: number) =>
-    onUpdateConfig({ sections: sections.filter((_, i) => i !== sIdx) });
-  const updateRow = (
-    sIdx: number,
-    rIdx: number,
-    patch: Partial<
-      NonNullable<SendListCfg["sections"]>[number]["rows"][number]
-    >,
-  ) => {
-    onUpdateConfig({
-      sections: sections.map((s, i) =>
-        i === sIdx
-          ? {
-              ...s,
-              rows: s.rows.map((r, j) => (j === rIdx ? { ...r, ...patch } : r)),
-            }
-          : s,
-      ),
-    });
-  };
-  const addRow = (sIdx: number) =>
-    onUpdateConfig({
-      sections: sections.map((s, i) =>
-        i === sIdx
-          ? {
-              ...s,
-              rows: [
-                ...s.rows,
-                {
-                  reply_id: `row_${totalRows + 1}`,
-                  title: `Option ${totalRows + 1}`,
-                  next_node_key: "",
-                },
-              ],
-            }
-          : s,
-      ),
-    });
-  const removeRow = (sIdx: number, rIdx: number) =>
-    onUpdateConfig({
-      sections: sections.map((s, i) =>
-        i === sIdx ? { ...s, rows: s.rows.filter((_, j) => j !== rIdx) } : s,
-      ),
-    });
-
-  return (
-    <>
-      <TextRow
-        label="Body text"
-        value={cfg.text ?? ""}
-        onChange={(v) => onUpdateConfig({ text: v })}
-        rows={3}
-      />
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <TextRow
-          label="Tap-to-expand button label (≤20 chars)"
-          value={cfg.button_label ?? ""}
-          onChange={(v) => onUpdateConfig({ button_label: v })}
-        />
-        <TextRow
-          label="Footer (optional, 60 chars)"
-          value={cfg.footer_text ?? ""}
-          onChange={(v) => onUpdateConfig({ footer_text: v })}
-        />
-      </div>
-
-      <div className="mt-2">
-        <label className="mb-2 block text-xs text-slate-400">
-          Rows (1–10 total across all sections)
-        </label>
-        {sections.map((section, sIdx) => (
-          <div
-            key={sIdx}
-            className="mb-3 rounded-md border border-slate-800 bg-slate-800/40 p-3"
-          >
-            <div className="mb-2 flex items-center gap-2">
-              <Input
-                value={section.title ?? ""}
-                onChange={(e) =>
-                  updateSection(sIdx, { title: e.target.value })
-                }
-                placeholder={`Section ${sIdx + 1} title (optional)`}
-                className="bg-slate-800 text-xs"
-              />
-              {sections.length > 1 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => removeSection(sIdx)}
-                  className="shrink-0 text-red-400 hover:bg-red-500/10 hover:text-red-300"
-                  aria-label="Remove section"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              )}
-            </div>
-            {section.rows.map((row, rIdx) => (
-              <div
-                key={rIdx}
-                className={cn(
-                  "mb-2 grid grid-cols-1 gap-2",
-                  showAdvanced
-                    ? "md:grid-cols-[1fr_2fr_2fr_auto]"
-                    : "md:grid-cols-[2fr_2fr_auto]",
-                )}
-              >
-                {showAdvanced && (
-                  <Input
-                    value={row.reply_id}
-                    onChange={(e) =>
-                      updateRow(sIdx, rIdx, {
-                        reply_id: slugify(
-                          e.target.value,
-                          `row_${rIdx + 1}`,
-                        ),
-                      })
-                    }
-                    placeholder="reply_id"
-                    className="bg-slate-800 font-mono text-xs"
-                  />
-                )}
-                <Input
-                  value={row.title}
-                  onChange={(e) =>
-                    updateRow(sIdx, rIdx, { title: e.target.value })
-                  }
-                  placeholder="Row title (≤24)"
-                  className="bg-slate-800"
-                  maxLength={24}
-                />
-                <NodeKeySelect
-                  value={row.next_node_key || null}
-                  nodes={allNodes}
-                  excludeKey={currentKey}
-                  onChange={(v) =>
-                    updateRow(sIdx, rIdx, { next_node_key: v ?? "" })
-                  }
-                  placeholder="Next node…"
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => removeRow(sIdx, rIdx)}
-                  className="text-red-400 hover:bg-red-500/10 hover:text-red-300"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            ))}
-            {totalRows < 10 && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => addRow(sIdx)}
-                className="mt-1"
-              >
-                <Plus className="h-3.5 w-3.5" />
-                Add row
-              </Button>
-            )}
-          </div>
-        ))}
-        {/* WhatsApp's interactive-list spec caps sections at 10. Group rows
-            by category (Billing / Support / Sales etc.) to give customers a
-            scannable menu. */}
-        {sections.length < 10 && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={addSection}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            Add section
-          </Button>
-        )}
-      </div>
-    </>
-  );
-}
-
-// ---- condition form ----
-
-interface ConditionCfg {
-  subject?: "var" | "tag" | "contact_field";
-  subject_key?: string;
-  operator?: "equals" | "contains" | "present" | "absent";
-  value?: string;
-  true_next?: string;
-  false_next?: string;
-}
-
-interface UserTag {
-  id: string;
-  name: string;
-  color?: string;
-}
-
-function ConditionForm({
-  cfg,
-  allNodes,
-  currentKey,
-  onUpdateConfig,
-}: {
-  cfg: ConditionCfg;
-  allNodes: BuilderNode[];
-  currentKey: string;
-  onUpdateConfig: (patch: Record<string, unknown>) => void;
-}) {
-  const [tags, setTags] = useState<UserTag[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch("/api/tags").catch(() => null);
-        if (!res || !res.ok) return;
-        const json = (await res.json()) as { tags?: UserTag[] };
-        if (!cancelled) setTags(json.tags ?? []);
-      } catch {
-        // Tags endpoint absent on older deployments — fall back to a
-        // plain text input so the condition is still authorable.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const subject = cfg.subject ?? "var";
-  const operator = cfg.operator ?? "equals";
-  const showValue = operator === "equals" || operator === "contains";
-
-  return (
-    <>
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-        <div>
-          <label className="mb-1 block text-xs text-slate-400">If</label>
-          <Select
-            value={subject}
-            onValueChange={(v) =>
-              onUpdateConfig({ subject: v as ConditionCfg["subject"] })
-            }
-          >
-            <SelectTrigger className="bg-slate-800">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="var">Captured variable</SelectItem>
-              <SelectItem value="tag">Contact has tag</SelectItem>
-              <SelectItem value="contact_field">Contact field</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="md:col-span-2">
-          <label className="mb-1 block text-xs text-slate-400">
-            {subject === "var"
-              ? "var name"
-              : subject === "tag"
-                ? "Tag"
-                : "Field"}
-          </label>
-          {subject === "tag" && tags.length > 0 ? (
-            <Select
-              value={cfg.subject_key ?? ""}
-              onValueChange={(v) => onUpdateConfig({ subject_key: v })}
-            >
-              <SelectTrigger className="bg-slate-800">
-                <SelectValue placeholder="Pick a tag…" />
-              </SelectTrigger>
-              <SelectContent>
-                {tags.map((t) => (
-                  <SelectItem key={t.id} value={t.id}>
-                    {t.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : subject === "contact_field" ? (
-            <Select
-              value={cfg.subject_key ?? ""}
-              onValueChange={(v) => onUpdateConfig({ subject_key: v })}
-            >
-              <SelectTrigger className="bg-slate-800">
-                <SelectValue placeholder="Pick a field…" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="name">name</SelectItem>
-                <SelectItem value="email">email</SelectItem>
-                <SelectItem value="phone">phone</SelectItem>
-                <SelectItem value="company">company</SelectItem>
-              </SelectContent>
-            </Select>
-          ) : (
-            <Input
-              value={cfg.subject_key ?? ""}
-              onChange={(e) => onUpdateConfig({ subject_key: e.target.value })}
-              placeholder={subject === "var" ? "e.g. email" : "tag UUID"}
-              className="bg-slate-800 font-mono text-xs"
-            />
-          )}
-        </div>
-      </div>
-
-      <div
-        className={cn(
-          "grid grid-cols-1 gap-3",
-          showValue ? "md:grid-cols-2" : "",
-        )}
-      >
-        <div>
-          <label className="mb-1 block text-xs text-slate-400">Operator</label>
-          <Select
-            value={operator}
-            onValueChange={(v) =>
-              onUpdateConfig({ operator: v as ConditionCfg["operator"] })
-            }
-          >
-            <SelectTrigger className="bg-slate-800">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="present">is present</SelectItem>
-              <SelectItem value="absent">is absent</SelectItem>
-              <SelectItem value="equals">equals</SelectItem>
-              <SelectItem value="contains">contains</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        {showValue && (
-          <div>
-            <label className="mb-1 block text-xs text-slate-400">Value</label>
-            <Input
-              value={cfg.value ?? ""}
-              onChange={(e) => onUpdateConfig({ value: e.target.value })}
-              className="bg-slate-800"
-            />
-          </div>
-        )}
-      </div>
-
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <NextNodeRow
-          value={cfg.true_next ?? ""}
-          allNodes={allNodes}
-          currentKey={currentKey}
-          onChange={(v) => onUpdateConfig({ true_next: v })}
-          label="If true → advance to"
-        />
-        <NextNodeRow
-          value={cfg.false_next ?? ""}
-          allNodes={allNodes}
-          currentKey={currentKey}
-          onChange={(v) => onUpdateConfig({ false_next: v })}
-          label="If false → advance to"
-        />
-      </div>
-    </>
-  );
-}
-
-// ---- set_tag form ----
-
-interface SetTagCfg {
-  mode?: "add" | "remove";
-  tag_id?: string;
-  next_node_key?: string;
-}
-
-function SetTagForm({
-  cfg,
-  allNodes,
-  currentKey,
-  onUpdateConfig,
-}: {
-  cfg: SetTagCfg;
-  allNodes: BuilderNode[];
-  currentKey: string;
-  onUpdateConfig: (patch: Record<string, unknown>) => void;
-}) {
-  const [tags, setTags] = useState<UserTag[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch("/api/tags").catch(() => null);
-        if (!res || !res.ok) return;
-        const json = (await res.json()) as { tags?: UserTag[] };
-        if (!cancelled) setTags(json.tags ?? []);
-      } catch {
-        // No tags endpoint — fall back to raw UUID input.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return (
-    <>
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <div>
-          <label className="mb-1 block text-xs text-slate-400">Action</label>
-          <Select
-            value={cfg.mode ?? "add"}
-            onValueChange={(v) =>
-              onUpdateConfig({ mode: v as SetTagCfg["mode"] })
-            }
-          >
-            <SelectTrigger className="bg-slate-800">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="add">Add tag</SelectItem>
-              <SelectItem value="remove">Remove tag</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div>
-          <label className="mb-1 block text-xs text-slate-400">Tag</label>
-          {tags.length > 0 ? (
-            <Select
-              value={cfg.tag_id ?? ""}
-              onValueChange={(v) => onUpdateConfig({ tag_id: v })}
-            >
-              <SelectTrigger className="bg-slate-800">
-                <SelectValue placeholder="Pick a tag…" />
-              </SelectTrigger>
-              <SelectContent>
-                {tags.map((t) => (
-                  <SelectItem key={t.id} value={t.id}>
-                    {t.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : (
-            <Input
-              value={cfg.tag_id ?? ""}
-              onChange={(e) => onUpdateConfig({ tag_id: e.target.value })}
-              placeholder="Tag UUID"
-              className="bg-slate-800 font-mono text-xs"
-            />
-          )}
-        </div>
-      </div>
-      <NextNodeRow
-        value={cfg.next_node_key ?? ""}
-        allNodes={allNodes}
-        currentKey={currentKey}
-        onChange={(v) => onUpdateConfig({ next_node_key: v })}
-        label="Then advance to"
-      />
-    </>
-  );
-}
-
-// ---- send_media form ----
-
-interface SendMediaCfg {
-  media_type?: "image" | "video" | "document";
-  media_url?: string;
-  caption?: string;
-  filename?: string;
-  next_node_key?: string;
-}
-
-// Mirrors the bucket's allowed_mime_types from migration 016. Kept in
-// sync with the storage policy so the picker rejects unsupported files
-// before they hit the network rather than failing with a confusing
-// Supabase RLS / mime-type error.
-const MEDIA_ACCEPT: Record<NonNullable<SendMediaCfg["media_type"]>, string> = {
-  image: "image/png,image/jpeg,image/webp",
-  video: "video/mp4,video/3gpp",
-  document:
-    "application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain",
-};
-
-const FLOW_MEDIA_BUCKET = "flow-media";
-// 16 MB — matches the bucket file_size_limit set in migration 016.
-const FLOW_MEDIA_MAX_BYTES = 16 * 1024 * 1024;
-
-function SendMediaForm({
-  cfg,
-  allNodes,
-  currentKey,
-  onUpdateConfig,
-}: {
-  cfg: SendMediaCfg;
-  allNodes: BuilderNode[];
-  currentKey: string;
-  onUpdateConfig: (patch: Record<string, unknown>) => void;
-}) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [uploading, setUploading] = useState(false);
-
-  const mediaType = cfg.media_type ?? "image";
-  const isDocument = mediaType === "document";
-  const displayName =
-    cfg.filename ||
-    (cfg.media_url ? cfg.media_url.split("/").pop() ?? "" : "");
-
-  const handleFile = useCallback(
-    async (file: File) => {
-      if (file.size > FLOW_MEDIA_MAX_BYTES) {
-        toast.error(
-          `File is ${(file.size / 1024 / 1024).toFixed(1)} MB — limit is 16 MB.`,
-        );
-        return;
-      }
-      setUploading(true);
-      try {
-        const supabase = createClient();
-        const {
-          data: { user },
-          error: userErr,
-        } = await supabase.auth.getUser();
-        if (userErr || !user) {
-          throw new Error("Not signed in.");
-        }
-        // Path convention matches migration 016's RLS policy: first
-        // segment must equal auth.uid(). Timestamp + random suffix
-        // prevents collisions between two builders open at once.
-        const ext = file.name.split(".").pop()?.toLowerCase() ?? "bin";
-        const safeBase = file.name
-          .replace(/\.[^.]+$/, "")
-          .replace(/[^a-zA-Z0-9_-]+/g, "_")
-          .slice(0, 40) || "file";
-        const path = `${user.id}/${Date.now()}-${safeBase}.${ext}`;
-        const { error: upErr } = await supabase.storage
-          .from(FLOW_MEDIA_BUCKET)
-          .upload(path, file, {
-            cacheControl: "3600",
-            upsert: false,
-            contentType: file.type,
-          });
-        if (upErr) throw new Error(upErr.message);
-        const {
-          data: { publicUrl },
-        } = supabase.storage.from(FLOW_MEDIA_BUCKET).getPublicUrl(path);
-        // Patch all three fields in one call so the form doesn't
-        // re-render with a half-uploaded state.
-        onUpdateConfig({
-          media_url: publicUrl,
-          filename: file.name,
-        });
-        toast.success("File uploaded.");
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Upload failed.";
-        toast.error(msg);
-      } finally {
-        setUploading(false);
-      }
-    },
-    [onUpdateConfig],
-  );
-
-  const handleClear = () => {
-    onUpdateConfig({ media_url: "", filename: "" });
-  };
-
-  return (
-    <>
-      <div>
-        <label className="mb-1 block text-xs text-slate-400">Media type</label>
-        <Select
-          value={mediaType}
-          onValueChange={(v) => {
-            // Changing type clears the existing file — the bucket
-            // accepts different MIME sets per type and a previously
-            // uploaded PDF can't be sent as an image.
-            onUpdateConfig({
-              media_type: v as NonNullable<SendMediaCfg["media_type"]>,
-              media_url: "",
-              filename: "",
-            });
-          }}
-        >
-          <SelectTrigger className="bg-slate-800">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="image">Image (PNG, JPEG, WebP)</SelectItem>
-            <SelectItem value="video">Video (MP4, 3GP)</SelectItem>
-            <SelectItem value="document">
-              Document (PDF, Word, Excel, PowerPoint, TXT)
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div>
-        <label className="mb-1 block text-xs text-slate-400">File</label>
-        {cfg.media_url ? (
-          <div className="flex items-center gap-2 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-xs">
-            <Paperclip className="h-3.5 w-3.5 shrink-0 text-cyan-400" />
-            <a
-              href={cfg.media_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="min-w-0 flex-1 truncate text-slate-200 hover:text-cyan-300"
-              title={displayName || cfg.media_url}
-            >
-              {displayName || cfg.media_url}
-            </a>
-            <button
-              type="button"
-              onClick={handleClear}
-              className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
-              aria-label="Remove file"
-              disabled={uploading}
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={uploading}
-            className="flex w-full items-center justify-center gap-2 rounded-md border border-dashed border-slate-700 bg-slate-900 px-3 py-4 text-xs text-slate-400 transition-colors hover:border-slate-600 hover:bg-slate-800 hover:text-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {uploading ? (
-              <>
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Uploading…
-              </>
-            ) : (
-              <>
-                <Upload className="h-3.5 w-3.5" />
-                Click to upload (max 16 MB)
-              </>
-            )}
-          </button>
-        )}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={MEDIA_ACCEPT[mediaType]}
-          className="hidden"
-          onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) void handleFile(f);
-            // Reset so picking the same file twice still fires onChange.
-            e.target.value = "";
-          }}
-        />
-      </div>
-
-      <TextRow
-        label="Caption (optional, shown under the media)"
-        value={cfg.caption ?? ""}
-        onChange={(v) => onUpdateConfig({ caption: v })}
-        rows={2}
-      />
-
-      {isDocument && (
-        <div>
-          <label className="mb-1 block text-xs text-slate-400">
-            Filename shown to the customer (documents only)
-          </label>
-          <Input
-            value={cfg.filename ?? ""}
-            onChange={(e) => onUpdateConfig({ filename: e.target.value })}
-            placeholder="invoice.pdf"
-            className="bg-slate-800 text-xs"
-          />
-        </div>
-      )}
-
-      <NextNodeRow
-        value={cfg.next_node_key ?? ""}
-        allNodes={allNodes}
-        currentKey={currentKey}
-        onChange={(v) => onUpdateConfig({ next_node_key: v })}
-        label="After sending, advance to"
-      />
-    </>
-  );
-}
-
-// ---- Smaller field components ----
-
-function TextRow({
-  label,
-  value,
-  onChange,
-  rows = 1,
-}: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  rows?: number;
-}) {
-  return (
-    <div>
-      <label className="mb-1 block text-xs text-slate-400">{label}</label>
-      {rows > 1 ? (
-        <Textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          rows={rows}
-          className="bg-slate-800"
-        />
-      ) : (
-        <Input
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="bg-slate-800"
-        />
-      )}
-    </div>
-  );
-}
-
-function NextNodeRow({
-  value,
-  allNodes,
-  currentKey,
-  onChange,
-  label,
-}: {
-  value: string;
-  allNodes: BuilderNode[];
-  currentKey: string;
-  onChange: (v: string) => void;
-  label: string;
-}) {
-  return (
-    <div>
-      <label className="mb-1 block text-xs text-slate-400">{label}</label>
-      <NodeKeySelect
-        value={value || null}
-        nodes={allNodes}
-        excludeKey={currentKey}
-        onChange={(v) => onChange(v ?? "")}
-        placeholder="Pick a next node…"
-      />
-    </div>
-  );
-}
-
-function NodeKeySelect({
-  value,
-  nodes,
-  excludeKey,
-  onChange,
-  placeholder,
-  className,
-}: {
-  value: string | null;
-  nodes: BuilderNode[];
-  excludeKey?: string;
-  onChange: (v: string | null) => void;
-  placeholder?: string;
-  className?: string;
-}) {
-  const options = nodes.filter((n) => n.node_key !== excludeKey);
-  return (
-    <Select
-      value={value ?? "__none__"}
-      onValueChange={(v) => onChange(v === "__none__" ? null : v)}
-    >
-      <SelectTrigger className={cn("bg-slate-800", className)}>
-        <SelectValue placeholder={placeholder ?? "—"} />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="__none__">— None —</SelectItem>
-        {options.map((n) => {
-          const Icon = NODE_META[n.node_type].icon;
-          return (
-            <SelectItem key={n.node_key} value={n.node_key}>
-              <span className="inline-flex items-center gap-1.5">
-                <Icon
-                  className={cn("h-3 w-3", NODE_META[n.node_type].color)}
-                />
-                {n.node_key}
-              </span>
-            </SelectItem>
-          );
-        })}
-      </SelectContent>
-    </Select>
-  );
-}
 
 // ============================================================
 // Add-node menu

--- a/src/components/flows/flow-canvas.tsx
+++ b/src/components/flows/flow-canvas.tsx
@@ -26,7 +26,7 @@
  * that has to stay stable across views.
  */
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Background,
   Controls,
@@ -36,24 +36,30 @@ import {
   type Node as RfNode,
   type Edge as RfEdge,
   type NodeProps,
+  type OnNodeDrag,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { Trash2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { deriveCanvasEdges } from "@/lib/flows/edges";
 import { autoLayout, shouldAutoLayout } from "@/lib/flows/layout";
 import {
   NODE_META,
   summarizeNode,
   type BuilderNode,
-  type NodeType,
 } from "./shared";
-import type { FlowNodeRow, FlowRow } from "@/lib/flows/types";
-
-interface FlowCanvasProps {
-  initialFlow: FlowRow;
-  initialNodes: FlowNodeRow[];
-}
+import { useFlowEditor } from "./flow-editor-state";
+import { NodeConfigForm } from "./forms/node-config-form";
 
 // React-Flow node `data` payload — the bits our custom renderer needs.
 interface NodeData extends Record<string, unknown> {
@@ -115,16 +121,30 @@ const NODE_TYPES = { flow: FlowNodeCard };
 // Root canvas
 // ============================================================
 
-export function FlowCanvas({ initialFlow, initialNodes }: FlowCanvasProps) {
-  const { rfNodes, rfEdges } = useMemo(() => {
-    const builderNodes: BuilderNode[] = initialNodes.map((n) => ({
-      node_key: n.node_key,
-      node_type: n.node_type as NodeType,
-      config: n.config as Record<string, unknown>,
-      position_x: n.position_x,
-      position_y: n.position_y,
-    }));
+export function FlowCanvas() {
+  const {
+    state,
+    setState,
+    updateNodeConfig,
+    updateNodePosition,
+    removeNode,
+  } = useFlowEditor();
+  const builderNodes = state.nodes;
+  const entryNodeId = state.entry_node_id;
 
+  // Side-panel state — which node's form is open. Canvas-only UI; the
+  // list view's analogue is the per-card expanded set in
+  // flow-builder.tsx.
+  const [selectedNodeKey, setSelectedNodeKey] = useState<string | null>(null);
+  const selectedNode = useMemo(
+    () =>
+      selectedNodeKey
+        ? builderNodes.find((n) => n.node_key === selectedNodeKey) ?? null
+        : null,
+    [selectedNodeKey, builderNodes],
+  );
+
+  const { rfNodes, rfEdges } = useMemo(() => {
     const canvasEdges = deriveCanvasEdges(builderNodes);
 
     // Decide whether to auto-layout. The helper guards against
@@ -155,12 +175,10 @@ export function FlowCanvas({ initialFlow, initialNodes }: FlowCanvasProps) {
         },
         data: {
           node: n,
-          isEntry: n.node_key === initialFlow.entry_node_id,
+          isEntry: n.node_key === entryNodeId,
         },
-        // Read-only in PR 1 — block all editing affordances. Drag is
-        // still allowed visually because disabling it makes the canvas
-        // feel inert in a way that's worse than letting users nudge a
-        // tile that won't save.
+        // Drag-to-connect + delete-key still off in PR 2a — those land
+        // in PR 2b with per-slot handles + cascading edge cleanup.
         connectable: false,
         deletable: false,
       };
@@ -183,7 +201,49 @@ export function FlowCanvas({ initialFlow, initialNodes }: FlowCanvasProps) {
     }));
 
     return { rfNodes, rfEdges };
-  }, [initialFlow.entry_node_id, initialNodes]);
+  }, [builderNodes, entryNodeId]);
+
+  // Drag-to-position: React-Flow tracks the visual drag internally and
+  // fires this once on release. We write the final coordinate back to
+  // the editor context (which flips `dirty`); save then ships the new
+  // positions in the existing PUT /api/flows/[id] body (the route
+  // already destructures position_x / position_y per migration 010).
+  // Writing only on dragStop (not on every position-change tick during
+  // the drag) keeps state updates cheap on long drags.
+  const handleNodeDragStop = useCallback<OnNodeDrag<RfNode<NodeData>>>(
+    (_event, node) => {
+      updateNodePosition(node.id, node.position.x, node.position.y);
+    },
+    [updateNodePosition],
+  );
+
+  const handleNodeClick = useCallback(
+    (_event: React.MouseEvent, node: RfNode<NodeData>) => {
+      setSelectedNodeKey(node.id);
+    },
+    [],
+  );
+
+  // Wrapped mutators that target the currently-selected node — pass to
+  // the form so each keystroke goes through the editor context (which
+  // flips `dirty` and feeds the validator).
+  const onSelectedUpdateConfig = useCallback(
+    (patch: Record<string, unknown>) => {
+      if (selectedNodeKey) updateNodeConfig(selectedNodeKey, patch);
+    },
+    [selectedNodeKey, updateNodeConfig],
+  );
+
+  const handleDeleteSelected = useCallback(() => {
+    if (!selectedNodeKey) return;
+    removeNode(selectedNodeKey);
+    setSelectedNodeKey(null);
+  }, [selectedNodeKey, removeNode]);
+
+  const handleSetEntry = useCallback(() => {
+    if (!selectedNodeKey) return;
+    setState((s) => ({ ...s, entry_node_id: selectedNodeKey }));
+  }, [selectedNodeKey, setState]);
 
   if (rfNodes.length === 0) {
     return (
@@ -203,8 +263,10 @@ export function FlowCanvas({ initialFlow, initialNodes }: FlowCanvasProps) {
           fitView
           fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
           proOptions={{ hideAttribution: true }}
-          // Read-only knobs — keeps PR 1's surface inert at the
-          // React-Flow level. PR 2 will flip these back on.
+          onNodeDragStop={handleNodeDragStop}
+          onNodeClick={handleNodeClick}
+          // Drag-to-connect + delete-by-keyboard still off — both land
+          // in PR 2b with per-slot handles + cascading edge cleanup.
           nodesConnectable={false}
           edgesFocusable={false}
           elementsSelectable={true}
@@ -228,6 +290,104 @@ export function FlowCanvas({ initialFlow, initialNodes }: FlowCanvasProps) {
           />
         </ReactFlow>
       </div>
+
+      <NodeEditSheet
+        node={selectedNode}
+        isEntry={selectedNode?.node_key === entryNodeId}
+        allNodes={builderNodes}
+        onClose={() => setSelectedNodeKey(null)}
+        onUpdateConfig={onSelectedUpdateConfig}
+        onDelete={handleDeleteSelected}
+        onSetEntry={handleSetEntry}
+      />
     </ReactFlowProvider>
+  );
+}
+
+// ============================================================
+// Side panel — opens when a canvas node is clicked. Mounts the
+// shared NodeConfigForm dispatcher so edits made here behave
+// identically to the list view's per-card editor.
+// ============================================================
+
+function NodeEditSheet({
+  node,
+  isEntry,
+  allNodes,
+  onClose,
+  onUpdateConfig,
+  onDelete,
+  onSetEntry,
+}: {
+  node: BuilderNode | null;
+  isEntry: boolean;
+  allNodes: BuilderNode[];
+  onClose: () => void;
+  onUpdateConfig: (patch: Record<string, unknown>) => void;
+  onDelete: () => void;
+  onSetEntry: () => void;
+}) {
+  // Sheet is controlled — opens when a node is selected, closes via
+  // Esc / overlay / close button (all delegated to onClose).
+  const open = node !== null;
+  if (!node) {
+    return (
+      <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+        <SheetContent side="right" className="w-full sm:max-w-md" />
+      </Sheet>
+    );
+  }
+  const meta = NODE_META[node.node_type];
+  const Icon = meta.icon;
+  return (
+    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 border-l border-slate-800 bg-slate-950 p-0 sm:max-w-md"
+      >
+        <SheetHeader className="border-b border-slate-800 px-5 py-4">
+          <SheetTitle className="flex items-center gap-2 text-slate-100">
+            <Icon className={cn("h-4 w-4 shrink-0", meta.color)} />
+            <span>{meta.label}</span>
+            {isEntry && (
+              <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-emerald-300">
+                Entry
+              </span>
+            )}
+          </SheetTitle>
+          <SheetDescription className="font-mono text-[11px] text-slate-400">
+            {node.node_key}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-5 py-4">
+          <NodeConfigForm
+            node={node}
+            allNodes={allNodes}
+            showAdvanced={false}
+            onUpdateConfig={onUpdateConfig}
+          />
+        </div>
+
+        <SheetFooter className="border-t border-slate-800 px-5 py-3 sm:flex-row sm:justify-between">
+          {!isEntry ? (
+            <Button variant="ghost" size="sm" onClick={onSetEntry}>
+              Set as entry
+            </Button>
+          ) : (
+            <span />
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onDelete}
+            className="text-red-400 hover:bg-red-500/10 hover:text-red-300"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Delete node
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/src/components/flows/flow-editor-shell.tsx
+++ b/src/components/flows/flow-editor-shell.tsx
@@ -21,6 +21,7 @@ import { LayoutGrid, ListTree } from "lucide-react";
 
 import { FlowBuilder } from "./flow-builder";
 import { FlowCanvas } from "./flow-canvas";
+import { FlowEditorProvider } from "./flow-editor-state";
 import { cn } from "@/lib/utils";
 import type { FlowRow, FlowNodeRow } from "@/lib/flows/types";
 
@@ -59,34 +60,32 @@ export function FlowEditorShell({ initialFlow, initialNodes }: Props) {
   };
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-end">
-        <div
-          role="group"
-          aria-label="Editor view"
-          className="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900 p-0.5 text-xs"
-        >
-          <ToggleButton
-            active={view === "canvas"}
-            onClick={() => choose("canvas")}
-            icon={<LayoutGrid className="h-3 w-3" />}
-            label="Canvas"
-          />
-          <ToggleButton
-            active={view === "list"}
-            onClick={() => choose("list")}
-            icon={<ListTree className="h-3 w-3" />}
-            label="List"
-          />
+    <FlowEditorProvider initialFlow={initialFlow} initialNodes={initialNodes}>
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-end">
+          <div
+            role="group"
+            aria-label="Editor view"
+            className="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900 p-0.5 text-xs"
+          >
+            <ToggleButton
+              active={view === "canvas"}
+              onClick={() => choose("canvas")}
+              icon={<LayoutGrid className="h-3 w-3" />}
+              label="Canvas"
+            />
+            <ToggleButton
+              active={view === "list"}
+              onClick={() => choose("list")}
+              icon={<ListTree className="h-3 w-3" />}
+              label="List"
+            />
+          </div>
         </div>
-      </div>
 
-      {view === "canvas" ? (
-        <FlowCanvas initialFlow={initialFlow} initialNodes={initialNodes} />
-      ) : (
-        <FlowBuilder initialFlow={initialFlow} initialNodes={initialNodes} />
-      )}
-    </div>
+        {view === "canvas" ? <FlowCanvas /> : <FlowBuilder />}
+      </div>
+    </FlowEditorProvider>
   );
 }
 

--- a/src/components/flows/flow-editor-state.test.ts
+++ b/src/components/flows/flow-editor-state.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  defaultConfigFor,
+  uniqueNodeKey,
+} from "./flow-editor-state";
+import type { BuilderNode, NodeType } from "./shared";
+
+describe("uniqueNodeKey", () => {
+  it("returns the base key when it isn't taken", () => {
+    expect(uniqueNodeKey("menu", [])).toBe("menu");
+    expect(
+      uniqueNodeKey("menu", [
+        { node_key: "other", node_type: "end", config: {} },
+      ]),
+    ).toBe("menu");
+  });
+
+  it("appends _2 when the base is taken", () => {
+    expect(
+      uniqueNodeKey("menu", [
+        { node_key: "menu", node_type: "end", config: {} },
+      ]),
+    ).toBe("menu_2");
+  });
+
+  it("walks forward until it finds an unused suffix", () => {
+    const existing: BuilderNode[] = [
+      { node_key: "menu", node_type: "end", config: {} },
+      { node_key: "menu_2", node_type: "end", config: {} },
+      { node_key: "menu_3", node_type: "end", config: {} },
+    ];
+    expect(uniqueNodeKey("menu", existing)).toBe("menu_4");
+  });
+});
+
+describe("defaultConfigFor", () => {
+  // The hook's addNode and the validator both depend on these defaults
+  // being self-consistent. A broken default would surface as a
+  // validation error on a freshly-added node, which is exactly what
+  // these snapshots guard against.
+  const types: NodeType[] = [
+    "start",
+    "send_message",
+    "send_buttons",
+    "send_list",
+    "send_media",
+    "collect_input",
+    "condition",
+    "set_tag",
+    "handoff",
+    "end",
+  ];
+
+  it("returns an object for every known node type", () => {
+    for (const t of types) {
+      expect(typeof defaultConfigFor(t)).toBe("object");
+    }
+  });
+
+  it("send_buttons default has at least one button row", () => {
+    const cfg = defaultConfigFor("send_buttons") as {
+      buttons?: Array<{ reply_id: string; title: string }>;
+    };
+    expect(cfg.buttons?.length).toBeGreaterThan(0);
+    expect(cfg.buttons?.[0].reply_id).toBeTruthy();
+  });
+
+  it("send_list default has at least one section with one row", () => {
+    const cfg = defaultConfigFor("send_list") as {
+      sections?: Array<{ rows: unknown[] }>;
+    };
+    expect(cfg.sections?.length).toBeGreaterThan(0);
+    expect(cfg.sections?.[0].rows.length).toBeGreaterThan(0);
+  });
+
+  it("send_media defaults to image (the most common case)", () => {
+    const cfg = defaultConfigFor("send_media") as { media_type?: string };
+    expect(cfg.media_type).toBe("image");
+  });
+
+  it("collect_input ships a valid var_key that passes the validator regex", () => {
+    const cfg = defaultConfigFor("collect_input") as { var_key?: string };
+    // Mirrors the regex in validate.ts: alphanumeric + underscore,
+    // starts with letter or underscore.
+    expect(cfg.var_key).toMatch(/^[a-zA-Z_][a-zA-Z0-9_]*$/);
+  });
+
+  it("end's default is an empty object (terminal — no config)", () => {
+    expect(defaultConfigFor("end")).toEqual({});
+  });
+});

--- a/src/components/flows/flow-editor-state.tsx
+++ b/src/components/flows/flow-editor-state.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+/**
+ * Single source of truth for the flow editor's state.
+ *
+ * Both views (list and canvas) read and mutate the same `BuilderState`
+ * via `useFlowEditor()`. The provider mounts once inside
+ * `FlowEditorShell`, so toggling views never resets unsaved edits.
+ *
+ * What lives here:
+ *   - `BuilderState` shape (header fields, trigger config, nodes).
+ *   - Dirty / saving / activating flags so the header save button
+ *     and the beforeunload guard share the same source.
+ *   - All mutations: name / description / trigger / fallback,
+ *     addNode / updateNode / updateNodeConfig / updateNodePosition /
+ *     removeNode, setEntryNodeId.
+ *   - Side effects: save (PUT), setStatus (POST /activate),
+ *     deleteFlow (DELETE then router.push).
+ *   - Validation issues + the canActivate boolean.
+ *
+ * What does NOT live here:
+ *   - List-view UI state (expanded card set, scroll refs,
+ *     flash-on-jump) — those are list-only and stay in
+ *     `flow-builder.tsx`.
+ *   - Canvas-view UI state (selected node id, side-sheet open) —
+ *     those are canvas-only and stay in `flow-canvas.tsx`.
+ *
+ * `removeNode` does NOT auto-clean inbound edges. The list-view's
+ * NodeKeySelect dropdowns and the validator both surface dangling
+ * `next_node_key` references; that visibility is enough for v1. PR 2b
+ * (canvas delete via keyboard) will revisit if the canvas adds an
+ * implicit-delete affordance that's easier to trip accidentally.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import {
+  validateFlowForActivation,
+  type ValidationIssue,
+} from "@/lib/flows/validate";
+import type { FlowNodeRow, FlowRow } from "@/lib/flows/types";
+import { NODE_META, slugify, type BuilderNode, type NodeType } from "./shared";
+
+// ============================================================
+// State shape
+// ============================================================
+
+export interface BuilderState {
+  name: string;
+  description: string;
+  trigger_type: "keyword" | "first_inbound_message" | "manual";
+  trigger_config: Record<string, unknown>;
+  entry_node_id: string | null;
+  status: FlowRow["status"];
+  nodes: BuilderNode[];
+}
+
+export interface FlowEditorContextValue {
+  /** Immutable post-load envelope: id, created_at, fallback_policy, etc. */
+  flow: FlowRow;
+
+  // Authored state
+  state: BuilderState;
+  /**
+   * Dirty-tracking React setState. Flips `dirty` on every call. Used
+   * by the list view's existing subcomponents (Header, TriggerPanel,
+   * EntryPicker) which mutate multiple fields atomically — granular
+   * setters below would force them to fan out the update.
+   */
+  setState: (
+    updaterOrValue:
+      | BuilderState
+      | ((prev: BuilderState) => BuilderState),
+  ) => void;
+  dirty: boolean;
+  saving: boolean;
+  activating: boolean;
+  issues: ValidationIssue[];
+  canActivate: boolean;
+
+  // Node mutations. addNode returns the generated key so the caller
+  // (a NodeCard "Add" button or canvas "+" button) can scroll to /
+  // focus / open the new node.
+  addNode: (type: NodeType) => string;
+  updateNode: (key: string, patch: Partial<BuilderNode>) => void;
+  updateNodeConfig: (key: string, patch: Record<string, unknown>) => void;
+  updateNodePosition: (key: string, x: number, y: number) => void;
+  removeNode: (key: string) => void;
+
+  // Actions
+  save: () => Promise<void>;
+  setStatus: (status: BuilderState["status"]) => Promise<void>;
+  deleteFlow: () => Promise<void>;
+}
+
+// ============================================================
+// Helpers — node_key generation + per-type default configs
+// ============================================================
+
+export function uniqueNodeKey(base: string, existing: BuilderNode[]): string {
+  if (!existing.some((n) => n.node_key === base)) return base;
+  let i = 2;
+  while (existing.some((n) => n.node_key === `${base}_${i}`)) i += 1;
+  return `${base}_${i}`;
+}
+
+export function defaultConfigFor(type: NodeType): Record<string, unknown> {
+  switch (type) {
+    case "start":
+      return { next_node_key: "" };
+    case "send_message":
+      return { text: "", next_node_key: "" };
+    case "send_buttons":
+      return {
+        text: "",
+        buttons: [{ reply_id: "yes", title: "Yes", next_node_key: "" }],
+      };
+    case "send_list":
+      return {
+        text: "",
+        button_label: "View options",
+        sections: [
+          {
+            title: "",
+            rows: [
+              { reply_id: "row_1", title: "Option 1", next_node_key: "" },
+            ],
+          },
+        ],
+      };
+    case "send_media":
+      return {
+        media_type: "image",
+        media_url: "",
+        caption: "",
+        filename: "",
+        next_node_key: "",
+      };
+    case "collect_input":
+      return {
+        prompt_text: "",
+        var_key: "answer",
+        next_node_key: "",
+      };
+    case "condition":
+      return {
+        subject: "var",
+        subject_key: "",
+        operator: "equals",
+        value: "",
+        true_next: "",
+        false_next: "",
+      };
+    case "set_tag":
+      return { mode: "add", tag_id: "", next_node_key: "" };
+    case "handoff":
+      return { note: "" };
+    case "end":
+      return {};
+  }
+}
+
+// ============================================================
+// Context
+// ============================================================
+
+const FlowEditorCtx = createContext<FlowEditorContextValue | null>(null);
+
+export function useFlowEditor(): FlowEditorContextValue {
+  const ctx = useContext(FlowEditorCtx);
+  if (!ctx) {
+    throw new Error(
+      "useFlowEditor must be called inside <FlowEditorProvider>",
+    );
+  }
+  return ctx;
+}
+
+// ============================================================
+// Provider
+// ============================================================
+
+interface ProviderProps {
+  initialFlow: FlowRow;
+  initialNodes: FlowNodeRow[];
+  children: ReactNode;
+}
+
+export function FlowEditorProvider({
+  initialFlow,
+  initialNodes,
+  children,
+}: ProviderProps) {
+  const router = useRouter();
+
+  const [state, setStateRaw] = useState<BuilderState>(() => ({
+    name: initialFlow.name,
+    description: initialFlow.description ?? "",
+    trigger_type: initialFlow.trigger_type,
+    trigger_config: initialFlow.trigger_config as Record<string, unknown>,
+    entry_node_id: initialFlow.entry_node_id,
+    status: initialFlow.status,
+    nodes: initialNodes.map((n) => ({
+      node_key: n.node_key,
+      node_type: n.node_type as NodeType,
+      config: n.config as Record<string, unknown>,
+      position_x: n.position_x,
+      position_y: n.position_y,
+    })),
+  }));
+
+  const [saving, setSaving] = useState(false);
+  const [activating, setActivating] = useState(false);
+  // dirty flips on user edits; status-only updates (after the activate
+  // API succeeds) use setStateRaw so they don't falsely re-flag the
+  // form as dirty.
+  const [dirty, setDirty] = useState(false);
+  const setState = useCallback<typeof setStateRaw>((updaterOrValue) => {
+    setDirty(true);
+    setStateRaw(updaterOrValue);
+  }, []);
+
+  // Browser-level reload / tab-close / external-link guard. SPA
+  // navigation (sidebar links, back button) isn't covered — Next 16
+  // routes through the App Router and beforeunload doesn't fire on
+  // client-side route changes. That's a follow-up; this catches the
+  // accidental refresh / closed-window class of data loss.
+  useEffect(() => {
+    if (!dirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Modern browsers ignore the return value but require something
+      // truthy to actually show the native prompt.
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [dirty]);
+
+  // ---- Validation ----
+  const issues = useMemo<ValidationIssue[]>(
+    () =>
+      validateFlowForActivation(
+        {
+          name: state.name,
+          trigger_type: state.trigger_type,
+          trigger_config: state.trigger_config,
+          entry_node_id: state.entry_node_id,
+        },
+        state.nodes,
+      ),
+    [state],
+  );
+  const canActivate = useMemo(
+    () => issues.every((i) => i.severity !== "error"),
+    [issues],
+  );
+
+  // ---- Save (PUT) ----
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/flows/${initialFlow.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: state.name,
+          description: state.description || null,
+          trigger_type: state.trigger_type,
+          trigger_config: state.trigger_config,
+          entry_node_id: state.entry_node_id,
+          nodes: state.nodes,
+        }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error ?? `Save failed: ${res.status}`);
+      }
+      setDirty(false);
+      toast.success("Saved.");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Save failed";
+      toast.error(msg);
+    } finally {
+      setSaving(false);
+    }
+  }, [initialFlow.id, state]);
+
+  // ---- Activate / Pause / Archive ----
+  const setStatus = useCallback(
+    async (next: BuilderState["status"]) => {
+      if (next === "active" && !canActivate) {
+        toast.error("Fix the issues below before activating.");
+        return;
+      }
+      setActivating(true);
+      try {
+        // Always save first so the activation validator sees the
+        // latest state — the user shouldn't have to remember "save
+        // then activate".
+        if (next === "active") {
+          await save();
+        }
+        const res = await fetch(`/api/flows/${initialFlow.id}/activate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: next }),
+        });
+        if (!res.ok) {
+          const json = await res.json().catch(() => ({}));
+          throw new Error(json.error ?? `Status update failed: ${res.status}`);
+        }
+        setStateRaw((s) => ({ ...s, status: next }));
+        toast.success(
+          next === "active"
+            ? "Flow activated."
+            : next === "archived"
+              ? "Archived."
+              : "Saved as draft.",
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Status update failed";
+        toast.error(msg);
+      } finally {
+        setActivating(false);
+      }
+    },
+    [canActivate, save, initialFlow.id],
+  );
+
+  // ---- Delete ----
+  const deleteFlow = useCallback(async () => {
+    const yes = window.confirm(
+      `Delete "${state.name}"? Any active runs end immediately. This can't be undone.`,
+    );
+    if (!yes) return;
+    try {
+      const res = await fetch(`/api/flows/${initialFlow.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+      router.push("/flows");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Delete failed";
+      toast.error(msg);
+    }
+  }, [initialFlow.id, router, state.name]);
+
+  // ---- Node mutations ----
+  const updateNode = useCallback(
+    (key: string, patch: Partial<BuilderNode>) => {
+      setState((s) => ({
+        ...s,
+        nodes: s.nodes.map((n) =>
+          n.node_key === key ? { ...n, ...patch } : n,
+        ),
+      }));
+    },
+    [setState],
+  );
+
+  const updateNodeConfig = useCallback(
+    (key: string, configPatch: Record<string, unknown>) => {
+      setState((s) => ({
+        ...s,
+        nodes: s.nodes.map((n) =>
+          n.node_key === key
+            ? { ...n, config: { ...n.config, ...configPatch } }
+            : n,
+        ),
+      }));
+    },
+    [setState],
+  );
+
+  const updateNodePosition = useCallback(
+    (key: string, x: number, y: number) => {
+      setState((s) => ({
+        ...s,
+        nodes: s.nodes.map((n) =>
+          n.node_key === key
+            ? { ...n, position_x: Math.round(x), position_y: Math.round(y) }
+            : n,
+        ),
+      }));
+    },
+    [setState],
+  );
+
+  const addNode = useCallback(
+    (type: NodeType): string => {
+      const meta = NODE_META[type];
+      const base = slugify(meta.label, type);
+      let createdKey = base;
+      setState((s) => {
+        const node_key = uniqueNodeKey(base, s.nodes);
+        createdKey = node_key;
+        const next: BuilderNode = {
+          node_key,
+          node_type: type,
+          config: defaultConfigFor(type),
+        };
+        return {
+          ...s,
+          nodes: [...s.nodes, next],
+          // If this is the first node and it's a start, pick it as
+          // the entry automatically. Saves a click.
+          entry_node_id:
+            s.entry_node_id ??
+            (type === "start" ? node_key : s.entry_node_id ?? null),
+        };
+      });
+      return createdKey;
+    },
+    [setState],
+  );
+
+  const removeNode = useCallback(
+    (key: string) => {
+      setState((s) => ({
+        ...s,
+        nodes: s.nodes.filter((n) => n.node_key !== key),
+        entry_node_id: s.entry_node_id === key ? null : s.entry_node_id,
+      }));
+    },
+    [setState],
+  );
+
+  const value = useMemo<FlowEditorContextValue>(
+    () => ({
+      flow: initialFlow,
+      state,
+      setState,
+      dirty,
+      saving,
+      activating,
+      issues,
+      canActivate,
+      addNode,
+      updateNode,
+      updateNodeConfig,
+      updateNodePosition,
+      removeNode,
+      save,
+      setStatus,
+      deleteFlow,
+    }),
+    [
+      initialFlow,
+      state,
+      setState,
+      dirty,
+      saving,
+      activating,
+      issues,
+      canActivate,
+      addNode,
+      updateNode,
+      updateNodeConfig,
+      updateNodePosition,
+      removeNode,
+      save,
+      setStatus,
+      deleteFlow,
+    ],
+  );
+
+  return <FlowEditorCtx.Provider value={value}>{children}</FlowEditorCtx.Provider>;
+}

--- a/src/components/flows/forms/fields.tsx
+++ b/src/components/flows/forms/fields.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Reusable field components shared across every per-node form.
+ *
+ * `NodeKeySelect` — picks a node from the flow's node list, rendered
+ * with the source node's icon so the dropdown reads as
+ * "destination = ◇ menu" rather than an opaque slug.
+ *
+ * `NextNodeRow` — wraps NodeKeySelect with a label; the most common
+ * per-node form row ("after this node, advance to…").
+ *
+ * `TextRow` — wraps Input or Textarea behind a label. Pure UI sugar
+ * to keep per-node forms uncluttered.
+ *
+ * Lives in src/components/flows/forms/ so both the list view's
+ * collapsed-card editor and the canvas view's side-panel editor
+ * (introduced in this PR) mount the exact same form components.
+ */
+
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { NODE_META, type BuilderNode } from "../shared";
+
+export function TextRow({
+  label,
+  value,
+  onChange,
+  rows = 1,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  rows?: number;
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs text-slate-400">{label}</label>
+      {rows > 1 ? (
+        <Textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={rows}
+          className="bg-slate-800"
+        />
+      ) : (
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="bg-slate-800"
+        />
+      )}
+    </div>
+  );
+}
+
+export function NextNodeRow({
+  value,
+  allNodes,
+  currentKey,
+  onChange,
+  label,
+}: {
+  value: string;
+  allNodes: BuilderNode[];
+  currentKey: string;
+  onChange: (v: string) => void;
+  label: string;
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs text-slate-400">{label}</label>
+      <NodeKeySelect
+        value={value || null}
+        nodes={allNodes}
+        excludeKey={currentKey}
+        onChange={(v) => onChange(v ?? "")}
+        placeholder="Pick a next node…"
+      />
+    </div>
+  );
+}
+
+export function NodeKeySelect({
+  value,
+  nodes,
+  excludeKey,
+  onChange,
+  placeholder,
+  className,
+}: {
+  value: string | null;
+  nodes: BuilderNode[];
+  excludeKey?: string;
+  onChange: (v: string | null) => void;
+  placeholder?: string;
+  className?: string;
+}) {
+  const options = nodes.filter((n) => n.node_key !== excludeKey);
+  return (
+    <Select
+      value={value ?? "__none__"}
+      onValueChange={(v) => onChange(v === "__none__" ? null : v)}
+    >
+      <SelectTrigger className={cn("bg-slate-800", className)}>
+        <SelectValue placeholder={placeholder ?? "—"} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="__none__">— None —</SelectItem>
+        {options.map((n) => {
+          const Icon = NODE_META[n.node_type].icon;
+          return (
+            <SelectItem key={n.node_key} value={n.node_key}>
+              <span className="inline-flex items-center gap-1.5">
+                <Icon
+                  className={cn("h-3 w-3", NODE_META[n.node_type].color)}
+                />
+                {n.node_key}
+              </span>
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/flows/forms/node-config-form.tsx
+++ b/src/components/flows/forms/node-config-form.tsx
@@ -1,0 +1,1076 @@
+"use client";
+
+/**
+ * Per-node configuration form, dispatched by node_type.
+ *
+ * One component, ten branches. Each branch renders the inputs that
+ * map onto the node's `config` JSONB shape (text + buttons for
+ * send_buttons, prompt + var_key for collect_input, etc.) and forwards
+ * edits up via `onUpdateConfig`.
+ *
+ * Why this lives in src/components/flows/forms/ instead of next to
+ * the list editor: PR 2 (canvas editing) needs to mount the same
+ * form in a side panel when a user clicks a node on the canvas.
+ * Keeping the per-node forms here means there's exactly one place
+ * where each form's behaviour and validation lives — drift between
+ * "what the list editor shows" and "what the canvas side panel
+ * shows" becomes impossible.
+ *
+ * `showAdvanced` is the disclosure that surfaces internal
+ * identifiers (node_key, button reply_id, list row reply_id) — owned
+ * by the host (NodeCard / SideSheet) so the toggle is rendered
+ * outside this form alongside whatever delete/cancel buttons that
+ * host wants. The form just reads the boolean and conditionally
+ * renders the advanced rows.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Loader2,
+  Paperclip,
+  Plus,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { createClient } from "@/lib/supabase/client";
+import { slugify, type BuilderNode } from "../shared";
+import { NextNodeRow, NodeKeySelect, TextRow } from "./fields";
+
+interface NodeConfigFormProps {
+  node: BuilderNode;
+  allNodes: BuilderNode[];
+  showAdvanced: boolean;
+  onUpdateConfig: (patch: Record<string, unknown>) => void;
+}
+
+export function NodeConfigForm({
+  node,
+  allNodes,
+  showAdvanced,
+  onUpdateConfig,
+}: NodeConfigFormProps) {
+  const cfg = node.config;
+  switch (node.node_type) {
+    case "start":
+      return (
+        <NextNodeRow
+          value={(cfg as { next_node_key?: string }).next_node_key ?? ""}
+          allNodes={allNodes}
+          currentKey={node.node_key}
+          onChange={(v) => onUpdateConfig({ next_node_key: v })}
+          label="Advances to"
+        />
+      );
+
+    case "send_message":
+      return (
+        <>
+          <TextRow
+            label="Text sent to the customer"
+            value={(cfg as { text?: string }).text ?? ""}
+            onChange={(v) => onUpdateConfig({ text: v })}
+          />
+          <NextNodeRow
+            value={(cfg as { next_node_key?: string }).next_node_key ?? ""}
+            allNodes={allNodes}
+            currentKey={node.node_key}
+            onChange={(v) => onUpdateConfig({ next_node_key: v })}
+            label="Advances to"
+          />
+        </>
+      );
+
+    case "send_buttons":
+      return (
+        <SendButtonsForm
+          cfg={cfg as SendButtonsCfg}
+          allNodes={allNodes}
+          currentKey={node.node_key}
+          onUpdateConfig={onUpdateConfig}
+          showAdvanced={showAdvanced}
+        />
+      );
+
+    case "send_list":
+      return (
+        <SendListForm
+          cfg={cfg as SendListCfg}
+          allNodes={allNodes}
+          currentKey={node.node_key}
+          onUpdateConfig={onUpdateConfig}
+          showAdvanced={showAdvanced}
+        />
+      );
+
+    case "send_media":
+      return (
+        <SendMediaForm
+          cfg={cfg as SendMediaCfg}
+          allNodes={allNodes}
+          currentKey={node.node_key}
+          onUpdateConfig={onUpdateConfig}
+        />
+      );
+
+    case "collect_input":
+      return (
+        <>
+          <TextRow
+            label="Prompt sent to the customer"
+            value={(cfg as { prompt_text?: string }).prompt_text ?? ""}
+            onChange={(v) => onUpdateConfig({ prompt_text: v })}
+            rows={2}
+          />
+          <div>
+            <label className="mb-1 block text-xs text-slate-400">
+              Variable key (stored in flow_runs.vars; alphanumeric + underscore)
+            </label>
+            <Input
+              value={(cfg as { var_key?: string }).var_key ?? ""}
+              onChange={(e) =>
+                onUpdateConfig({
+                  var_key: e.target.value.replace(/[^a-zA-Z0-9_]/g, ""),
+                })
+              }
+              placeholder="e.g. name, email, company"
+              className="bg-slate-800 font-mono text-xs"
+            />
+            <p className="mt-1 text-[10px] text-slate-500">
+              Interpolate in downstream prompts and handoff notes with{" "}
+              <code className="rounded bg-slate-800 px-1">
+                {"{{vars."}
+                {(cfg as { var_key?: string }).var_key || "name"}
+                {"}}"}
+              </code>
+              .
+            </p>
+          </div>
+          <NextNodeRow
+            value={(cfg as { next_node_key?: string }).next_node_key ?? ""}
+            allNodes={allNodes}
+            currentKey={node.node_key}
+            onChange={(v) => onUpdateConfig({ next_node_key: v })}
+            label="After capturing, advance to"
+          />
+        </>
+      );
+
+    case "condition":
+      return (
+        <ConditionForm
+          cfg={cfg as ConditionCfg}
+          allNodes={allNodes}
+          currentKey={node.node_key}
+          onUpdateConfig={onUpdateConfig}
+        />
+      );
+
+    case "set_tag":
+      return (
+        <SetTagForm
+          cfg={cfg as SetTagCfg}
+          allNodes={allNodes}
+          currentKey={node.node_key}
+          onUpdateConfig={onUpdateConfig}
+        />
+      );
+
+    case "handoff":
+      return (
+        <TextRow
+          label="Internal note (for the agent picking up)"
+          value={(cfg as { note?: string }).note ?? ""}
+          onChange={(v) => onUpdateConfig({ note: v })}
+          rows={2}
+        />
+      );
+
+    case "end":
+      return (
+        <p className="text-xs text-slate-500">
+          Terminal node. When the runner reaches this node the run is marked
+          complete. No config needed.
+        </p>
+      );
+  }
+}
+
+// ============================================================
+// send_buttons
+// ============================================================
+
+interface SendButtonsCfg {
+  text?: string;
+  footer_text?: string;
+  buttons?: Array<{ reply_id: string; title: string; next_node_key: string }>;
+}
+
+function SendButtonsForm({
+  cfg,
+  allNodes,
+  currentKey,
+  onUpdateConfig,
+  showAdvanced,
+}: {
+  cfg: SendButtonsCfg;
+  allNodes: BuilderNode[];
+  currentKey: string;
+  onUpdateConfig: (patch: Record<string, unknown>) => void;
+  showAdvanced: boolean;
+}) {
+  const buttons = cfg.buttons ?? [];
+  const updateButton = (
+    idx: number,
+    patch: Partial<NonNullable<SendButtonsCfg["buttons"]>[number]>,
+  ) => {
+    onUpdateConfig({
+      buttons: buttons.map((b, i) => (i === idx ? { ...b, ...patch } : b)),
+    });
+  };
+  const addButton = () =>
+    onUpdateConfig({
+      buttons: [
+        ...buttons,
+        {
+          reply_id: `btn_${buttons.length + 1}`,
+          title: "Option",
+          next_node_key: "",
+        },
+      ],
+    });
+  const removeButton = (idx: number) =>
+    onUpdateConfig({ buttons: buttons.filter((_, i) => i !== idx) });
+
+  return (
+    <>
+      <TextRow
+        label="Body text"
+        value={cfg.text ?? ""}
+        onChange={(v) => onUpdateConfig({ text: v })}
+        rows={3}
+      />
+      <TextRow
+        label="Footer (optional, 60 chars)"
+        value={cfg.footer_text ?? ""}
+        onChange={(v) => onUpdateConfig({ footer_text: v })}
+      />
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <label className="text-xs text-slate-400">
+            Buttons (1–3) — each one routes to a different next node
+          </label>
+        </div>
+        <div className="flex flex-col gap-3">
+          {buttons.map((b, i) => (
+            <div
+              key={i}
+              className={cn(
+                "grid grid-cols-1 gap-2 rounded-md border border-slate-800 bg-slate-800/40 p-3",
+                showAdvanced
+                  ? "md:grid-cols-[1fr_2fr_2fr_auto]"
+                  : "md:grid-cols-[2fr_2fr_auto]",
+              )}
+            >
+              {showAdvanced && (
+                <Input
+                  value={b.reply_id}
+                  onChange={(e) =>
+                    updateButton(i, {
+                      reply_id: slugify(e.target.value, `btn_${i + 1}`),
+                    })
+                  }
+                  placeholder="reply_id"
+                  className="bg-slate-800 font-mono text-xs"
+                />
+              )}
+              <Input
+                value={b.title}
+                onChange={(e) => updateButton(i, { title: e.target.value })}
+                placeholder="Visible title (≤20 chars)"
+                className="bg-slate-800"
+                maxLength={20}
+              />
+              <NodeKeySelect
+                value={b.next_node_key || null}
+                nodes={allNodes}
+                excludeKey={currentKey}
+                onChange={(v) => updateButton(i, { next_node_key: v ?? "" })}
+                placeholder="Next node…"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => removeButton(i)}
+                className="text-red-400 hover:bg-red-500/10 hover:text-red-300"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+        {buttons.length < 3 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={addButton}
+            className="mt-2"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add button
+          </Button>
+        )}
+      </div>
+    </>
+  );
+}
+
+// ============================================================
+// send_list
+// ============================================================
+
+interface SendListCfg {
+  text?: string;
+  button_label?: string;
+  footer_text?: string;
+  sections?: Array<{
+    title?: string;
+    rows: Array<{
+      reply_id: string;
+      title: string;
+      description?: string;
+      next_node_key: string;
+    }>;
+  }>;
+}
+
+function SendListForm({
+  cfg,
+  allNodes,
+  currentKey,
+  onUpdateConfig,
+  showAdvanced,
+}: {
+  cfg: SendListCfg;
+  allNodes: BuilderNode[];
+  currentKey: string;
+  onUpdateConfig: (patch: Record<string, unknown>) => void;
+  showAdvanced: boolean;
+}) {
+  const sections = cfg.sections ?? [];
+  const totalRows = sections.reduce((sum, s) => sum + s.rows.length, 0);
+
+  const updateSection = (
+    sIdx: number,
+    patch: Partial<NonNullable<SendListCfg["sections"]>[number]>,
+  ) => {
+    onUpdateConfig({
+      sections: sections.map((s, i) =>
+        i === sIdx ? { ...s, ...patch } : s,
+      ),
+    });
+  };
+  const addSection = () =>
+    onUpdateConfig({
+      sections: [
+        ...sections,
+        {
+          title: "",
+          rows: [
+            {
+              reply_id: `row_${totalRows + 1}`,
+              title: `Option ${totalRows + 1}`,
+              next_node_key: "",
+            },
+          ],
+        },
+      ],
+    });
+  const removeSection = (sIdx: number) =>
+    onUpdateConfig({ sections: sections.filter((_, i) => i !== sIdx) });
+  const updateRow = (
+    sIdx: number,
+    rIdx: number,
+    patch: Partial<
+      NonNullable<SendListCfg["sections"]>[number]["rows"][number]
+    >,
+  ) => {
+    onUpdateConfig({
+      sections: sections.map((s, i) =>
+        i === sIdx
+          ? {
+              ...s,
+              rows: s.rows.map((r, j) => (j === rIdx ? { ...r, ...patch } : r)),
+            }
+          : s,
+      ),
+    });
+  };
+  const addRow = (sIdx: number) =>
+    onUpdateConfig({
+      sections: sections.map((s, i) =>
+        i === sIdx
+          ? {
+              ...s,
+              rows: [
+                ...s.rows,
+                {
+                  reply_id: `row_${totalRows + 1}`,
+                  title: `Option ${totalRows + 1}`,
+                  next_node_key: "",
+                },
+              ],
+            }
+          : s,
+      ),
+    });
+  const removeRow = (sIdx: number, rIdx: number) =>
+    onUpdateConfig({
+      sections: sections.map((s, i) =>
+        i === sIdx ? { ...s, rows: s.rows.filter((_, j) => j !== rIdx) } : s,
+      ),
+    });
+
+  return (
+    <>
+      <TextRow
+        label="Body text"
+        value={cfg.text ?? ""}
+        onChange={(v) => onUpdateConfig({ text: v })}
+        rows={3}
+      />
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <TextRow
+          label="Tap-to-expand button label (≤20 chars)"
+          value={cfg.button_label ?? ""}
+          onChange={(v) => onUpdateConfig({ button_label: v })}
+        />
+        <TextRow
+          label="Footer (optional, 60 chars)"
+          value={cfg.footer_text ?? ""}
+          onChange={(v) => onUpdateConfig({ footer_text: v })}
+        />
+      </div>
+
+      <div className="mt-2">
+        <label className="mb-2 block text-xs text-slate-400">
+          Rows (1–10 total across all sections)
+        </label>
+        {sections.map((section, sIdx) => (
+          <div
+            key={sIdx}
+            className="mb-3 rounded-md border border-slate-800 bg-slate-800/40 p-3"
+          >
+            <div className="mb-2 flex items-center gap-2">
+              <Input
+                value={section.title ?? ""}
+                onChange={(e) =>
+                  updateSection(sIdx, { title: e.target.value })
+                }
+                placeholder={`Section ${sIdx + 1} title (optional)`}
+                className="bg-slate-800 text-xs"
+              />
+              {sections.length > 1 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeSection(sIdx)}
+                  className="shrink-0 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+                  aria-label="Remove section"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+            {section.rows.map((row, rIdx) => (
+              <div
+                key={rIdx}
+                className={cn(
+                  "mb-2 grid grid-cols-1 gap-2",
+                  showAdvanced
+                    ? "md:grid-cols-[1fr_2fr_2fr_auto]"
+                    : "md:grid-cols-[2fr_2fr_auto]",
+                )}
+              >
+                {showAdvanced && (
+                  <Input
+                    value={row.reply_id}
+                    onChange={(e) =>
+                      updateRow(sIdx, rIdx, {
+                        reply_id: slugify(
+                          e.target.value,
+                          `row_${rIdx + 1}`,
+                        ),
+                      })
+                    }
+                    placeholder="reply_id"
+                    className="bg-slate-800 font-mono text-xs"
+                  />
+                )}
+                <Input
+                  value={row.title}
+                  onChange={(e) =>
+                    updateRow(sIdx, rIdx, { title: e.target.value })
+                  }
+                  placeholder="Row title (≤24)"
+                  className="bg-slate-800"
+                  maxLength={24}
+                />
+                <NodeKeySelect
+                  value={row.next_node_key || null}
+                  nodes={allNodes}
+                  excludeKey={currentKey}
+                  onChange={(v) =>
+                    updateRow(sIdx, rIdx, { next_node_key: v ?? "" })
+                  }
+                  placeholder="Next node…"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeRow(sIdx, rIdx)}
+                  className="text-red-400 hover:bg-red-500/10 hover:text-red-300"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            ))}
+            {totalRows < 10 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => addRow(sIdx)}
+                className="mt-1"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add row
+              </Button>
+            )}
+          </div>
+        ))}
+        {/* WhatsApp's interactive-list spec caps sections at 10. Group rows
+            by category (Billing / Support / Sales etc.) to give customers a
+            scannable menu. */}
+        {sections.length < 10 && (
+          <Button variant="outline" size="sm" onClick={addSection}>
+            <Plus className="h-3.5 w-3.5" />
+            Add section
+          </Button>
+        )}
+      </div>
+    </>
+  );
+}
+
+// ============================================================
+// condition
+// ============================================================
+
+interface ConditionCfg {
+  subject?: "var" | "tag" | "contact_field";
+  subject_key?: string;
+  operator?: "equals" | "contains" | "present" | "absent";
+  value?: string;
+  true_next?: string;
+  false_next?: string;
+}
+
+interface UserTag {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+function ConditionForm({
+  cfg,
+  allNodes,
+  currentKey,
+  onUpdateConfig,
+}: {
+  cfg: ConditionCfg;
+  allNodes: BuilderNode[];
+  currentKey: string;
+  onUpdateConfig: (patch: Record<string, unknown>) => void;
+}) {
+  const tags = useUserTags();
+
+  const subject = cfg.subject ?? "var";
+  const operator = cfg.operator ?? "equals";
+  const showValue = operator === "equals" || operator === "contains";
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div>
+          <label className="mb-1 block text-xs text-slate-400">If</label>
+          <Select
+            value={subject}
+            onValueChange={(v) =>
+              onUpdateConfig({ subject: v as ConditionCfg["subject"] })
+            }
+          >
+            <SelectTrigger className="bg-slate-800">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="var">Captured variable</SelectItem>
+              <SelectItem value="tag">Contact has tag</SelectItem>
+              <SelectItem value="contact_field">Contact field</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="md:col-span-2">
+          <label className="mb-1 block text-xs text-slate-400">
+            {subject === "var"
+              ? "var name"
+              : subject === "tag"
+                ? "Tag"
+                : "Field"}
+          </label>
+          {subject === "tag" && tags.length > 0 ? (
+            <Select
+              value={cfg.subject_key ?? ""}
+              onValueChange={(v) => onUpdateConfig({ subject_key: v })}
+            >
+              <SelectTrigger className="bg-slate-800">
+                <SelectValue placeholder="Pick a tag…" />
+              </SelectTrigger>
+              <SelectContent>
+                {tags.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : subject === "contact_field" ? (
+            <Select
+              value={cfg.subject_key ?? ""}
+              onValueChange={(v) => onUpdateConfig({ subject_key: v })}
+            >
+              <SelectTrigger className="bg-slate-800">
+                <SelectValue placeholder="Pick a field…" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="name">name</SelectItem>
+                <SelectItem value="email">email</SelectItem>
+                <SelectItem value="phone">phone</SelectItem>
+                <SelectItem value="company">company</SelectItem>
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              value={cfg.subject_key ?? ""}
+              onChange={(e) =>
+                onUpdateConfig({ subject_key: e.target.value })
+              }
+              placeholder={subject === "var" ? "e.g. email" : "tag UUID"}
+              className="bg-slate-800 font-mono text-xs"
+            />
+          )}
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-3",
+          showValue ? "md:grid-cols-2" : "",
+        )}
+      >
+        <div>
+          <label className="mb-1 block text-xs text-slate-400">Operator</label>
+          <Select
+            value={operator}
+            onValueChange={(v) =>
+              onUpdateConfig({ operator: v as ConditionCfg["operator"] })
+            }
+          >
+            <SelectTrigger className="bg-slate-800">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="present">is present</SelectItem>
+              <SelectItem value="absent">is absent</SelectItem>
+              <SelectItem value="equals">equals</SelectItem>
+              <SelectItem value="contains">contains</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {showValue && (
+          <div>
+            <label className="mb-1 block text-xs text-slate-400">Value</label>
+            <Input
+              value={cfg.value ?? ""}
+              onChange={(e) => onUpdateConfig({ value: e.target.value })}
+              className="bg-slate-800"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <NextNodeRow
+          value={cfg.true_next ?? ""}
+          allNodes={allNodes}
+          currentKey={currentKey}
+          onChange={(v) => onUpdateConfig({ true_next: v })}
+          label="If true → advance to"
+        />
+        <NextNodeRow
+          value={cfg.false_next ?? ""}
+          allNodes={allNodes}
+          currentKey={currentKey}
+          onChange={(v) => onUpdateConfig({ false_next: v })}
+          label="If false → advance to"
+        />
+      </div>
+    </>
+  );
+}
+
+// ============================================================
+// set_tag
+// ============================================================
+
+interface SetTagCfg {
+  mode?: "add" | "remove";
+  tag_id?: string;
+  next_node_key?: string;
+}
+
+function SetTagForm({
+  cfg,
+  allNodes,
+  currentKey,
+  onUpdateConfig,
+}: {
+  cfg: SetTagCfg;
+  allNodes: BuilderNode[];
+  currentKey: string;
+  onUpdateConfig: (patch: Record<string, unknown>) => void;
+}) {
+  const tags = useUserTags();
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <label className="mb-1 block text-xs text-slate-400">Action</label>
+          <Select
+            value={cfg.mode ?? "add"}
+            onValueChange={(v) =>
+              onUpdateConfig({ mode: v as SetTagCfg["mode"] })
+            }
+          >
+            <SelectTrigger className="bg-slate-800">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="add">Add tag</SelectItem>
+              <SelectItem value="remove">Remove tag</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs text-slate-400">Tag</label>
+          {tags.length > 0 ? (
+            <Select
+              value={cfg.tag_id ?? ""}
+              onValueChange={(v) => onUpdateConfig({ tag_id: v })}
+            >
+              <SelectTrigger className="bg-slate-800">
+                <SelectValue placeholder="Pick a tag…" />
+              </SelectTrigger>
+              <SelectContent>
+                {tags.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              value={cfg.tag_id ?? ""}
+              onChange={(e) => onUpdateConfig({ tag_id: e.target.value })}
+              placeholder="Tag UUID"
+              className="bg-slate-800 font-mono text-xs"
+            />
+          )}
+        </div>
+      </div>
+      <NextNodeRow
+        value={cfg.next_node_key ?? ""}
+        allNodes={allNodes}
+        currentKey={currentKey}
+        onChange={(v) => onUpdateConfig({ next_node_key: v })}
+        label="Then advance to"
+      />
+    </>
+  );
+}
+
+/**
+ * Shared loader for both `condition` (subject=tag) and `set_tag`.
+ * Falls back to raw UUID input if the endpoint is absent on older
+ * deployments — the form remains authorable in that case.
+ */
+function useUserTags(): UserTag[] {
+  const [tags, setTags] = useState<UserTag[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/tags").catch(() => null);
+        if (!res || !res.ok) return;
+        const json = (await res.json()) as { tags?: UserTag[] };
+        if (!cancelled) setTags(json.tags ?? []);
+      } catch {
+        // Tags endpoint absent — caller falls back to raw input.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return tags;
+}
+
+// ============================================================
+// send_media
+// ============================================================
+
+interface SendMediaCfg {
+  media_type?: "image" | "video" | "document";
+  media_url?: string;
+  caption?: string;
+  filename?: string;
+  next_node_key?: string;
+}
+
+// Mirrors the bucket's allowed_mime_types from migration 016. Kept in
+// sync with the storage policy so the picker rejects unsupported files
+// before they hit the network rather than failing with a confusing
+// Supabase RLS / mime-type error.
+const MEDIA_ACCEPT: Record<NonNullable<SendMediaCfg["media_type"]>, string> = {
+  image: "image/png,image/jpeg,image/webp",
+  video: "video/mp4,video/3gpp",
+  document:
+    "application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain",
+};
+
+const FLOW_MEDIA_BUCKET = "flow-media";
+// 16 MB — matches the bucket file_size_limit set in migration 016.
+const FLOW_MEDIA_MAX_BYTES = 16 * 1024 * 1024;
+
+function SendMediaForm({
+  cfg,
+  allNodes,
+  currentKey,
+  onUpdateConfig,
+}: {
+  cfg: SendMediaCfg;
+  allNodes: BuilderNode[];
+  currentKey: string;
+  onUpdateConfig: (patch: Record<string, unknown>) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const mediaType = cfg.media_type ?? "image";
+  const isDocument = mediaType === "document";
+  const displayName =
+    cfg.filename ||
+    (cfg.media_url ? cfg.media_url.split("/").pop() ?? "" : "");
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      if (file.size > FLOW_MEDIA_MAX_BYTES) {
+        toast.error(
+          `File is ${(file.size / 1024 / 1024).toFixed(1)} MB — limit is 16 MB.`,
+        );
+        return;
+      }
+      setUploading(true);
+      try {
+        const supabase = createClient();
+        const {
+          data: { user },
+          error: userErr,
+        } = await supabase.auth.getUser();
+        if (userErr || !user) {
+          throw new Error("Not signed in.");
+        }
+        // Path convention matches migration 016's RLS policy: first
+        // segment must equal auth.uid(). Timestamp + random suffix
+        // prevents collisions between two builders open at once.
+        const ext = file.name.split(".").pop()?.toLowerCase() ?? "bin";
+        const safeBase =
+          file.name
+            .replace(/\.[^.]+$/, "")
+            .replace(/[^a-zA-Z0-9_-]+/g, "_")
+            .slice(0, 40) || "file";
+        const path = `${user.id}/${Date.now()}-${safeBase}.${ext}`;
+        const { error: upErr } = await supabase.storage
+          .from(FLOW_MEDIA_BUCKET)
+          .upload(path, file, {
+            cacheControl: "3600",
+            upsert: false,
+            contentType: file.type,
+          });
+        if (upErr) throw new Error(upErr.message);
+        const {
+          data: { publicUrl },
+        } = supabase.storage.from(FLOW_MEDIA_BUCKET).getPublicUrl(path);
+        // Patch all fields in one call so the form doesn't re-render
+        // with a half-uploaded state.
+        onUpdateConfig({
+          media_url: publicUrl,
+          filename: file.name,
+        });
+        toast.success("File uploaded.");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Upload failed.";
+        toast.error(msg);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [onUpdateConfig],
+  );
+
+  const handleClear = () => {
+    onUpdateConfig({ media_url: "", filename: "" });
+  };
+
+  return (
+    <>
+      <div>
+        <label className="mb-1 block text-xs text-slate-400">Media type</label>
+        <Select
+          value={mediaType}
+          onValueChange={(v) => {
+            // Changing type clears the existing file — the bucket
+            // accepts different MIME sets per type and a previously
+            // uploaded PDF can't be sent as an image.
+            onUpdateConfig({
+              media_type: v as NonNullable<SendMediaCfg["media_type"]>,
+              media_url: "",
+              filename: "",
+            });
+          }}
+        >
+          <SelectTrigger className="bg-slate-800">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="image">Image (PNG, JPEG, WebP)</SelectItem>
+            <SelectItem value="video">Video (MP4, 3GP)</SelectItem>
+            <SelectItem value="document">
+              Document (PDF, Word, Excel, PowerPoint, TXT)
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs text-slate-400">File</label>
+        {cfg.media_url ? (
+          <div className="flex items-center gap-2 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-xs">
+            <Paperclip className="h-3.5 w-3.5 shrink-0 text-cyan-400" />
+            <a
+              href={cfg.media_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="min-w-0 flex-1 truncate text-slate-200 hover:text-cyan-300"
+              title={displayName || cfg.media_url}
+            >
+              {displayName || cfg.media_url}
+            </a>
+            <button
+              type="button"
+              onClick={handleClear}
+              className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Remove file"
+              disabled={uploading}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="flex w-full items-center justify-center gap-2 rounded-md border border-dashed border-slate-700 bg-slate-900 px-3 py-4 text-xs text-slate-400 transition-colors hover:border-slate-600 hover:bg-slate-800 hover:text-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {uploading ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Uploading…
+              </>
+            ) : (
+              <>
+                <Upload className="h-3.5 w-3.5" />
+                Click to upload (max 16 MB)
+              </>
+            )}
+          </button>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={MEDIA_ACCEPT[mediaType]}
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) void handleFile(f);
+            // Reset so picking the same file twice still fires onChange.
+            e.target.value = "";
+          }}
+        />
+      </div>
+
+      <TextRow
+        label="Caption (optional, shown under the media)"
+        value={cfg.caption ?? ""}
+        onChange={(v) => onUpdateConfig({ caption: v })}
+        rows={2}
+      />
+
+      {isDocument && (
+        <div>
+          <label className="mb-1 block text-xs text-slate-400">
+            Filename shown to the customer (documents only)
+          </label>
+          <Input
+            value={cfg.filename ?? ""}
+            onChange={(e) => onUpdateConfig({ filename: e.target.value })}
+            placeholder="invoice.pdf"
+            className="bg-slate-800 text-xs"
+          />
+        </div>
+      )}
+
+      <NextNodeRow
+        value={cfg.next_node_key ?? ""}
+        allNodes={allNodes}
+        currentKey={currentKey}
+        onChange={(v) => onUpdateConfig({ next_node_key: v })}
+        label="After sending, advance to"
+      />
+    </>
+  );
+}

--- a/src/components/flows/shared.tsx
+++ b/src/components/flows/shared.tsx
@@ -114,6 +114,25 @@ export const NODE_META: Record<
 };
 
 // ============================================================
+// Pure editing helpers — used by forms in both views.
+// ============================================================
+
+/**
+ * Coerce an arbitrary string into a stable identifier (node_key,
+ * reply_id, etc.). Lowercases, collapses non-alphanumerics into
+ * single underscores, and trims leading/trailing underscores. Falls
+ * back to `fallback` for inputs that reduce to an empty string.
+ */
+export function slugify(s: string, fallback: string): string {
+  const cleaned = s
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned || fallback;
+}
+
+// ============================================================
 // Summary helpers — short, single-line content previews used in
 // collapsed node cards (list view) and node tiles (canvas view).
 // Returns null when there's nothing meaningful to show (start/end,


### PR DESCRIPTION
## Summary

Builds on [#158](https://github.com/ArnasDon/wacrm/pull/158)'s read-only canvas. This PR brings the canvas to ~75% of list-view parity:

- **Drag-to-reposition**, persisted on save
- **Click-to-edit via a side panel** that mounts the same per-node forms the list view uses

Drag-to-connect, add-from-canvas, and keyboard delete land in PR 2b (separately for review surface).

## What's in this PR

### Architecture (the bulk of the diff)

**Form extraction** — `src/components/flows/forms/`
- `fields.tsx` — shared `TextRow`, `NextNodeRow`, `NodeKeySelect`
- `node-config-form.tsx` — single dispatcher (`NodeConfigForm`) + all per-type forms (`SendButtonsForm`, `SendListForm`, `SendMediaForm`, `ConditionForm`, `SetTagForm`, plus the inline forms for `send_message`, `collect_input`, `handoff`, `start`, `end`). Both views now mount the SAME dispatcher, so behaviour can't drift between "what the list editor shows" and "what the canvas side panel shows".

**State lifting** — `src/components/flows/flow-editor-state.tsx`
- `FlowEditorProvider` + `useFlowEditor()` — single source of truth for `BuilderState`, dirty / saving / activating flags, validation issues, and all mutations (`addNode`, `updateNode`, `updateNodeConfig`, `updateNodePosition`, `removeNode`, plus the existing `save`, `setStatus`, `deleteFlow` actions).
- Mounted once in `FlowEditorShell` and consumed by both views. Toggling Canvas ⇄ List **never resets unsaved edits** — same nodes array, same dirty flag.
- `flow-builder.tsx` shrinks from ~2400 lines to ~900 lines. List-only UI state (expanded card set, scroll refs, jump-to-node flash) stays internal.

### Canvas additions

- `onNodeDragStop` writes the final position to context via `updateNodePosition` (flips dirty; serialized in the existing PUT `/api/flows/[id]` body — the route already accepts `position_x` / `position_y` per migration 010).
- `onNodeClick` opens a controlled shadcn Sheet (right-side panel) with the per-node form, plus "Set as entry" and "Delete node" buttons. Esc / overlay / close button all close.

## What's intentionally still NOT in this PR (PR 2b)

- Per-slot Handle components on the custom node renderer
- Drag-to-connect handler that maps target → updated `next_node_key` for the right slot
- Floating "+" button to add nodes from canvas
- Keyboard / context-menu delete

## Verification done

- `npm test` — 301 passing (9 new pure-helper tests for `uniqueNodeKey` + `defaultConfigFor` self-consistency)
- `npm run typecheck` — clean
- `npm run lint` — no new warnings in any touched file
- `npm run build` — production build succeeds

Hook integration tests deferred — would require adding `@testing-library/react` + jsdom, which warrants its own PR.

## Test plan
- [ ] Open a flow in Canvas view — drag a node, click Save → reload page → node stays at the new position
- [ ] Click a node — Sheet opens on the right with the per-type form populated correctly
- [ ] Edit a field in the Sheet → Save → reload → edit persists
- [ ] "Set as entry" in the Sheet updates the "Entry" pill on the corresponding canvas tile
- [ ] "Delete node" in the Sheet removes the tile and closes the Sheet
- [ ] Toggle to List view mid-edit (with unsaved changes) → edits are preserved
- [ ] Toggle back to Canvas → drag-positions and unsaved edits all preserved
- [ ] Test with each node type that the Sheet form behaves identically to the list-view card form

## Follow-ups
- **PR 2b**: per-slot handles + drag-to-connect + add/delete from canvas
- **PR 3**: polish (validator jump-to-node pans canvas, mobile fallback, keyboard shortcuts, onboarding hint)
- **Future**: hook integration tests behind `@testing-library/react`

🤖 Generated with [Claude Code](https://claude.com/claude-code)