### PR TITLE
fix(automations): remove spurious third output on condition steps

### DIFF
--- a/src/components/automations/automation-builder.tsx
+++ b/src/components/automations/automation-builder.tsx
@@ -927,9 +927,14 @@ function StepRenderer({
         )}
       </div>
 
-      <AddButton
-        onPick={(t) => props.addStepAt(parentScope, index + 1, t)}
-      />
+      {/* A condition branches into Yes/No (rendered above by
+          ConditionBranches), so it has no linear "continue" path — adding
+          the trailing connector here would produce a spurious third output. */}
+      {!isCondition && (
+        <AddButton
+          onPick={(t) => props.addStepAt(parentScope, index + 1, t)}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Problem

Closes #256. Adding a Condition (If/Else) step to an automation showed **three** add-step connectors below it: **Yes**, **No**, and an extra unlabeled `+` in the main flow. An If/Else block should only branch into Yes and No.

## Root cause

In `StepRenderer` (`src/components/automations/automation-builder.tsx`), every step gets a trailing `AddButton` after its card — the normal linear "insert after" connector. For a condition step, `ConditionBranches` *already* renders the Yes/No branch columns (each a `StepList` with its own leading `AddButton`), so the trailing button became a spurious third output.

## Fix

Skip the trailing `AddButton` when `step.step_type === "condition"`. A condition branches into Yes/No and has no linear "continue" path — steps after a condition are added inside one of its branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)