### PR TITLE
fix(inbox): let the conversation list scroll instead of clipping

### DIFF
--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -187,8 +187,13 @@ export function ConversationList({
         </DropdownMenu>
       </div>
 
-      {/* Conversation Items */}
-      <ScrollArea className="flex-1">
+      {/* Conversation Items.
+          `min-h-0` is load-bearing: a flex child defaults to
+          min-height:auto, so without it this ScrollArea grows to fit
+          every conversation instead of shrinking to the remaining
+          space — the list then overflows and gets clipped by the
+          parent's overflow-hidden with no scrollbar (issue #229). */}
+      <ScrollArea className="min-h-0 flex-1">
         {loading ? (
           <div className="flex items-center justify-center py-12">
             <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />


### PR DESCRIPTION
Fixes #229.

## Problem
On the Inbox, the contact/conversation list doesn't show a vertical scrollbar when there are more contacts than fit — the extra ones are unreachable.

## Cause
The list renders inside a fixed-height flex column (`h-[calc(100vh-3.5rem)]` → `flex-1 overflow-hidden` → `h-full` panel → `flex-col h-full` list) with the items in `<ScrollArea className="flex-1">`. A flex child defaults to `min-height: auto`, so the `flex-1` ScrollArea grew to fit **every** conversation instead of shrinking to the leftover space. The list then overflowed and was clipped by the row's `overflow-hidden` — no scrollbar.

## Fix
Add `min-h-0` to the ScrollArea ([conversation-list.tsx](src/components/inbox/conversation-list.tsx)) so it can shrink below its content height and the viewport scrolls. One-line change.

## Testing
- `tsc --noEmit` ✅
- `eslint` ✅

I didn't do a live browser pass — reproducing needs an authed session with enough conversations to overflow the viewport, and there's no preview launch config for this app. The change is the standard fix for a clipped `flex-1` scroll container and is CSS-only.

Note: `contact-sidebar.tsx` (the single-contact detail panel) has the same `flex-1` ScrollArea pattern and the same latent issue; left out of this fix since the report is specifically the contact list. Flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)