### PR TITLE
fix(inbox): reply quote no longer overflows or single-lines (#165)

### DIFF
--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -530,10 +530,16 @@ export default function InboxPage() {
         {/* Center panel: Message thread.
             Hidden on mobile when no conversation is selected so the
             list can occupy the full width. Always visible on lg+
-            (shows its own empty-state if no thread is picked yet). */}
+            (shows its own empty-state if no thread is picked yet).
+
+            `min-w-0` is load-bearing: without it, a single wide piece
+            of content inside the thread (long quote preview, very
+            long URL in a message body) forces the flex child past
+            its share and pushes the contact-sidebar panel off-screen
+            on the right. Issue #165. */}
         <div
           className={cn(
-            "flex h-full flex-1 lg:flex",
+            "flex h-full min-w-0 flex-1 lg:flex",
             hasActiveConv ? "flex" : "hidden lg:flex",
           )}
         >

--- a/src/components/inbox/message-actions.tsx
+++ b/src/components/inbox/message-actions.tsx
@@ -85,7 +85,12 @@ export function MessageActions({
       onContextMenu={handleContextMenu}
       onBlur={() => setTouchOpen(false)}
     >
-      <div className="group/actions relative max-w-[75%]">
+      {/* `min-w-0` lets this flex child actually respect the 75% cap.
+       *  Default `min-width: auto` lets content (a long quote preview,
+       *  an unbroken URL) push past the cap and shove the row past
+       *  100%, which used to bleed across into the contact-sidebar
+       *  area. See issue #165. */}
+      <div className="group/actions relative min-w-0 max-w-[75%]">
         {children}
       <div
         data-touch-open={touchOpen || pickerOpen ? "true" : undefined}

--- a/src/components/inbox/reply-quote.tsx
+++ b/src/components/inbox/reply-quote.tsx
@@ -31,11 +31,20 @@ export function ReplyQuote({
           : "mb-1.5 rounded-md bg-black/20",
       )}
     >
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 overflow-hidden">
         <div className="truncate text-[11px] font-medium text-primary">
           {authorLabel}
         </div>
-        <div className="truncate text-xs text-slate-200/80">{preview}</div>
+        {/* Wrap the preview instead of truncating to a single line.
+         *  `truncate` (white-space: nowrap) forced the quote onto one
+         *  impossibly-wide line and — because the parent flex chain
+         *  lacked `min-w-0` at every step — pushed the entire inbox
+         *  layout wider, shoving the contact sidebar off-screen.
+         *  `break-words` also wraps long URLs that have no whitespace
+         *  to break on. Issue #165. */}
+        <div className="whitespace-pre-wrap break-words text-xs text-slate-200/80">
+          {preview}
+        </div>
       </div>
       {onDismiss && (
         <button


### PR DESCRIPTION
Closes #165.

## Summary

A long reply quote was forcing the entire 3-panel inbox layout wider, pushing the contact sidebar off-screen and making the page horizontally scrollable. Two root causes — both correctly diagnosed by @tekrexllp in the issue:

1. `ReplyQuote` applied `truncate` to the preview text. `truncate` is `white-space: nowrap` + `text-overflow: ellipsis`, so a long preview became one impossibly-wide line instead of wrapping.
2. The flex chain from `MessageBubble` outward (`MessageActions` → middle-panel wrapper → page) had no `min-w-0` on its flex children. Default `min-width: auto` lets a flex child grow to its content's natural width, so the wide quote propagated all the way up to the inbox-page flex container.

## Changes (3 files, +25/-5)

- **`src/components/inbox/reply-quote.tsx`** — preview swapped from `truncate` to `whitespace-pre-wrap break-words`. `break-words` also handles long URLs without spaces. Author label stays `truncate` (it's a single-line sender name). Added `overflow-hidden` on the inner text container as a belt-and-braces second line of defense.
- **`src/components/inbox/message-actions.tsx`** — `.group/actions` flex child gets `min-w-0` so the `max-w-[75%]` cap actually holds when content is wide.
- **`src/app/(dashboard)/inbox/page.tsx`** — middle-panel wrapper gets `min-w-0` so the message thread can shrink below its natural content width when the conversation list and contact sidebar are also flexing.

## Audit of the same pattern elsewhere

The reporter's question deserves an answer beyond just patching the reported spot. I grepped every `truncate` usage in `src/components` (40 hits) and traced the flex layouts:

| Location | Verdict |
| --- | --- |
| `reply-quote.tsx` preview | **Bug** — fixed in this PR |
| `reply-quote.tsx` author label | Correct — single-line sender name |
| `conversation-list.tsx` last-message preview | Correct — single-line in a list |
| `message-bubble.tsx` document filename | Correct — single-line filename |
| `message-thread.tsx` header name/phone | Correct |
| `layout/header.tsx`, `layout/sidebar.tsx` | Correct — labels and nav |
| `pipeline-board.tsx`, `deal-card.tsx`, `contact-detail-view.tsx` | Correct |
| `template-picker.tsx`, `automation-builder.tsx`, `flow-builder.tsx`, `flow-canvas.tsx`, `dashboard/*` | Correct — node summaries / list previews |

`MessageContent` already uses `whitespace-pre-wrap break-words` for actual message bodies — that's the right pattern. The bug was specifically that `ReplyQuote` deviated from it.

**Conclusion: ReplyQuote was the only multi-line `truncate` misuse.** The `min-w-0` additions on the chain are defensive against the same shape of bug landing elsewhere — once the chain can shrink, any single piece of wide content has nowhere to push.

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings (9 pre-existing in unrelated files)
- [x] `npm test` — 319 passing
- [x] `npm run build` — production build succeeds

## Test plan
- [ ] `/inbox`, open a conversation, hit Reply on a long (3+ line) message → quote preview wraps cleanly; contact sidebar stays on screen
- [ ] Reply to a message containing a very long URL with no whitespace → URL breaks at the container width
- [ ] An incoming message that itself contains a reply quote → embedded variant in the bubble also wraps; bubble respects its 75% width cap
- [ ] Page is no longer horizontally scrollable in any of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)