### PR TITLE
docs(readme): expand Hostinger deploy promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 > sales pipelines, broadcasts, and no-code automations. Fork it, brand
 > it, host it.
 
-[![Deploy on Hostinger](https://img.shields.io/badge/Deploy_on-Hostinger-673DE6?style=for-the-badge&logo=hostinger&logoColor=white)](https://www.hostinger.com/web-apps-hosting)
+<p align="center">
+  <a href="https://www.hostinger.com/web-apps-hosting">
+    <img src="https://img.shields.io/badge/Deploy_on-Hostinger-673DE6?style=for-the-badge&logo=hostinger&logoColor=white" alt="Deploy on Hostinger" height="60">
+  </a>
+</p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](./LICENSE)
 [![CI](https://github.com/ArnasDon/wacrm/actions/workflows/ci.yml/badge.svg)](https://github.com/ArnasDon/wacrm/actions/workflows/ci.yml)
@@ -43,8 +47,10 @@ This is a **template**, not a product. Forking means you get:
   modules you don't, redesign anything. The stack is boring on
   purpose (Next.js + Supabase + Tailwind) so the learning curve is
   short.
-- **Zero ops to start** — Hostinger Managed Node.js deploys a fork in
-  a few clicks. No Docker, no Kubernetes, no infra team needed.
+- **Zero ops to start** — [Hostinger](https://www.hostinger.com/web-apps-hosting)
+  Managed Node.js deploys a fork in a few clicks. No Docker, no
+  Kubernetes, no infra team needed.
+  ([See below ↓](#-deploy-on-hostinger-recommended))
 - **Real security primitives** — token encryption (AES-256-GCM), RLS
   on every table, HMAC-verified webhooks, CSP, rate limiting, CI
   typecheck/build on every PR.
@@ -65,6 +71,51 @@ npm run dev
 
 Open <http://localhost:3000>. You'll be redirected to `/login` (or
 `/dashboard` if already signed in).
+
+## 🚀 Deploy on Hostinger (recommended)
+
+<p align="center">
+  <a href="https://www.hostinger.com/web-apps-hosting">
+    <img src="https://img.shields.io/badge/Deploy_your_fork_on-Hostinger-673DE6?style=for-the-badge&logo=hostinger&logoColor=white" alt="Deploy on Hostinger" height="64">
+  </a>
+  &nbsp;
+  <a href="https://wacrm.tech/docs/deployment-hostinger">
+    <img src="https://img.shields.io/badge/Step--by--step_guide-wacrm.tech%2Fdocs-111?style=for-the-badge" alt="Step-by-step guide" height="64">
+  </a>
+</p>
+
+**wacrm is built to run on [Hostinger](https://www.hostinger.com/web-apps-hosting).**
+It's the path we test, document, and recommend — and the fastest way
+to get a production-grade CRM live without owning a VPS or a
+Kubernetes cluster.
+
+### Why Hostinger?
+
+| | |
+|---|---|
+| **One-click Git deploy** | Connect your fork, push to `main`, Hostinger builds and ships it. No SSH, no Docker, no CI to wire up — this repo's own `main` deploys this way. |
+| **Managed Node.js** | Next.js 16 (App Router, server actions, ISR) runs out of the box on [Premium, Business, and Cloud](https://www.hostinger.com/web-apps-hosting) shared plans. You don't manage Node versions, processes, or reverse proxies. |
+| **Free SSL + free domain** | Automatic Let's Encrypt on your custom domain (or a free one included with annual plans). HTTPS is on by default — required for the WhatsApp Business webhook. |
+| **Global CDN + LiteSpeed** | Static assets cached at the edge, dynamic routes served from LiteSpeed. Snappy dashboards out of the box, no Cloudflare setup required. |
+| **Env vars + logs in hPanel** | Set `SUPABASE_*`, `WHATSAPP_*`, and `ENCRYPTION_KEY` from the panel — no `.env` on the server. Live application logs in the same UI. |
+| **DDoS protection + daily backups** | Built-in, no add-ons. The webhook endpoint is a public target — having protection at the edge matters. |
+| **Cheaper than a VPS** | Plans start at a few dollars a month — order-of-magnitude less than a comparable managed Node.js host, and you don't pay extra for the database (that's Supabase). |
+| **24/7 human support** | Live chat support in 20+ languages — useful when your CRM is the thing your team relies on to talk to customers. |
+
+### The 60-second version
+
+1. **Fork** this repo on GitHub.
+2. In **hPanel → Websites → Create**, pick **Node.js** and connect
+   your fork.
+3. Paste your Supabase + Meta env vars into hPanel.
+4. Push to `main`. Hostinger builds and serves it. Done.
+
+Full walkthrough with screenshots:
+**[wacrm.tech/docs/deployment-hostinger](https://wacrm.tech/docs/deployment-hostinger)**.
+
+> _Note: wacrm is MIT-licensed and runs anywhere Node.js does
+> (Vercel, Railway, your own VPS). Hostinger is recommended, not
+> required._
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Promote Hostinger as the recommended deploy target with a bigger, centered CTA badge above the fold (HTML-scaled SVG, ~60px tall).
- Add a dedicated **🚀 Deploy on Hostinger (recommended)** section right after Quick start: pitch line, "Why Hostinger?" table (Git auto-deploy, Managed Node.js, free SSL/domain, CDN/LiteSpeed, env vars in hPanel, DDoS + backups, pricing, 24/7 support) and a 60-second deploy walkthrough.
- Link the existing "Zero ops to start" bullet in "Why fork this?" down to the new section.
- Keep an honest MIT/runs-anywhere disclaimer so it doesn't feel coercive.

## Test plan
- [ ] Open the rendered README on GitHub and confirm the top Hostinger badge is noticeably larger and centered.
- [ ] Click the top badge → lands on https://www.hostinger.com/web-apps-hosting.
- [ ] Confirm the new section renders with the table + 60-second steps, both buttons centered.
- [ ] Click the "See below ↓" link from the "Why fork this?" bullet and confirm the anchor jumps to the new section.
- [ ] Click "Step-by-step guide" → lands on https://wacrm.tech/docs/deployment-hostinger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)