### PR TITLE
feat(inbox): add "Unread" filter to conversation list

### DIFF
--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -36,8 +36,11 @@ const STATUS_COLORS: Record<ConversationStatus, string> = {
   closed: "bg-muted-foreground",
 };
 
-const FILTER_OPTIONS: { label: string; value: ConversationStatus | "all" }[] = [
+type InboxFilter = ConversationStatus | "all" | "unread";
+
+const FILTER_OPTIONS: { label: string; value: InboxFilter }[] = [
   { label: "All", value: "all" },
+  { label: "Unread", value: "unread" },
   { label: "Open", value: "open" },
   { label: "Pending", value: "pending" },
   { label: "Closed", value: "closed" },
@@ -51,7 +54,7 @@ export function ConversationList({
   resyncToken = 0,
 }: ConversationListProps) {
   const [search, setSearch] = useState("");
-  const [filter, setFilter] = useState<ConversationStatus | "all">("all");
+  const [filter, setFilter] = useState<InboxFilter>("all");
   const [loading, setLoading] = useState(true);
 
   // Keep the latest callback in a ref so the fetch effect below can
@@ -110,7 +113,9 @@ export function ConversationList({
   const filtered = useMemo(() => {
     let result = conversations;
 
-    if (filter !== "all") {
+    if (filter === "unread") {
+      result = result.filter((c) => c.unread_count > 0);
+    } else if (filter !== "all") {
       result = result.filter((c) => c.status === filter);
     }
 


### PR DESCRIPTION
## What & why

Closes #233. Adds an **"Unread"** option to the Inbox conversation-list filter dropdown so users can quickly surface contacts with unread messages instead of scanning the list or opening threads manually.

## Changes

Single file — `src/components/inbox/conversation-list.tsx`:
- New `InboxFilter` type (`ConversationStatus | "all" | "unread"`) applied to the filter options and state.
- `{ label: "Unread", value: "unread" }` added to the dropdown, right after "All".
- Filter logic branches so `"unread"` filters by `unread_count > 0` instead of comparing against `status`.

No schema, migration, API, or data-fetch changes — `unread_count` is already tracked per conversation and hydrated on every fetch. Filtering is client-side, identical in mechanism to the existing status filter.

## Verification
- `npx tsc --noEmit` → exit 0
- `npm run lint` → 0 errors (pre-existing warnings only)
- Manual: select **Unread** → only badged conversations remain; open one → marks read and drops out live (existing realtime/optimistic path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)