### PR TITLE
add offer catalog

### DIFF
--- a/src/app/(dashboard)/products/page.tsx
+++ b/src/app/(dashboard)/products/page.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { BriefcaseBusiness, Loader2, Plus } from 'lucide-react';
+import { createClient } from '@/lib/supabase/client';
+import type { Offer } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface ProductForm {
+  name: string;
+  category: string;
+  provider: string;
+  price_amount: string;
+  fee_amount: string;
+  benefits: string;
+  min_budget: string;
+  city: string;
+  requirements: string;
+  commission_value: string;
+  metadata: string;
+  is_active: boolean;
+}
+
+const EMPTY_FORM: ProductForm = {
+  name: '',
+  category: '',
+  provider: '',
+  price_amount: '0',
+  fee_amount: '0',
+  benefits: '',
+  min_budget: '',
+  city: '',
+  requirements: '',
+  commission_value: '0',
+  metadata: '',
+  is_active: true,
+};
+
+export default function ProductsPage() {
+  const supabase = createClient();
+  const [products, setProducts] = useState<Offer[]>([]);
+  const [form, setForm] = useState<ProductForm>(EMPTY_FORM);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const fetchProducts = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('offers')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (error) toast.error(error.message);
+    else setProducts((data ?? []) as Offer[]);
+    setLoading(false);
+  }, [supabase]);
+
+  useEffect(() => {
+    void fetchProducts();
+  }, [fetchProducts]);
+
+  function updateForm(patch: Partial<ProductForm>) {
+    setForm((current) => ({ ...current, ...patch }));
+  }
+
+  async function saveProduct() {
+    if (!form.name.trim() || !form.category.trim()) {
+      toast.error('Offer name and category are required.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const user = session?.user;
+      if (!user) throw new Error('You are not signed in.');
+
+      const { error } = await supabase.from('offers').insert({
+        user_id: user.id,
+        name: form.name.trim(),
+        category: form.category.trim(),
+        provider: form.provider.trim(),
+        price_amount: Number(form.price_amount) || 0,
+        fee_amount: Number(form.fee_amount) || 0,
+        benefits: csv(form.benefits),
+        rules: {
+          min_budget: Number(form.min_budget) || undefined,
+          city: csv(form.city).map((value) => value.toLowerCase()),
+        },
+        requirements: csv(form.requirements),
+        commission_value: Number(form.commission_value) || 0,
+        metadata: parseMetadata(form.metadata),
+        is_active: form.is_active,
+      });
+
+      if (error) throw error;
+      toast.success('Offer saved');
+      setForm(EMPTY_FORM);
+      await fetchProducts();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to save offer',
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Catalog</h1>
+        <p className="mt-1 text-sm text-slate-400">
+          Manage products, services, packages, eligibility rules, and
+          commissions.
+        </p>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[420px_minmax(0,1fr)]">
+        <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+          <h2 className="font-semibold text-white">Add Offer</h2>
+          <div className="mt-4 grid gap-3">
+            <Input
+              value={form.name}
+              onChange={(event) => updateForm({ name: event.target.value })}
+              placeholder="Offer name"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <Input
+              value={form.category}
+              onChange={(event) => updateForm({ category: event.target.value })}
+              placeholder="Category, e.g. credit_card, clinic, course"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <Input
+              value={form.provider}
+              onChange={(event) => updateForm({ provider: event.target.value })}
+              placeholder="Provider or brand"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                value={form.price_amount}
+                onChange={(event) =>
+                  updateForm({ price_amount: event.target.value })
+                }
+                placeholder="Price"
+                className="border-slate-700 bg-slate-950 text-white"
+              />
+              <Input
+                value={form.fee_amount}
+                onChange={(event) =>
+                  updateForm({ fee_amount: event.target.value })
+                }
+                placeholder="Fee"
+                className="border-slate-700 bg-slate-950 text-white"
+              />
+            </div>
+            <Input
+              value={form.benefits}
+              onChange={(event) => updateForm({ benefits: event.target.value })}
+              placeholder="Benefits, comma-separated"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <Input
+              value={form.min_budget}
+              onChange={(event) =>
+                updateForm({ min_budget: event.target.value })
+              }
+              placeholder="Minimum budget"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <Input
+              value={form.city}
+              onChange={(event) => updateForm({ city: event.target.value })}
+              placeholder="Cities, comma-separated"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <Input
+              value={form.requirements}
+              onChange={(event) =>
+                updateForm({ requirements: event.target.value })
+              }
+              placeholder="Requirements, comma-separated"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <Input
+              value={form.commission_value}
+              onChange={(event) =>
+                updateForm({ commission_value: event.target.value })
+              }
+              placeholder="Commission value"
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <Input
+              value={form.metadata}
+              onChange={(event) => updateForm({ metadata: event.target.value })}
+              placeholder='Optional JSON metadata, e.g. {"annual_fee":999}'
+              className="border-slate-700 bg-slate-950 text-white"
+            />
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={form.is_active}
+                onChange={(event) =>
+                  updateForm({ is_active: event.target.checked })
+                }
+                className="size-4 rounded border-slate-700 bg-slate-950"
+              />
+              Active
+            </label>
+            <Button onClick={saveProduct} disabled={saving}>
+              {saving ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Plus className="size-4" />
+              )}
+              Save Offer
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-900/50">
+          <div className="border-b border-slate-800 p-4">
+            <h2 className="font-semibold text-white">Offers</h2>
+          </div>
+          {loading ? (
+            <div className="flex h-48 items-center justify-center">
+              <Loader2 className="size-6 animate-spin text-violet-500" />
+            </div>
+          ) : products.length === 0 ? (
+            <div className="p-10 text-center">
+              <BriefcaseBusiness className="mx-auto mb-3 size-10 text-slate-600" />
+              <p className="text-sm text-slate-500">No offers yet.</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-slate-800">
+              {products.map((product) => (
+                <div key={product.id} className="p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="font-medium text-white">{product.name}</h3>
+                      <p className="text-sm text-slate-400">
+                        {[product.category, product.provider]
+                          .filter(Boolean)
+                          .join(' - ')}
+                      </p>
+                    </div>
+                    <span
+                      className={
+                        product.is_active
+                          ? 'rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400'
+                          : 'rounded-full bg-slate-500/10 px-2 py-0.5 text-xs font-medium text-slate-400'
+                      }
+                    >
+                      {product.is_active ? 'Active' : 'Inactive'}
+                    </span>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-sm text-slate-300 sm:grid-cols-3">
+                    <p>Price: {money(product.price_amount)}</p>
+                    <p>Fee: {money(product.fee_amount)}</p>
+                    <p>Commission: {money(product.commission_value)}</p>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-1.5">
+                    {product.benefits.map((benefit) => (
+                      <span
+                        key={benefit}
+                        className="rounded-full bg-violet-500/10 px-2 py-0.5 text-xs text-violet-300"
+                      >
+                        {benefit}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function csv(value: string): string[] {
+  return value
+    .split(',')
+    .map((row) => row.trim())
+    .filter(Boolean);
+}
+
+function parseMetadata(value: string): Record<string, unknown> {
+  if (!value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function money(value: number): string {
+  return new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency: 'INR',
+    maximumFractionDigits: 0,
+  }).format(value);
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -23,6 +23,7 @@ const pageTitles: Record<string, string> = {
   "/contacts": "Contacts",
   "/pipelines": "Pipelines",
   "/broadcasts": "Broadcasts",
+  "/products": "Catalog",
   "/automations": "Automations",
   "/settings": "Settings",
 };

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Users,
   GitBranch,
   Radio,
+  Package,
   Zap,
   Workflow,
   Settings,
@@ -49,6 +50,7 @@ const navItems: NavItem[] = [
   { href: "/contacts", label: "Contacts", icon: Users },
   { href: "/pipelines", label: "Pipelines", icon: GitBranch },
   { href: "/broadcasts", label: "Broadcasts", icon: Radio },
+  { href: "/products", label: "Catalog", icon: Package },
   { href: "/automations", label: "Automations", icon: Zap },
   { href: "/flows", label: "Flows", icon: Workflow, beta: true },
 ];

--- a/src/lib/products/offers.test.ts
+++ b/src/lib/products/offers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { Offer } from '@/types';
+import { matchOffers } from './offers';
+
+function offer(overrides: Partial<Offer>): Offer {
+  return {
+    id: 'offer-1',
+    user_id: 'user-1',
+    name: 'Starter Website Package',
+    category: 'local_service',
+    provider: 'Acme Studio',
+    price_amount: 15000,
+    fee_amount: 0,
+    commission_value: 1200,
+    benefits: ['website', 'booking'],
+    rules: { city: ['mumbai', 'delhi'], min_budget: 10000 },
+    requirements: ['Business name'],
+    metadata: {},
+    is_active: true,
+    created_at: '2026-05-21T00:00:00.000Z',
+    updated_at: '2026-05-21T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('offer matching', () => {
+  it('matches by category, interest, location, and budget', () => {
+    const matches = matchOffers({
+      offers: [
+        offer({ id: 'inactive', is_active: false }),
+        offer({
+          id: 'card',
+          category: 'credit_card',
+          benefits: ['cashback'],
+          metadata: { annual_fee: 499 },
+        }),
+        offer({
+          id: 'service',
+          category: 'local_service',
+          benefits: ['website', 'booking'],
+          commission_value: 2500,
+        }),
+      ],
+      lead: {
+        category: 'local_service',
+        interest: 'website booking package',
+        city: 'Mumbai',
+        budget: 20000,
+      },
+    });
+
+    expect(matches.map((match) => match.offer.id)).toEqual(['service']);
+    expect(matches[0].reasons).toContain('Category match');
+  });
+
+  it('keeps credit-card details in metadata instead of the base catalog shape', () => {
+    const matches = matchOffers({
+      offers: [
+        offer({
+          id: 'cashback-card',
+          category: 'credit_card',
+          benefits: ['cashback'],
+          metadata: { annual_fee: 999, network: 'Visa' },
+        }),
+      ],
+      lead: {
+        category: 'credit_card',
+        interest: 'cashback card',
+        city: 'Delhi',
+        budget: 1000,
+      },
+    });
+
+    expect(matches[0].offer.metadata).toEqual({
+      annual_fee: 999,
+      network: 'Visa',
+    });
+  });
+
+  it('rejects offers when required budget or city rules fail', () => {
+    const matches = matchOffers({
+      offers: [
+        offer({
+          id: 'premium-service',
+          rules: { min_budget: 100000, city: ['bengaluru'] },
+        }),
+      ],
+      lead: {
+        interest: 'website',
+        city: 'Delhi',
+        budget: 20000,
+      },
+    });
+
+    expect(matches).toEqual([]);
+  });
+});

--- a/src/lib/products/offers.ts
+++ b/src/lib/products/offers.ts
@@ -1,0 +1,132 @@
+import type { Offer } from '@/types';
+
+export interface OfferLeadProfile {
+  category?: string | null;
+  interest?: string | null;
+  city?: string | null;
+  budget?: number | null;
+}
+
+export interface OfferMatch {
+  offer: Offer;
+  score: number;
+  reasons: string[];
+}
+
+interface OfferRules {
+  min_budget?: number;
+  max_budget?: number;
+  city?: string[];
+}
+
+export function matchOffers({
+  offers,
+  lead,
+}: {
+  offers: Offer[];
+  lead: OfferLeadProfile;
+}): OfferMatch[] {
+  return offers
+    .filter((offer) => offer.is_active)
+    .map((offer) => scoreOffer(offer, lead))
+    .filter((match): match is OfferMatch => Boolean(match))
+    .sort((a, b) => b.score - a.score);
+}
+
+function scoreOffer(offer: Offer, lead: OfferLeadProfile): OfferMatch | null {
+  const rules = normalizeRules(offer.rules);
+  const leadCategory = normalize(lead.category);
+  const leadInterest = normalize(lead.interest);
+  const leadCity = normalize(lead.city);
+  const offerCategory = normalize(offer.category);
+  const minBudget = minimumBudgetFor(offer, rules);
+
+  if (leadCategory && offerCategory !== leadCategory) return null;
+
+  if (
+    rules.city &&
+    rules.city.length > 0 &&
+    (!leadCity || !rules.city.map(normalize).includes(leadCity))
+  ) {
+    return null;
+  }
+
+  if (minBudget && (!lead.budget || lead.budget < minBudget)) {
+    return null;
+  }
+
+  if (rules.max_budget && lead.budget && lead.budget > rules.max_budget) {
+    return null;
+  }
+
+  let score = 0;
+  const reasons: string[] = [];
+
+  if (leadCategory) {
+    score += 30;
+    reasons.push('Category match');
+  }
+
+  if (leadInterest) {
+    const searchable = [
+      offer.name,
+      offer.category,
+      offer.provider,
+      ...offer.benefits,
+    ]
+      .map(normalize)
+      .join(' ');
+
+    if (!containsInterest(searchable, leadInterest)) return null;
+
+    score += 30;
+    reasons.push('Interest match');
+  }
+
+  if (leadCity && rules.city?.map(normalize).includes(leadCity)) {
+    score += 20;
+    reasons.push(`Available in ${lead.city}`);
+  }
+
+  if (minBudget && lead.budget) {
+    score += 10;
+    reasons.push('Budget eligible');
+  }
+
+  score += Math.min(20, Math.round(offer.commission_value / 100));
+
+  return score > 0 ? { offer, score, reasons } : null;
+}
+
+function minimumBudgetFor(offer: Offer, rules: OfferRules): number | undefined {
+  const annualFee = offer.metadata.annual_fee;
+  if (
+    normalize(offer.category) === 'credit_card' &&
+    typeof annualFee === 'number'
+  ) {
+    return annualFee;
+  }
+
+  return rules.min_budget;
+}
+
+function containsInterest(searchable: string, interest: string): boolean {
+  const tokens = interest.split(/\s+/).filter((token) => token.length > 2);
+  return tokens.some((token) => searchable.includes(token));
+}
+
+function normalizeRules(value: Record<string, unknown>): OfferRules {
+  return {
+    min_budget:
+      typeof value.min_budget === 'number' ? value.min_budget : undefined,
+    max_budget:
+      typeof value.max_budget === 'number' ? value.max_budget : undefined,
+    city: Array.isArray(value.city)
+      ? value.city.filter((row): row is string => typeof row === 'string')
+      : undefined,
+  };
+}
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,7 +37,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Protected pages - redirect to login if not authenticated
-  const protectedPaths = ['/dashboard', '/inbox', '/contacts', '/pipelines', '/broadcasts', '/automations', '/settings']
+  const protectedPaths = ['/dashboard', '/inbox', '/contacts', '/pipelines', '/broadcasts', '/products', '/automations', '/settings']
   if (!user && protectedPaths.some(path => request.nextUrl.pathname.startsWith(path))) {
     const url = request.nextUrl.clone()
     url.pathname = '/login'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -288,6 +288,24 @@ export interface BroadcastRecipient {
   contact?: Contact;
 }
 
+export interface Offer {
+  id: string;
+  user_id: string;
+  name: string;
+  category: string;
+  provider: string;
+  price_amount: number;
+  fee_amount: number;
+  commission_value: number;
+  benefits: string[];
+  rules: Record<string, unknown>;
+  requirements: string[];
+  metadata: Record<string, unknown>;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 // ============================================================
 // Automations (migration 006)
 // ============================================================

--- a/supabase/migrations/20260530115239_offer_catalog.sql
+++ b/supabase/migrations/20260530115239_offer_catalog.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS public.offers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  provider TEXT NOT NULL DEFAULT '',
+  price_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  fee_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  commission_value NUMERIC(12,2) NOT NULL DEFAULT 0,
+  benefits TEXT[] NOT NULL DEFAULT '{}',
+  rules JSONB NOT NULL DEFAULT '{}'::jsonb,
+  requirements TEXT[] NOT NULL DEFAULT '{}',
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_offers_user_active
+  ON public.offers(user_id, is_active);
+
+CREATE INDEX IF NOT EXISTS idx_offers_category
+  ON public.offers(user_id, category);
+
+CREATE INDEX IF NOT EXISTS idx_offers_provider
+  ON public.offers(user_id, provider);
+
+ALTER TABLE public.offers ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.offers TO authenticated;
+
+DROP POLICY IF EXISTS "Users can manage own offers"
+  ON public.offers;
+
+CREATE POLICY "Users can manage own offers"
+  ON public.offers
+  FOR ALL
+  TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP TRIGGER IF EXISTS set_updated_at ON public.offers;
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.offers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- add a protected /products catalog page with create/list UI for offers
- add an offers table migration with authenticated grants and RLS scoped to each user
- add generic offer matching helper and tests for category, interest, city, budget, and metadata-based credit-card fees
- add Catalog to sidebar and page title mapping without changing existing navigation labels

## Why
This ports the catalog work from the CardReach branch onto current main without merging the larger CardReach changes. It keeps the current WhatsApp CRM modules intact while adding a reusable catalog for products, services, packages, eligibility rules, and commissions.

## Validation
- npm test -- src/lib/products/offers.test.ts
- npm test
- npm run typecheck
- npm run lint (0 errors, existing 20 warnings)
- npm run build
- browser check at http://localhost:3001/products showed Catalog nav/header, add-offer form, and existing offers rendering

## Notes
- supabase migration list --local could not run because local Postgres at 127.0.0.1:54322 is not running
- build still shows upstream's existing custom Cache-Control warning for /_next/static; separate PR #163 addresses that