### PR TITLE
feat(ui): user-facing fixes from multi-user review (M3, M4, S3)

### DIFF
--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -26,7 +26,14 @@ import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { toast } from 'sonner';
-import { CheckCircle, Loader2, MailX, ShieldCheck, UsersRound } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle,
+  Loader2,
+  MailX,
+  ShieldCheck,
+  UsersRound,
+} from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -36,6 +43,14 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { createClient } from '@/lib/supabase/client';
 
 interface PeekOk {
@@ -87,6 +102,12 @@ export default function JoinPage() {
     undefined, // undefined = unknown / still loading; null = signed out
   );
   const [accepting, setAccepting] = useState(false);
+  // `redeem_invitation` returns 409 when the caller's current account
+  // has domain data, or they're already a member of a shared account.
+  // A transient toast wasn't enough — the user has no actionable next
+  // step. Surface a blocking modal that walks them through it.
+  const [conflictMessage, setConflictMessage] = useState<string | null>(null);
+  const [signingOut, setSigningOut] = useState(false);
 
   // Fetch peek + auth state on mount. The peek endpoint is
   // rate-limited per-IP (30/min) so double-mounting in React 19
@@ -130,7 +151,19 @@ export default function JoinPage() {
         const payload = (await res.json().catch(() => ({}))) as {
           error?: string;
         };
-        toast.error(payload.error || 'Failed to accept invitation');
+        // 409 = caller already has data / is in another shared
+        // account. The redeem RPC's error message is descriptive
+        // enough to show directly; we open a modal so the user has
+        // a clear next-action (sign out → use different email)
+        // rather than a 3-second toast.
+        if (res.status === 409) {
+          setConflictMessage(
+            payload.error ||
+              'You are already in another account. Sign in with a different email to join this one.',
+          );
+        } else {
+          toast.error(payload.error || 'Failed to accept invitation');
+        }
         setAccepting(false);
         return;
       }
@@ -144,6 +177,21 @@ export default function JoinPage() {
       setAccepting(false);
     }
   }, [token]);
