### PR TITLE
fix(theme): suppress hydration warning on root html data-theme (#207)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -70,6 +70,13 @@ export default function RootLayout({
       lang="en"
       data-theme={DEFAULT_THEME}
       className={`${inter.variable} h-full antialiased`}
+      // The `theme-boot` script below rewrites `data-theme` on <html>
+      // from localStorage before React hydrates, so for any non-default
+      // theme the client DOM intentionally differs from the server-
+      // rendered `DEFAULT_THEME`. suppressHydrationWarning silences the
+      // expected mismatch — it only applies to this element's own
+      // attributes, so genuine mismatches in children still surface.
+      suppressHydrationWarning
     >
       <head>
         <Script


### PR DESCRIPTION
## Summary

Fixes #207. The `theme-boot` `beforeInteractive` script in `src/app/layout.tsx` rewrites `data-theme` on `<html>` from `localStorage` **before React hydrates**. The server always renders `data-theme={DEFAULT_THEME}` (`"violet"`), so whenever the saved theme differs, React logs a hydration mismatch on `<html>`:

```
<html lang="en"
+ data-theme="violet"   (server)
- data-theme="cobalt"   (client)
>
```

The colors were already correct — only the console error was the problem.

## Fix

Add `suppressHydrationWarning` to the root `<html>`. This is the conventional fix for an intentional pre-hydration root mutation:
- It's scoped to **this element's own attributes** — genuine mismatches in children still surface.
- It preserves the documented **localStorage-only / device-scoped** theme design. A cookie-based SSR alternative would work too but would change that documented behavior, so it was not chosen.
- Confirmed still supported (non-deprecated) in this repo's bundled Next 16.2.6 docs.

## Verification (in-browser, Next 16.2.6 / Turbopack)
Drove a real browser against the dev server with `localStorage['wacrm.theme'] = 'cobalt'`:

| State | Result |
|-------|--------|
| **With fix** | `data-theme="cobalt"` applied, **0 console errors/warnings** |
| **Without fix** (negative control) | exact issue error reproduced: `+ data-theme="violet" / - data-theme="cobalt"` on `<html>` |
| **Fix restored** | clean again |

`npm run typecheck` ✅ · `npm run lint` → 0 errors ✅ · `npm test` → 370 passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)