### PR TITLE
fix(migrations): heal orphaned auth.users before account backfill (017)

### DIFF
--- a/supabase/migrations/017_account_sharing.sql
+++ b/supabase/migrations/017_account_sharing.sql
@@ -193,6 +193,7 @@ ALTER TABLE flow_runs                      ADD COLUMN IF NOT EXISTS account_id U
 -- BACKFILL
 --
 -- Order is load-bearing:
+--   0. Heal orphaned auth.users that never got a profile row.
 --   1. Create one account per existing profile (the existing user
 --      is the owner).
 --   2. Stamp profile.account_id / account_role from the row above.
@@ -214,6 +215,26 @@ DECLARE
     'flows', 'flow_runs'
   ];
 BEGIN
+  -- (0) Heal orphaned users. The pre-017 signup trigger (migration
+  -- 001) inserted the profile inside an `EXCEPTION WHEN OTHERS ...
+  -- RAISE WARNING; RETURN NEW` block, so a signup could leave an
+  -- auth.users row with no matching profiles row. Those orphans would
+  -- be skipped by step (1) below, get no account, and — if they own
+  -- any domain rows (pre-017 RLS only required auth.uid() = user_id,
+  -- not a profile) — leave account_id NULL and abort the SET NOT NULL
+  -- step. Backfilling the missing profile first keys the whole backfill
+  -- off auth.users instead of profiles, so every authenticated user is
+  -- migrated and no domain row can be left without an account.
+  -- full_name / email are NOT NULL on profiles, hence the COALESCE.
+  INSERT INTO public.profiles (user_id, full_name, email)
+  SELECT u.id,
+         COALESCE(u.raw_user_meta_data->>'full_name', ''),
+         COALESCE(u.email, '')
+  FROM auth.users u
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.profiles p WHERE p.user_id = u.id
+  );
+
   -- (1) Create one account per existing profile whose user does not
   -- yet own one. Idempotent: skips users that already have an account.
   INSERT INTO accounts (name, owner_user_id)


### PR DESCRIPTION
## Problem (fixes #274)

Upgrading an existing database to the account-sharing release (migrations 017–020) can **abort migration 017** when an `auth.users` row exists without a matching `profiles` row.

### Why orphaned profiles exist
The pre-017 signup trigger `handle_new_user` (migration [001](supabase/migrations/001_initial_schema.sql)) inserts the `profiles` row inside an `EXCEPTION WHEN OTHERS THEN RAISE WARNING; RETURN NEW` block. Any failure during profile creation is swallowed, leaving an `auth.users` row with **no** `profiles` row.

### Why that breaks 017
The 017 backfill keys accounts off `profiles`, not `auth.users`:

1. The orphaned user has no profile → gets **no account** and is never linked.
2. Pre-017 RLS only required `auth.uid() = user_id` (not a profile), so the orphan could still own `contacts`, `conversations`, etc. Step 3 propagates `account_id` via `t.user_id = p.user_id`, so those rows keep `account_id = NULL`.
3. Step 4 runs `ALTER TABLE ... SET NOT NULL` on every `account_id` → **aborts** on the NULL rows, rolling the migration back.

This matches the reporter's manual recovery in #274 (recreate the missing profile, re-run migrations).

## Fix

Add step (0) to the 017 backfill `DO` block: create the missing `profiles` row for every `auth.users` row lacking one, **before** accounts are created. This keys the entire backfill off `auth.users` instead of `profiles`.

Because every domain `user_id` is an FK to `auth.users` (`ON DELETE CASCADE`), healing every auth user guarantees no `account_id` can remain NULL — so the `SET NOT NULL` step can no longer abort. `full_name`/`email` are `NOT NULL` on `profiles`, hence the `COALESCE`. Idempotent and safe to re-run, consistent with the rest of 017.

## Testing
No local Postgres in the working environment, so this was validated by static analysis of the migration chain (001 trigger → 017 backfill ordering → `SET NOT NULL`). The change is a standard `INSERT ... SELECT ... WHERE NOT EXISTS` inside the existing plpgsql `DO` block. Recommend running the 001→017 upgrade against a fixture DB containing an orphaned `auth.users` row (with and without owned domain rows) to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)