### PR TITLE
fix(invite): derive invite-URL origin from the request, not wacrm.tech

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -28,8 +28,12 @@ META_APP_SECRET=your-meta-app-secret
 # ============================================================
 
 # Canonical public URL of this deployment (scheme + host, no trailing
-# slash). Used for the sitemap, OG images, and any email the app
-# sends. Defaults to https://wacrm.tech if unset.
+# slash). Used for the sitemap and OG images. Routes that need a
+# self-referential URL (invite links from /api/account/invitations,
+# any future email-bound link) derive the origin from the request
+# itself, so this variable is *only* needed when the request-derived
+# origin would be wrong — e.g. when generating links from a cron job
+# or a background worker that has no incoming request.
 NEXT_PUBLIC_SITE_URL=https://crm.example.com
 
 # ============================================================

--- a/src/app/api/account/invitations/route.ts
+++ b/src/app/api/account/invitations/route.ts
@@ -28,11 +28,57 @@ import {
 } from "@/lib/auth/invitations";
 import { isAccountRole } from "@/lib/auth/roles";
 
-// Resolve the base URL we publish invite links under. Mirrors the
-// .env.local.example default so dev / preview / forks all behave
-// without explicit config.
-function getBaseUrl(): string {
-  return process.env.NEXT_PUBLIC_SITE_URL || "https://wacrm.tech";
+// Resolve the base URL we publish invite links under.
+//
+// Resolution order, first match wins:
+//
+//   1. `NEXT_PUBLIC_SITE_URL` — admin's explicit config. Trumps
+//      everything; if you set this, that's where links point.
+//   2. `X-Forwarded-Host` (+ `X-Forwarded-Proto`) — set by every
+//      reverse proxy in front of the app: Hostinger Managed
+//      Node.js, Vercel, Cloudflare, nginx. This is what makes
+//      invite links Just Work in production without forcing the
+//      operator to set an env var.
+//   3. `Host` header + the protocol the request arrived on —
+//      bare deployments without a proxy.
+//   4. Last-resort marketing-site fallback. Only hit if the
+//      request has no Host header at all, which is essentially
+//      impossible from a real browser. Logs a warning so the
+//      operator can spot the misconfig.
+//
+// Previous implementation hard-defaulted to `https://wacrm.tech`
+// (the docs/marketing site, a different repo). Forks that didn't
+// set `NEXT_PUBLIC_SITE_URL` got invite links pointing at the
+// marketing site, which 404s on `/join/<token>`. This resolution
+// chain removes the foot-gun.
+function getBaseUrl(request: Request): string {
+  const explicit = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (explicit) return explicit.replace(/\/+$/, "");
+
+  const forwardedHost = request.headers
+    .get("x-forwarded-host")
+    ?.split(",")[0]
+    ?.trim();
+  const forwardedProto = request.headers
+    .get("x-forwarded-proto")
+    ?.split(",")[0]
+    ?.trim();
+  if (forwardedHost) {
+    return `${forwardedProto || "https"}://${forwardedHost}`;
+  }
+
+  const host = request.headers.get("host")?.trim();
+  if (host) {
+    // The protocol on `request.url` is whatever the framework saw —
+    // reliable for bare deployments where no proxy is rewriting it.
+    const reqProto = new URL(request.url).protocol.replace(":", "");
+    return `${reqProto}://${host}`;
+  }
+
+  console.warn(
+    "[POST /api/account/invitations] could not derive base URL from request; falling back to marketing domain",
+  );
+  return "https://wacrm.tech";
 }
 
 const MAX_LABEL_LEN = 80;
@@ -133,7 +179,7 @@ export async function POST(request: Request) {
         invitation: data,
         // Plaintext payload — visible to the admin exactly once.
         token,
-        url: inviteUrl(token, getBaseUrl()),
+        url: inviteUrl(token, getBaseUrl(request)),
         expiresInDays: expiryDays,
       },
       { status: 201 },


### PR DESCRIPTION
## Summary

Invite links generated by `POST /api/account/invitations` were defaulting to `https://wacrm.tech/join/<token>` when `NEXT_PUBLIC_SITE_URL` wasn't set. `wacrm.tech` is the **docs/marketing site** (separate `ArnasDon/wacrm-site` repo) — it has no `/join/[token]` route, so clicks 404'd. Reported while live-testing the invite flow on the production deployment.

## Repro

Without the fix:

1. Don't set `NEXT_PUBLIC_SITE_URL` on the app's Hostinger deployment.
2. As an admin, generate an invite from Settings → Members → Invite.
3. Result URL is `https://wacrm.tech/join/<token>`.
4. Click → 404 from the marketing site.

## Fix

`getBaseUrl()` now takes the incoming `Request` and resolves the origin in this priority:

| # | Source | When it wins |
|---|---|---|
| 1 | `NEXT_PUBLIC_SITE_URL` env | Explicit operator config — unchanged behavior |
| 2 | `X-Forwarded-Host` + `X-Forwarded-Proto` | Behind any reverse proxy (Hostinger / Vercel / Cloudflare). **This is what unblocks the bug.** |
| 3 | `Host` header + request protocol | Bare deployments with no proxy |
| 4 | `https://wacrm.tech` + `console.warn` | Last resort. Unreachable from a real browser; only fires if the request has no Host header at all |

The previous default (#4) was the silent landmine. The new chain means a freshly-forked install with no env-var tweaks generates invite links pointing back into its own app domain — no manual configuration required.

Also updated `.env.local.example` so the variable's purpose matches the new behavior:

```diff
-# Canonical public URL of this deployment ... Used for the sitemap,
-# OG images, and any email the app sends. Defaults to
-# https://wacrm.tech if unset.
+# Canonical public URL of this deployment ... Used for the sitemap
+# and OG images. Routes that need a self-referential URL (invite
+# links from /api/account/invitations, any future email-bound link)
+# derive the origin from the request itself, so this variable is
+# *only* needed when the request-derived origin would be wrong —
+# e.g. when generating links from a cron job or a background
+# worker that has no incoming request.
```

## Test plan

- [x] `npm run lint` — 0 errors (same 19 pre-existing warnings)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 366/366 pass
- [x] `npm run build` — succeeds
- [ ] Manual against the affected deployment:
  - Generate an invite. The result URL's origin matches the app's deployed origin (not `wacrm.tech`).
  - Open the URL in incognito → `/join/<token>` page renders.
  - With `NEXT_PUBLIC_SITE_URL` explicitly set, the env value still wins.

## No migration / no breaking change

Pure server-side resolution change. No DB, no API shape change, no client code touched. Existing pending invitations created before this fix still 404 (they were stamped with the bad URL); admins should revoke and re-issue them after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)