### PR TITLE
fix(inbox): chat thread overlapping contact sidebar on fullscreen desktop (#257)

### DIFF
--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -721,7 +721,15 @@ export function MessageThread({
     : "Assign";
 
   return (
-    <div className={cn("flex flex-1 flex-col", DOODLE_BG_CLASSES)}>
+    // `min-w-0` is load-bearing: the page already puts min-w-0 on the
+    // thread's flex *wrapper* (issue #165), but this root keeps the
+    // default `min-width: auto`, so a single wide message (long unbroken
+    // URL/word) expands the whole thread past its flex share and the chat
+    // paints on top of the contact sidebar at lg+ — outgoing bubbles get
+    // clipped and the hover toolbar overlaps the Tags panel. Letting the
+    // root shrink lets the bubbles' break-words / max-w caps apply.
+    // Issue #257.
+    <div className={cn("flex min-w-0 flex-1 flex-col", DOODLE_BG_CLASSES)}>
       {/* Header — solid card surface sits on top of the doodle so the
           name/avatar/dropdowns stay legible. */}
       <div className="flex items-center justify-between gap-2 border-b border-border bg-card px-3 py-3 sm:px-4">


### PR DESCRIPTION
Fixes #257.

## Problem
At `lg+` (three-column inbox: list + chat + contact sidebar), the chat thread could paint **on top of** the contact sidebar — outgoing bubbles clipped on the right, and the message hover toolbar (reply/copy/react) floating over the Tags/contact panel. Only visible at fullscreen desktop width; mobile/narrow viewports were fine.

## Root cause
The page wrapper around the thread already carries `min-w-0` (the #165 fix), but the `MessageThread` **root** element (`flex flex-1 flex-col`) kept the default `min-width: auto`. So a single wide message (a long unbroken URL or word) expanded the whole thread past its flex share. Since neither the root nor its wrapper clipped horizontally, the thread overflowed and painted over the sidebar.

## Fix
One class: add `min-w-0` to the `MessageThread` root so it can shrink to its column. The bubbles' existing `break-words` / `max-w-[75%]` caps then actually apply.

## Verification
Reproduced and measured in-browser by injecting the exact class structure against the served Tailwind CSS (login wall blocked the real `/inbox`):

| | Before | After |
|---|---|---|
| Thread/messages width (1272px column) | 1634px | 672px |
| Overlap onto sidebar | **962px** | **0px** |
| Hover toolbar vs sidebar edge | +934px over | 28px inside |
| Horizontal scroll | 0 (content wraps) | 0 |

`tsc --noEmit` passes; eslint clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)