+
+  const handleSignOutAndRetry = useCallback(async () => {
+    setSigningOut(true);
+    try {
+      await createClient().auth.signOut();
+      // Hard reload so the new auth state propagates everywhere
+      // (middleware, AuthProvider). Preserves the invite token in
+      // the URL so the rebuilt page renders the signed-out CTA path.
+      window.location.reload();
+    } catch (err) {
+      console.error('[join] sign-out error:', err);
+      toast.error('Could not sign out. Try refreshing the page.');
+      setSigningOut(false);
+    }
+  }, []);
 
   // ----- Loading state (peek pending OR auth not yet resolved) -----
   if (peek === null || authedUserId === undefined) {
@@ -220,33 +268,90 @@ export default function JoinPage() {
   // ----- Authed: show Accept button -----
   if (authedUserId) {
     return (
-      <Card className="w-full max-w-md border-slate-800 bg-slate-900">
-        {inviteHeader}
-        <CardContent className="flex flex-col gap-3">
-          <Button
-            onClick={handleAccept}
-            disabled={accepting}
-            className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
-          >
-            {accepting ? (
-              <>
-                <Loader2 className="size-4 animate-spin" />
-                Accepting…
-              </>
-            ) : (
-              <>
-                <CheckCircle className="size-4" />
-                Accept invitation
-              </>
-            )}
-          </Button>
-          <p className="text-center text-xs text-slate-500">
-            Accepting moves your login into{' '}
-            <span className="text-slate-400">{peek.account_name}</span>. Your
-            empty personal account from signup will be cleaned up.
-          </p>
-        </CardContent>
-      </Card>
+      <>
+        <Card className="w-full max-w-md border-slate-800 bg-slate-900">
+          {inviteHeader}
+          <CardContent className="flex flex-col gap-3">
+            <Button
+              onClick={handleAccept}
+              disabled={accepting}
+              className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              {accepting ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Accepting…
+                </>
+              ) : (
+                <>
+                  <CheckCircle className="size-4" />
+                  Accept invitation
+                </>
+              )}
+            </Button>
+            <p className="text-center text-xs text-slate-500">
+              Accepting moves your login into{' '}
+              <span className="text-slate-400">{peek.account_name}</span>. Your
+              empty personal account from signup will be cleaned up.
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Conflict modal — opens when the redeem endpoint returns 409
+            (caller already in a shared account or has domain data).
+            Blocks the flow until the user picks a recovery action so
+            they aren't stuck retrying an inevitable failure. */}
+        <Dialog
+          open={conflictMessage !== null}
+          onOpenChange={(open) => {
+            if (!open) setConflictMessage(null);
+          }}
+        >
+          <DialogContent className="bg-slate-900 border-slate-700 sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2 text-white">
+                <AlertTriangle className="size-4 text-amber-400" />
+                Can&apos;t join {peek.account_name} with this account
+              </DialogTitle>
+              <DialogDescription className="text-slate-400">
+                {conflictMessage}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2 py-2 text-xs text-slate-500">
+              <p>
+                To join{' '}
+                <span className="text-slate-300">{peek.account_name}</span>,
+                sign out and sign up again with a different email address.
+                The invite link stays valid as long as it hasn&apos;t
+                expired.
+              </p>
+            </div>
+            <DialogFooter className="bg-slate-900 border-slate-700">
+              <Button
+                variant="outline"
+                onClick={() => setConflictMessage(null)}
+                className="border-slate-700 text-slate-300 hover:bg-slate-800"
+              >
+                Stay signed in
+              </Button>
+              <Button
+                onClick={handleSignOutAndRetry}
+                disabled={signingOut}
+                className="bg-primary text-primary-foreground hover:bg-primary/90"
+              >
+                {signingOut ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Signing out…
+                  </>
+                ) : (
+                  'Sign out & use a different email'
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
 

--- a/src/components/settings/invite-member-dialog.tsx
+++ b/src/components/settings/invite-member-dialog.tsx
@@ -36,6 +36,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { useAuth } from '@/hooks/use-auth';
 
 type InviteRole = 'admin' | 'agent' | 'viewer';
 
@@ -65,6 +66,9 @@ interface CreatedInvite {
   url: string;
   role: InviteRole;
   expiresInDays: number;
+  /** Snapshotted at creation time so a later account rename can't
+   *  retroactively change the wa.me message text on the result step. */
+  accountName: string;
 }
 
 export function InviteMemberDialog({
@@ -72,6 +76,7 @@ export function InviteMemberDialog({
   onOpenChange,
   onCreated,
 }: InviteMemberDialogProps) {
+  const { account } = useAuth();
   const [role, setRole] = useState<InviteRole>('agent');
   const [expiry, setExpiry] = useState<string>('7');
   const [label, setLabel] = useState('');
@@ -110,7 +115,17 @@ export function InviteMemberDialog({
         expiresInDays: number;
       };
 
-      setResult({ url: data.url, role, expiresInDays: data.expiresInDays });
+      setResult({
+        url: data.url,
+        role,
+        expiresInDays: data.expiresInDays,
+        // Snapshot the account name into the result so the wa.me
+        // share message has team context. Falls back to a generic
+        // string if `account` hasn't loaded yet (shouldn't happen
+        // — the dialog requires admin+ which requires a loaded
+        // profile — but stay safe).
+        accountName: account?.name ?? 'our wacrm account',
+      });
       onCreated();
     } catch (err) {
       console.error('[InviteMemberDialog] create error:', err);
@@ -134,7 +149,12 @@ export function InviteMemberDialog({
   }
 
   function whatsappShareUrl(url: string): string {
-    const message = `Join our wacrm account using this link (valid for ${result?.expiresInDays} days): ${url}`;
+    // Include the account name so the recipient knows which team
+    // they're being invited to before clicking through. This matters
+    // for users in multi-team contexts where "our wacrm account"
+    // wouldn't be enough to disambiguate.
+    const accountName = result?.accountName ?? 'our wacrm account';
+    const message = `Join ${accountName} on wacrm using this link (valid for ${result?.expiresInDays} days): ${url}`;
     return `https://wa.me/?text=${encodeURIComponent(message)}`;
   }
 

--- a/src/components/settings/members-tab.tsx
+++ b/src/components/settings/members-tab.tsx
@@ -287,92 +287,107 @@ export function MembersTab() {
               return (
                 <li
                   key={member.user_id}
-                  className="flex items-center gap-4 px-4 py-3"
+                  // Mobile: stack identity (avatar+name+email) above the
+                  // role/remove actions so the role dropdown's fixed
+                  // 128px width doesn't force the name into a 50-pixel
+                  // truncation. Desktop (sm+): everything inline as
+                  // before.
+                  className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4"
                 >
-                  <Avatar className="size-9 shrink-0">
-                    {member.avatar_url ? (
-                      <AvatarImage
-                        src={member.avatar_url}
-                        alt={member.full_name || 'Member'}
-                      />
-                    ) : null}
-                    <AvatarFallback className="bg-primary/10 text-sm font-medium text-primary">
-                      {(member.full_name || member.email || 'U')
-                        .charAt(0)
-                        .toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
+                  <div className="flex min-w-0 flex-1 items-center gap-4">
+                    <Avatar className="size-9 shrink-0">
+                      {member.avatar_url ? (
+                        <AvatarImage
+                          src={member.avatar_url}
+                          alt={member.full_name || 'Member'}
+                        />
+                      ) : null}
+                      <AvatarFallback className="bg-primary/10 text-sm font-medium text-primary">
+                        {(member.full_name || member.email || 'U')
+                          .charAt(0)
+                          .toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
 
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate text-sm font-medium text-white">
-                        {member.full_name || 'Unnamed'}
-                      </span>
-                      {isSelf && (
-                        <Badge className="bg-slate-800 text-slate-300 border-slate-700 text-[10px] uppercase tracking-wide">
-                          You
-                        </Badge>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate text-sm font-medium text-white">
+                          {member.full_name || 'Unnamed'}
+                        </span>
+                        {isSelf && (
+                          <Badge className="bg-slate-800 text-slate-300 border-slate-700 text-[10px] uppercase tracking-wide">
+                            You
+                          </Badge>
+                        )}
+                      </div>
+                      {member.email && (
+                        <p className="truncate text-xs text-slate-500">
+                          {member.email}
+                        </p>
                       )}
                     </div>
-                    {member.email && (
-                      <p className="truncate text-xs text-slate-500">
-                        {member.email}
-                      </p>
-                    )}
                   </div>
 
+                  {/* Joined date stays desktop-only. The mobile row's
+                      vertical density makes the joined date noise. */}
                   <div className="hidden sm:block text-right text-xs text-slate-500">
                     Joined {fmtDate(member.joined_at)}
                   </div>
 
-                  {/* Role display / editor. Inline Select is admin+
-                      only AND not allowed on the owner row (owner
-                      changes go through transfer, which lands later). */}
-                  {canManageMembers && !isOwnerRow && !isSelf ? (
-                    <Select
-                      value={member.role}
-                      onValueChange={(v) =>
-                        // Base UI Select can emit null on clear. We
-                        // don't expose a clear affordance, so the
-                        // guard is defensive — but the typed
-                        // signature requires it.
-                        v && handleRoleChange(member, v as AccountRole)
-                      }
-                    >
-                      <SelectTrigger
-                        className="w-32 bg-slate-800 border-slate-700 text-slate-200"
-                        disabled={isBusy}
+                  {/* Actions cluster. On mobile this is its own row
+                      below the identity block; on desktop it sits
+                      inline. Items align to the start on mobile so the
+                      role dropdown lines up under the avatar. */}
+                  <div className="flex items-center gap-2 sm:gap-3">
+                    {/* Role display / editor. Inline Select is admin+
+                        only AND not allowed on the owner row (owner
+                        changes go through transfer, which lands later). */}
+                    {canManageMembers && !isOwnerRow && !isSelf ? (
+                      <Select
+                        value={member.role}
+                        onValueChange={(v) =>
+                          // Base UI Select can emit null on clear. We
+                          // don't expose a clear affordance, so the
+                          // guard is defensive — but the typed
+                          // signature requires it.
+                          v && handleRoleChange(member, v as AccountRole)
+                        }
                       >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {EDITABLE_ROLES.map((r) => (
-                          <SelectItem key={r.value} value={r.value}>
-                            {r.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  ) : (
-                    <span className="inline-flex items-center gap-1.5 rounded-md border border-slate-700 bg-slate-800 px-2.5 py-1 text-xs font-medium text-slate-200">
-                      <RoleIcon className="size-3.5 text-slate-400" />
-                      {ROLE_LABELS[member.role]}
-                    </span>
-                  )}
+                        <SelectTrigger
+                          className="w-32 bg-slate-800 border-slate-700 text-slate-200"
+                          disabled={isBusy}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {EDITABLE_ROLES.map((r) => (
+                            <SelectItem key={r.value} value={r.value}>
+                              {r.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <span className="inline-flex items-center gap-1.5 rounded-md border border-slate-700 bg-slate-800 px-2.5 py-1 text-xs font-medium text-slate-200">
+                        <RoleIcon className="size-3.5 text-slate-400" />
+                        {ROLE_LABELS[member.role]}
+                      </span>
+                    )}
 
-                  {/* Remove. Admin+ only; never on the owner row;
-                      never on yourself. */}
-                  {canManageMembers && !isOwnerRow && !isSelf && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setRemovingMember(member)}
-                      disabled={isBusy}
-                      className="border-slate-700 text-slate-300 hover:bg-red-500/10 hover:border-red-500/40 hover:text-red-300"
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
-                  )}
+                    {/* Remove. Admin+ only; never on the owner row;
+                        never on yourself. */}
+                    {canManageMembers && !isOwnerRow && !isSelf && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setRemovingMember(member)}
+                        disabled={isBusy}
+                        className="border-slate-700 text-slate-300 hover:bg-red-500/10 hover:border-red-500/40 hover:text-red-300"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    )}
+                  </div>
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary

**PR B** of the post-review fix series. Closes the three user-blocking UI gaps the design / UX review flagged. Each fix is self-contained — no migration, no API changes.

| Review ID | Fix |
| --- | --- |
| **M3** (CRITICAL, UX) | Charlie's 409 redeem dead-end → blocking recovery modal with "Sign out & use a different email" action |
| **M4** (CRITICAL, UX) | WhatsApp share message now includes the account name |
| **S3** (MAJOR, mobile) | Members tab roster reflows below `sm:` so the fixed-width role Select doesn't crush the name column |

## M3 — Charlie's 409 modal

**Before:** existing-user-with-data clicks invite → "Accept" → server returns 409 → 3-second toast → button re-enables → user retries → 409 again → infinite loop with no actionable next step.

**After:** 409 is detected explicitly and surfaces a blocking dialog:

```
⚠️ Can't join Acme with this account
You are already in another shared account; sign up with a
different email to join this one.

To join Acme, sign out and sign up again with a different
email address. The invite link stays valid as long as it
hasn't expired.

[Stay signed in]   [Sign out & use a different email]
```

The "Sign out & retry" button calls `supabase.signOut()` then `window.location.reload()`. The invite token stays in the URL through the reload so the rebuilt page renders the signed-out CTA path — recovery is one click.

Non-409 errors keep the existing toast path; only the conflict case gets the modal.

## M4 — WhatsApp share copy

**Before:** `"Join our wacrm account using this link (valid for X days): <url>"`. No team context.

**After:** `"Join <Account Name> on wacrm using this link (valid for X days): <url>"`.

Implementation note: the account name is **snapshotted into the `CreatedInvite` result at creation time** rather than read fresh on each share-click. If an admin renames the account after creating the invite, the wa.me message keeps the name that was current at invite-creation. Aligns with the existing pattern of snapshotting `role` and `expiresInDays` into the result.

## S3 — Members tab mobile reflow

**Before** (mobile, 375px viewport):
```
[👤] John Doe (truncated em…  [🛡️ Agent v] [🗑️]
     j.doe@example.c…
```
The fixed-width 128px Select + 36px Remove button left ~50px for the name + email.

**After:**
```
[👤] John Doe Long Name
     j.doe@example.com

     [🛡️ Agent      v] [🗑️]
```
At base width the row stacks vertically — identity block on top, actions cluster (role + Remove) below. At `sm:` and up the original inline layout returns. The joined-date column stays desktop-only.

Two-row layout uses `flex-col gap-3 sm:flex-row sm:items-center sm:gap-4`. Actions are wrapped in their own flex container so the role Select + Remove cluster together on both breakpoints.

## Test plan

- [x] `npm run lint` — 0 errors (same 19 pre-existing warnings)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 366/366 pass
- [x] `npm run build` — succeeds
- [ ] Manual against staging:
  - As an existing wacrm user with contacts/conversations, click an invite link. "Accept invitation" → modal appears with explanation. Click "Sign out & use a different email" → signs out, page reloads, "Create account & join" CTA visible.
  - As an admin, generate an invite. Click "Send via WhatsApp" on the result step. wa.me opens with the message `"Join <YourAccountName> on wacrm using this link..."`.
  - On a 375px-wide viewport: open Settings → Members. Member rows stack vertically (identity above, role + Remove below). Resize to ≥640px → rows return to inline layout.

## Up next (in this fix series)

- **PR C**: front-end correctness — exhaustive `useCan`, `<GatedButton>` helper that fixes the disabled-tooltip portability issue, optimistic-update revert, sidebar flag alignment, Referrer-Policy on `/join`.
- **PR D**: visual polish — owner crown, destructive-button defaults, role-chip colors, amber-callout contrast, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)