### PR TITLE
fix(automations): persist default match_type for Keyword Match triggers

### DIFF
--- a/src/components/automations/automation-builder.tsx
+++ b/src/components/automations/automation-builder.tsx
@@ -723,6 +723,18 @@ function KeywordMatchConfig({
   // when the trigger type changes, so the seed stays in sync.
   const [draft, setDraft] = useState(keywords.join(", "))
 
+  // Persist the default the <select> displays. The dropdown falls back to
+  // "contains" for display, but leaving it untouched would otherwise omit
+  // match_type from the saved config — and activation validation then
+  // rejected it (trigger.match_type). Seed once on mount; the component
+  // remounts when the trigger type changes, matching the keywords draft.
+  useEffect(() => {
+    if (config?.match_type == null) {
+      onChange({ ...config, match_type: "contains" })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   function commit() {
     const parsed = draft
       .split(",")

--- a/src/lib/automations/validate.test.ts
+++ b/src/lib/automations/validate.test.ts
@@ -212,6 +212,12 @@ describe("validateTriggerForActivation", () => {
     expect(issues.map((i) => i.path)).toContain("trigger.match_type");
   });
 
+  it("accepts keyword_match with a missing match_type (defaults to contains)", () => {
+    expect(
+      validateTriggerForActivation("keyword_match", { keywords: ["hi"] }),
+    ).toEqual([]);
+  });
+
   it("requires schedule on time_based triggers", () => {
     expect(validateTriggerForActivation("time_based", {})).toEqual([
       { path: "trigger.schedule", message: "schedule is required" },

--- a/src/lib/automations/validate.ts
+++ b/src/lib/automations/validate.ts
@@ -154,7 +154,13 @@ export function validateTriggerForActivation(
     } else if (k.some((v) => typeof v !== 'string' || v.trim() === '')) {
       issues.push({ path: 'trigger.keywords', message: 'keywords cannot be empty strings' })
     }
-    if (cfg.match_type !== 'exact' && cfg.match_type !== 'contains') {
+    // A missing match_type defaults to "contains" at runtime (see
+    // automations/engine.ts and flows/engine.ts, which both read
+    // `match_type ?? "contains"`), so only an explicit, unrecognised
+    // value is invalid here. This keeps activation validation in step
+    // with the engine and with the builder's "Contains" default — an
+    // automation that shows the default in the UI must not be rejected.
+    if (cfg.match_type != null && cfg.match_type !== 'exact' && cfg.match_type !== 'contains') {
       issues.push({
         path: 'trigger.match_type',
         message: 'match type must be "exact" or "contains"',


### PR DESCRIPTION
## Problem (fixes #271)

Creating a new automation with trigger **Keyword Match**, keywords filled in, and **Match type** left on the default **Contains** fails to save when Active is enabled:

```
match type must be "exact" or "contains"   (path: trigger.match_type)
```

The dropdown shows "Contains", but saving still errors. The workaround was to switch Match type to **Exact**, save, then change back to **Contains**.

### Root cause

The Match type `<select>` used `value={config?.match_type ?? "contains"}` — a **display-only** fallback. Until the user actually changes the dropdown, `config.match_type` stays `undefined`, so the saved `trigger_config` omits `match_type` entirely:

```json
{ "trigger_type": "keyword_match", "trigger_config": { "keywords": ["test"] }, "is_active": true }
```

Activation validation ([validate.ts](src/lib/automations/validate.ts)) then rejected the missing value — even though **both engines already treat a missing `match_type` as `"contains"`** (`automations/engine.ts`, `flows/engine.ts` both read `match_type ?? "contains"`). The validator was simply stricter than runtime.

## Fix (two coordinated changes)

1. **`validate.ts`** — accept a missing `match_type` (defaults to `"contains"`, matching the engines); only an *explicit, unrecognised* value is rejected. This stops the 400 for any client, UI or API.
2. **`automation-builder.tsx`** — seed `match_type: "contains"` on mount of `KeywordMatchConfig`, so the displayed default is actually persisted and the saved record is explicit/self-describing (also closes the inactive-draft footgun noted in the issue).

## Testing
- `npx vitest run src/lib/automations/ src/lib/flows/engine.test.ts` → **48 passed**, including a new regression test: a `keyword_match` config with no `match_type` now passes activation validation.
- `tsc --noEmit` clean on the touched files.
- The "fuzzy" (explicit invalid value) rejection test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)