### PR TITLE
fix(migrations): make 017 RLS rewrite re-runnable

### DIFF
--- a/supabase/migrations/017_account_sharing.sql
+++ b/supabase/migrations/017_account_sharing.sql
@@ -352,6 +352,35 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_one_active_run_per_contact
 -- assignment + audit) but is no longer consulted for isolation.
 -- ============================================================
 
+-- Make the RLS rewrite re-runnable. CREATE POLICY has no IF NOT EXISTS
+-- form, and the DROP statements below only name the *legacy* policies —
+-- the new ones (contacts_select, …) would error with 42710 "policy
+-- already exists" on a second run. 017 owns every policy on these tables
+-- (no later migration adds others), so drop them all first, then the
+-- CREATEs below re-establish the full set.
+DO $$
+DECLARE
+  pol RECORD;
+BEGIN
+  FOR pol IN
+    SELECT policyname, tablename
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = ANY (ARRAY[
+        'contacts', 'tags', 'custom_fields', 'contact_notes',
+        'conversations', 'whatsapp_config', 'message_templates',
+        'pipelines', 'deals', 'broadcasts', 'automations',
+        'automation_logs', 'flows', 'flow_runs', 'contact_tags',
+        'contact_custom_values', 'messages', 'pipeline_stages',
+        'broadcast_recipients', 'automation_steps', 'flow_nodes',
+        'flow_run_events', 'message_reactions', 'profiles',
+        'accounts', 'account_invitations'
+      ])
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', pol.policyname, pol.tablename);
+  END LOOP;
+END $$;
+
 -- ---- contacts ---------------------------------------------------
 DROP POLICY IF EXISTS "Users can manage own contacts" ON contacts;
 CREATE POLICY contacts_select ON contacts FOR SELECT USING (is_account_member(account_id));


### PR DESCRIPTION
## Problem

Re-running migration `017_account_sharing.sql` against a database where it had already partially (or fully) applied fails with:

```
ERROR: 42710: policy "contacts_select" for table "contacts" already exists
```

The migration's header claims it is idempotent ("policies are dropped before recreate"), but the RLS rewrite only drops the **legacy** policy names (e.g. `"Users can manage own contacts"`). The **new** policies (`contacts_select`, `contacts_insert`, …) are created with no preceding `DROP`, and `CREATE POLICY` has no `IF NOT EXISTS` form — so the second run aborts as soon as it reaches a policy that already exists.

This is the follow-up to #276: that PR fixed the orphaned-profile backfill abort, but re-running 017 to recover then surfaced this latent non-idempotency.

## Fix

Add a `DO` block at the start of the RLS rewrite that drops every policy on the tables 017 manages, before the `CREATE POLICY` statements re-establish the full set.

Safe because 017 owns **all** RLS on those tables — migrations 021–023 only add policies on `storage.objects`, never on these public tables, so nothing else's policies are clobbered by the drop.

## Testing
No local Postgres in the working environment; validated by static analysis of the migration. The `DO` block is a standard `pg_policies` loop with `DROP POLICY IF EXISTS`. Recommend re-running 017 against a DB that already has it applied to confirm it now completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)