### PR TITLE
fix(flows): allow multiple comma-separated keywords in trigger (#234)

### DIFF
--- a/src/components/flows/flow-builder.tsx
+++ b/src/components/flows/flow-builder.tsx
@@ -203,6 +203,55 @@ export function FlowBuilder() {
 
 
 // ============================================================
+// Keyword trigger input
+// ============================================================
+
+/**
+ * Comma-separated keyword entry. Keeps a local draft string so the
+ * comma (and trailing space) the user types survive until they're done
+ * — parsing into the keywords array on every keystroke stripped the
+ * trailing comma the instant it was typed, making it impossible to
+ * start a second keyword (issue #234). We commit on blur / Enter, then
+ * re-display the cleaned, rejoined form. Seeded once on mount; the
+ * component unmounts/remounts when the trigger type changes, so the
+ * seed stays in sync. Mirrors the automations builder's KeywordMatchConfig.
+ */
+function KeywordsInput({
+  keywords,
+  onChange,
+}: {
+  keywords: string[];
+  onChange: (keywords: string[]) => void;
+}) {
+  const [draft, setDraft] = useState(keywords.join(", "));
+
+  function commit() {
+    const parsed = draft
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean);
+    setDraft(parsed.join(", "));
+    onChange(parsed);
+  }
+
+  return (
+    <Input
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          commit();
+        }
+      }}
+      placeholder="support, help, hi"
+      className="bg-slate-800"
+    />
+  );
+}
+
+// ============================================================
 // Trigger panel
 // ============================================================
 
@@ -253,26 +302,18 @@ function TriggerPanel({
             <label className="mb-1 block text-xs text-slate-400">
               Keywords (comma-separated)
             </label>
-            <Input
-              value={
+            <KeywordsInput
+              keywords={
                 Array.isArray(state.trigger_config.keywords)
-                  ? (state.trigger_config.keywords as string[]).join(", ")
-                  : ""
+                  ? (state.trigger_config.keywords as string[])
+                  : []
               }
-              onChange={(e) =>
+              onChange={(keywords) =>
                 setState((s) => ({
                   ...s,
-                  trigger_config: {
-                    ...s.trigger_config,
-                    keywords: e.target.value
-                      .split(",")
-                      .map((k) => k.trim())
-                      .filter(Boolean),
-                  },
+                  trigger_config: { ...s.trigger_config, keywords },
                 }))
               }
-              placeholder="support, help, hi"
-              className="bg-slate-800"
             />
           </div>
         )}


### PR DESCRIPTION
## Problem

Closes #234. In the Flow editor's **list view** (the default on mobile, ≤767px, where the canvas is unusable), the keyword trigger input would not let you type a comma — so you could never add more than one keyword.

## Root cause

The input was controlled off `keywords.join(", ")` but re-parsed the value into the keywords array on **every keystroke**:

```ts
keywords: e.target.value.split(",").map(k => k.trim()).filter(Boolean)
```

Typing a comma after `support` yields `["support", ""]`; `.filter(Boolean)` drops the empty segment, state becomes `["support"]`, and the controlled value re-renders back to `"support"` — the comma is stripped the instant it's typed. A second keyword can never be started.

## Fix

Extracted a `KeywordsInput` component that keeps a local **draft string** and only commits (split / trim / drop-empties / rejoin) on **blur or Enter**. This is the same proven pattern already used by the automations builder's `KeywordMatchConfig`. Entering `support, help, hi` now works.

## Verification

- `tsc --noEmit` clean, ESLint clean on the changed file
- Flow test suite green (115 tests) — keyword matching already covers multiple keywords (`engine.test.ts`)
- The UI lives behind an auth-gated dashboard route (Supabase + a saved flow + list/mobile view), so it isn't exercisable by a fresh dev server; verified via types/lint/tests + parity with the existing automations implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)