### PR TITLE
Settings: full-bleed layout for wide screens

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -62,7 +62,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="mx-auto max-w-[1040px]">
+    <div>
       <div>
         <h1 className="text-2xl font-bold tracking-tight text-foreground">
           Settings
@@ -73,7 +73,7 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      <div className="mt-6 grid gap-6 lg:grid-cols-[236px_1fr] lg:items-start">
+      <div className="mt-6 grid gap-6 lg:grid-cols-[236px_minmax(0,1fr)] lg:items-start">
         <SettingsRail active={section} onSelect={go} hints={hints} />
         <div className="min-w-0">{panel[section]}</div>
       </div>

--- a/src/components/settings/appearance-panel.tsx
+++ b/src/components/settings/appearance-panel.tsx
@@ -22,7 +22,7 @@ import { SettingsPanelHead } from "./settings-panel-head";
 export function AppearancePanel() {
   const { theme, setTheme, mode, setMode } = useTheme();
   return (
-    <section className="animate-in fade-in-50 duration-200">
+    <section className="max-w-3xl animate-in fade-in-50 duration-200">
       <SettingsPanelHead
         title="Appearance"
         description="Set the mode and accent colour used across the app. Saved to this device — try it, it changes live."

--- a/src/components/settings/deals-settings.tsx
+++ b/src/components/settings/deals-settings.tsx
@@ -68,7 +68,7 @@ export function DealsSettings() {
   }
 
   return (
-    <section className="animate-in fade-in-50 duration-200">
+    <section className="max-w-2xl animate-in fade-in-50 duration-200">
       <SettingsPanelHead
         title="Deals & currency"
         description="The currency used for new deals and for pipeline and dashboard totals."

--- a/src/components/settings/fields-and-tags-panel.tsx
+++ b/src/components/settings/fields-and-tags-panel.tsx
@@ -17,7 +17,7 @@ export function FieldsAndTagsPanel() {
   const canEditSettings = useCan('edit-settings');
 
   return (
-    <section className="animate-in fade-in-50 space-y-4 duration-200">
+    <section className="max-w-3xl animate-in fade-in-50 space-y-4 duration-200">
       <SettingsPanelHead
         title="Fields & tags"
         description="Two ways to organize contacts: colour-coded tags for quick grouping, and custom fields for structured data."

--- a/src/components/settings/profile-form.tsx
+++ b/src/components/settings/profile-form.tsx
@@ -205,7 +205,7 @@ export function ProfileForm() {
     : '—';
 
   return (
-    <section className="animate-in fade-in-50 duration-200">
+    <section className="max-w-2xl animate-in fade-in-50 duration-200">
       <SettingsPanelHead
         title="Your profile"
         description="How you show up across the app. Your avatar and name appear in the header, sidebar, and anywhere your teammates see you."

--- a/src/components/settings/security-panel.tsx
+++ b/src/components/settings/security-panel.tsx
@@ -10,7 +10,7 @@ import { SettingsPanelHead } from './settings-panel-head';
  */
 export function SecurityPanel() {
   return (
-    <section className="animate-in fade-in-50 duration-200">
+    <section className="max-w-2xl animate-in fade-in-50 duration-200">
       <SettingsPanelHead
         title="Login & security"
         description="Change your password and sign out of your devices. These keep your account safe."

--- a/src/components/settings/settings-overview.tsx
+++ b/src/components/settings/settings-overview.tsx
@@ -248,7 +248,7 @@ export function SettingsOverview({
       </Card>
 
       {/* Status tiles */}
-      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
         {tiles.map(({ section, loading, subtitle }) => {
           const meta = SECTION_META[section];
           const Icon = meta.icon;

--- a/src/components/settings/template-manager.tsx
+++ b/src/components/settings/template-manager.tsx
@@ -515,7 +515,7 @@ export function TemplateManager() {
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-3">
+        <div className="grid gap-3 xl:grid-cols-2">
           {templates.map((template) => {
             const statusKey = template.status || 'DRAFT';
             const status = templateStatusConfig[statusKey];


### PR DESCRIPTION
## Summary

Follow-up to #265. On wide monitors the redesigned Settings page floated centered with large black gutters on both sides, while every other dashboard route is full-bleed. Settings was the only page capping content at `max-w-[1040px] mx-auto`.

This removes the cap so the page fills the available width like the rest of the app, spending the extra space where it actually helps rather than stretching forms:

- **Overview** status tiles: 2-up → **3-up** on `xl`; identity card spans the full content width.
- **Templates** list: **2-up** on `xl`.
- **Form-heavy panels** (Profile, Login & security, Deals) keep a readable `max-w-2xl`; **Fields & tags** and **Appearance** use `max-w-3xl` — so single-column inputs don't stretch edge-to-edge on large displays.
- Content grid uses `minmax(0,1fr)` to prevent blowout from long values (e.g. tokens, IDs).

Lists/heavy panels (Templates, Members, WhatsApp) fill the width; forms stay at a comfortable line length, left-aligned under the rail.

## Verification
- `tsc --noEmit` clean; `eslint` 0 errors.
- Browser-verified at 1920×1080: Overview fills the width with 3-up tiles, Profile/form panels stay readable-width and left-aligned, no console errors. Mobile rail layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)