### PR TITLE
fix(account-sharing): stamp account_id on flow & pipeline inserts (#210)

### DIFF
--- a/src/app/(dashboard)/pipelines/page.tsx
+++ b/src/app/(dashboard)/pipelines/page.tsx
@@ -27,6 +27,7 @@ import { Label } from "@/components/ui/label";
 import { GitBranch, Plus, ChevronDown, Settings } from "lucide-react";
 import { toast } from "sonner";
 import { useCan } from "@/hooks/use-can";
+import { useAuth } from "@/hooks/use-auth";
 import { GatedButton } from "@/components/ui/gated-button";
 
 // Pipeline creation is admin-class (settings-tier write under
@@ -47,6 +48,7 @@ export default function PipelinesPage() {
   const supabase = createClient();
   const canEditSettings = useCan("edit-settings");
   const canCreateDeals = useCan("send-messages");
+  const { accountId } = useAuth();
 
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
   const [selectedPipelineId, setSelectedPipelineId] = useState<string>("");
@@ -111,10 +113,12 @@ export default function PipelinesPage() {
     } = await supabase.auth.getSession();
     const user = session?.user;
     if (!user) return null;
+    // pipelines.account_id is NOT NULL post-017 with no DB default.
+    if (!accountId) return null;
 
     const { data: pipeline, error } = await supabase
       .from("pipelines")
-      .insert({ user_id: user.id, name: "Sales Pipeline" })
+      .insert({ user_id: user.id, account_id: accountId, name: "Sales Pipeline" })
       .select()
       .single();
 
@@ -132,7 +136,7 @@ export default function PipelinesPage() {
     await supabase.from("pipeline_stages").insert(stagesPayload);
 
     return pipeline as Pipeline;
-  }, [supabase]);
+  }, [supabase, accountId]);
 
   // Initial load + seed-if-empty
   useEffect(() => {
@@ -254,10 +258,16 @@ export default function PipelinesPage() {
       setCreating(false);
       return;
     }
+    // pipelines.account_id is NOT NULL post-017 with no DB default.
+    if (!accountId) {
+      toast.error("Your profile is not linked to an account.");
+      setCreating(false);
+      return;
+    }
 
     const { data: pipeline, error } = await supabase
       .from("pipelines")
-      .insert({ user_id: user.id, name })
+      .insert({ user_id: user.id, account_id: accountId, name })
       .select()
       .single();
 

--- a/src/app/api/flows/route.ts
+++ b/src/app/api/flows/route.ts
@@ -49,7 +49,23 @@ export async function POST(request: Request) {
   if (!guard.ok) {
     return NextResponse.json(guard.body, { status: guard.status })
   }
-  const { userId } = guard
+  const { userId, supabase } = guard
+
+  // Resolve the caller's account_id — `flows.account_id` is NOT NULL
+  // post-017, so an INSERT without it trips the not-null constraint
+  // even though the admin client below bypasses RLS.
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('account_id')
+    .eq('user_id', userId)
+    .single()
+  const accountId = profile?.account_id as string | undefined
+  if (!accountId) {
+    return NextResponse.json(
+      { error: 'Your profile is not linked to an account.' },
+      { status: 403 },
+    )
+  }
 
   const body = (await request.json().catch(() => null)) as
     | {
@@ -85,6 +101,7 @@ export async function POST(request: Request) {
       .from('flows')
       .insert({
         user_id: userId,
+        account_id: accountId,
         name: body.name?.trim() || template.name,
         description: template.description,
         status: 'draft',
@@ -133,6 +150,7 @@ export async function POST(request: Request) {
     .from('flows')
     .insert({
       user_id: userId,
+      account_id: accountId,
       name: body.name.trim(),
       description: body.description ?? null,
       status: 'draft',


### PR DESCRIPTION
Fixes #210 and an identical bug found while auditing similar flows.

## Root cause

Migration `017_account_sharing.sql` set `account_id` **NOT NULL** (no DB default, no auto-fill trigger) on 15 tables. Any `.insert(...)` that omits `account_id` therefore fails with:

> `null value in column "account_id" of relation "<table>" violates not-null constraint`

This is the same class as #205/#206; those PRs fixed most sites but missed two.

## Reported bug — `POST /api/flows` (#210)

`src/app/api/flows/route.ts` inserted flows with only `user_id`. Both creation paths failed:
- **Template clone** path
- **Blank/manual** create path

Fix: resolve the caller's `profiles.account_id` (via the user-scoped client, like the `automations` route) and stamp it on both `flows.insert(...)` calls. Returns `403` if the profile isn't linked to an account. The child `flow_nodes` insert needs no change — `flow_nodes` is not account-scoped.

## Same bug found in pipelines — `src/app/(dashboard)/pipelines/page.tsx`

`pipelines` **is** in the NOT-NULL list (017:262), but both client-side inserts omitted `account_id`:
- `seedDefaultPipeline()` — auto-seed on first visit (line ~117)
- `handleCreatePipeline()` — manual "New pipeline" (line ~260)

So pipeline auto-seeding and manual creation were both broken post-017. Fix: stamp `account_id` from `useAuth()` (the established client-side source, same as `deal-form.tsx`) and guard when it's absent.

## Audit of other "similar flows"

I checked **every** insert into the 15 NOT-NULL-account_id tables (contacts, tags, custom_fields, contact_notes, conversations, whatsapp_config, message_templates, pipelines, deals, broadcasts, automations, automation_logs, automation_pending_executions, flows, flow_runs) across API routes, server engines/cron/webhook, and client components. **All other sites already stamp `account_id`** — these two were the only remaining gaps. Inserts into non-scoped tables (`flow_nodes`, `pipeline_stages`, `messages`) correctly need no change.

## Verification

- `npm run typecheck` → pass
- `npm run test` → **370 passed (24 files)**
- `npm run lint` → 0 errors (pre-existing warnings only)

Note: the POST route handlers have no unit-test harness in this repo (none existed for the #206 fixes either), so no route test was added; the fix mirrors the proven `automations` route + `deal-form` patterns.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)