### PR TITLE
feat(api): public send endpoint — POST /api/v1/messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ always did.
   (`messages`, `contacts`, …) follow one at a time. See
   `docs/public-api.md`. **Migration required:** apply
   `supabase/migrations/026_api_keys.sql`. ([#245](https://github.com/ArnasDon/wacrm/issues/245))
+- **Public API — `POST /api/v1/messages`.** The first data endpoint:
+  send a WhatsApp message (text, template, or media) to a phone number
+  with a `messages:send`-scoped key. You pass an E.164 number, not an
+  internal id — the API finds-or-creates the contact and conversation,
+  then sends through the same engine the dashboard uses. See
+  `docs/public-api.md`. ([#245](https://github.com/ArnasDon/wacrm/issues/245))
 
 ### Changed
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -4,10 +4,10 @@ The public API lets you drive your wacrm instance from your own
 scripts and automations — send messages, manage contacts, launch
 broadcasts — without going through the dashboard UI.
 
-> **Status:** groundwork release. Authentication, scopes, rate
-> limiting, and the `GET /api/v1/me` probe ship now. The data
-> endpoints (`messages`, `contacts`, …) land one at a time in
-> follow-up releases — see [Roadmap](#roadmap).
+> **Status:** building out. Authentication, scopes, rate limiting,
+> the `GET /api/v1/me` probe, and **`POST /api/v1/messages`** ship
+> now. The remaining data endpoints (`contacts`, `conversations`,
+> `broadcasts`, …) land one at a time — see [Roadmap](#roadmap).
 
 ## Authentication
 
@@ -115,13 +115,60 @@ curl https://your-crm.example.com/api/v1/me \
 }
 ```
 
+### `POST /api/v1/messages`
+
+Send a WhatsApp message to a phone number. Scope: **`messages:send`**.
+
+You send a **phone number**, not an internal id — the API finds the
+matching contact (or creates one) and its conversation, then sends.
+
+**Body**
+
+| Field                 | Type             | Notes                                                        |
+| --------------------- | ---------------- | ------------------------------------------------------------ |
+| `to`                  | string, required | Recipient phone in E.164, e.g. `+14155550123`.               |
+| `type`                | string           | `text` (default), `template`, `image`, `video`, `document`, `audio`. |
+| `text`                | string           | Body for `text`; caption for media kinds (≤1024 chars).      |
+| `media_url`           | string           | Public URL. Required for `image`/`video`/`document`/`audio`. |
+| `filename`            | string           | Optional document filename shown to the recipient.           |
+| `template`            | object           | Required for `type=template`: `{ name, language, params }`. `params` as an **array** = positional body variables; as an **object** = structured header/body/button params. |
+| `reply_to_message_id` | string           | Optional. Must be a message in the same conversation.        |
+| `name`                | string           | Optional. Names the contact if this call creates it.         |
+
+> WhatsApp's 24-hour customer-service window applies: outside an open
+> window, only approved **templates** are delivered. Send a `template`
+> first to (re)open the window.
+
+**Example**
+
+```bash
+curl -X POST https://your-crm.example.com/api/v1/messages \
+  -H "Authorization: Bearer wacrm_live_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{ "to": "+14155550123", "type": "text", "text": "Hi from the API 👋" }'
+```
+
+```json
+{
+  "data": {
+    "message_id": "…",
+    "whatsapp_message_id": "wamid.…",
+    "conversation_id": "…",
+    "contact_id": "…",
+    "contact_created": true
+  }
+}
+```
+
+Common errors: `bad_request` (bad `to`/params), `whatsapp_not_configured`
+(no WhatsApp connected), `meta_error` (Meta rejected the send, 502).
+
 ## Roadmap
 
 Planned endpoints, shipping one per release (tracked in
 [#245](https://github.com/ArnasDon/wacrm/issues/245)):
 
-- `POST /api/v1/messages` — send a message to a phone number
-  (`messages:send`)
+- ~~`POST /api/v1/messages` — send a message to a phone number~~ ✅ shipped
 - `GET/POST /api/v1/contacts`, `GET/PATCH /api/v1/contacts/{id}`
   (`contacts:read` / `contacts:write`)
 - `GET /api/v1/conversations` (`conversations:read`)

--- a/src/app/api/v1/messages/route.ts
+++ b/src/app/api/v1/messages/route.ts
@@ -1,0 +1,123 @@
+// ============================================================
+// POST /api/v1/messages — send a WhatsApp message via the public API.
+//
+// The headline public endpoint (issue #245). Unlike the dashboard's
+// `/api/whatsapp/send` (which takes an internal `conversation_id`),
+// this takes a phone number — what an external automation actually
+// has — resolves-or-creates the contact + conversation, then runs the
+// same shared send core.
+//
+// Auth: API key with the `messages:send` scope. Account context (and
+// the service-role client) come from `requireApiKey`.
+//
+// Body:
+//   {
+//     "to": "+14155550123",                 // required, E.164
+//     "type": "text",                        // text|template|image|video|document|audio (default: text)
+//     "text": "Hello!",                      // text body, or media caption
+//     "media_url": "https://…/file.pdf",     // required for image/video/document/audio
+//     "filename": "invoice.pdf",             // optional, document filename
+//     "template": {                          // required when type=template
+//       "name": "order_update",
+//       "language": "en_US",
+//       "params": ["A123"] | { "body": [...] }   // array = positional body; object = structured
+//     },
+//     "reply_to_message_id": "<uuid>",       // optional, must be in the same conversation
+//     "name": "Jane Doe"                     // optional, names a newly-created contact
+//   }
+//
+// Response (201):
+//   { "data": { "message_id", "whatsapp_message_id", "conversation_id",
+//               "contact_id", "contact_created" } }
+// ============================================================
+
+import { requireApiKey } from '@/lib/auth/api-context';
+import { ok, fail, toApiErrorResponse } from '@/lib/api/v1/respond';
+import { resolveConversationByPhone } from '@/lib/whatsapp/resolve-conversation';
+import {
+  sendMessageToConversation,
+  SendMessageError,
+} from '@/lib/whatsapp/send-message';
+
+export async function POST(request: Request) {
+  try {
+    const ctx = await requireApiKey(request, 'messages:send');
+
+    const body = (await request.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    if (!body || typeof body !== 'object') {
+      return fail('bad_request', 'Request body must be a JSON object', 400);
+    }
+
+    const to = typeof body.to === 'string' ? body.to.trim() : '';
+    if (!to) {
+      return fail('bad_request', "'to' is required", 400);
+    }
+
+    const type = typeof body.type === 'string' ? body.type : 'text';
+
+    // Unpack the optional `template` object into the flat params the
+    // send core expects. `params` as an array → legacy positional body
+    // params; as an object → structured header/body/button params.
+    const template =
+      body.template && typeof body.template === 'object'
+        ? (body.template as Record<string, unknown>)
+        : null;
+    const templateParams = Array.isArray(template?.params)
+      ? (template?.params as string[])
+      : undefined;
+    const templateMessageParams =
+      template?.params && !Array.isArray(template.params)
+        ? template.params
+        : undefined;
+
+    // Find-or-create the conversation for this phone, then send. Both
+    // steps share `SendMessageError`, so one catch maps the whole
+    // pipeline to the envelope.
+    const resolved = await resolveConversationByPhone(
+      ctx.supabase,
+      ctx.accountId,
+      to,
+      typeof body.name === 'string' ? body.name : null
+    );
+
+    const result = await sendMessageToConversation(
+      ctx.supabase,
+      ctx.accountId,
+      {
+        conversationId: resolved.conversationId,
+        messageType: type,
+        contentText: typeof body.text === 'string' ? body.text : null,
+        mediaUrl: typeof body.media_url === 'string' ? body.media_url : null,
+        filename: typeof body.filename === 'string' ? body.filename : null,
+        templateName: typeof template?.name === 'string' ? template.name : null,
+        templateLanguage:
+          typeof template?.language === 'string' ? template.language : null,
+        templateParams,
+        templateMessageParams,
+        replyToMessageId:
+          typeof body.reply_to_message_id === 'string'
+            ? body.reply_to_message_id
+            : null,
+      }
+    );
+
+    return ok(
+      {
+        message_id: result.messageId,
+        whatsapp_message_id: result.whatsappMessageId,
+        conversation_id: resolved.conversationId,
+        contact_id: resolved.contactId,
+        contact_created: resolved.contactCreated,
+      },
+      201
+    );
+  } catch (err) {
+    if (err instanceof SendMessageError) {
+      return fail(err.code, err.message, err.status);
+    }
+    return toApiErrorResponse(err);
+  }
+}

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -1,444 +1,85 @@
-import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
 import {
-  sendTextMessage,
-  sendTemplateMessage,
-  sendMediaMessage,
-  type MediaKind,
-} from '@/lib/whatsapp/meta-api'
-import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption'
-import { supabaseAdmin } from '@/lib/flows/admin-client'
-import {
-  sanitizePhoneForMeta,
-  isValidE164,
-  phoneVariants,
-  isRecipientNotAllowedError,
-} from '@/lib/whatsapp/phone-utils'
+  sendMessageToConversation,
+  SendMessageError,
+} from '@/lib/whatsapp/send-message';
 import {
   checkRateLimit,
   rateLimitResponse,
   RATE_LIMITS,
-} from '@/lib/rate-limit'
-import type { MessageTemplate } from '@/types'
-import { isMessageTemplate } from '@/lib/whatsapp/template-row-guard'
+} from '@/lib/rate-limit';
 
 export async function POST(request: Request) {
   try {
-    const supabase = await createClient()
+    const supabase = await createClient();
 
     const {
       data: { user },
       error: authError,
-    } = await supabase.auth.getUser()
+    } = await supabase.auth.getUser();
 
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      )
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Per-user rate limit. Bucket key is scoped to this route so
     // `/broadcast` has an independent budget.
-    const limit = checkRateLimit(`send:${user.id}`, RATE_LIMITS.send)
+    const limit = checkRateLimit(`send:${user.id}`, RATE_LIMITS.send);
     if (!limit.success) {
-      return rateLimitResponse(limit)
+      return rateLimitResponse(limit);
     }
 
-    // Resolve the caller's account_id. Every downstream lookup
-    // (conversation, whatsapp_config, message_templates) is account-
-    // scoped post-multi-user, so the previous `user_id` filters
-    // returned nothing for teammates who didn't author the row.
+    // Resolve the caller's account_id. Every downstream lookup is
+    // account-scoped post-multi-user.
     const { data: profile } = await supabase
       .from('profiles')
       .select('account_id')
       .eq('user_id', user.id)
-      .maybeSingle()
-    const accountId = profile?.account_id as string | undefined
+      .maybeSingle();
+    const accountId = profile?.account_id as string | undefined;
     if (!accountId) {
       return NextResponse.json(
         { error: 'Your profile is not linked to an account.' },
-        { status: 403 },
-      )
+        { status: 403 }
+      );
     }
 
-    const body = await request.json()
-    const {
-      conversation_id,
-      message_type,
-      content_text,
-      media_url,
-      filename,
-      template_name,
-      template_language,
-      template_params,
-      template_message_params,
-      reply_to_message_id,
-    } = body
+    const body = await request.json();
 
-    if (!conversation_id || !message_type) {
-      return NextResponse.json(
-        { error: 'conversation_id and message_type are required' },
-        { status: 400 }
-      )
-    }
-
-    // Media kinds (image/video/document/audio) are sent to Meta via a
-    // public URL the composer already uploaded to the chat-media bucket.
-    const MEDIA_KINDS = ['image', 'video', 'document', 'audio'] as const
-    const isMediaKind = (MEDIA_KINDS as readonly string[]).includes(message_type)
-
-    // Reject anything outside the known set up front rather than letting
-    // an unknown type fall through to the text path with empty content.
-    const VALID_MESSAGE_TYPES = ['text', 'template', ...MEDIA_KINDS] as const
-    if (!(VALID_MESSAGE_TYPES as readonly string[]).includes(message_type)) {
-      return NextResponse.json(
-        { error: `Unsupported message_type "${message_type}"` },
-        { status: 400 }
-      )
-    }
-
-    if (message_type === 'text' && !content_text) {
-      return NextResponse.json(
-        { error: 'content_text is required for text messages' },
-        { status: 400 }
-      )
-    }
-
-    if (message_type === 'template' && !template_name) {
-      return NextResponse.json(
-        { error: 'template_name is required for template messages' },
-        { status: 400 }
-      )
-    }
-
-    if (isMediaKind && !media_url) {
-      return NextResponse.json(
-        { error: `media_url is required for ${message_type} messages` },
-        { status: 400 }
-      )
-    }
-
-    // Meta caps media captions at 1024 chars; reject before the upload is
-    // wasted at the Meta call. (Audio carries no caption — see meta-api.)
-    if (
-      isMediaKind &&
-      message_type !== 'audio' &&
-      typeof content_text === 'string' &&
-      content_text.length > 1024
-    ) {
-      return NextResponse.json(
-        { error: 'Caption exceeds the 1024-character limit' },
-        { status: 400 }
-      )
-    }
-
-    // Fetch conversation and contact
-    const { data: conversation, error: convError } = await supabase
-      .from('conversations')
-      .select('*, contact:contacts(*)')
-      .eq('id', conversation_id)
-      .eq('account_id', accountId)
-      .single()
-
-    if (convError || !conversation) {
-      return NextResponse.json(
-        { error: 'Conversation not found' },
-        { status: 404 }
-      )
-    }
-
-    const contact = conversation.contact
-    if (!contact?.phone) {
-      return NextResponse.json(
-        { error: 'Contact phone number not found' },
-        { status: 400 }
-      )
-    }
-
-    // Sanitize and validate phone
-    const sanitizedPhone = sanitizePhoneForMeta(contact.phone)
-    if (!isValidE164(sanitizedPhone)) {
-      return NextResponse.json(
-        { error: 'Invalid phone number format' },
-        { status: 400 }
-      )
-    }
-
-    // Fetch and decrypt WhatsApp config
-    const { data: config, error: configError } = await supabase
-      .from('whatsapp_config')
-      .select('*')
-      .eq('account_id', accountId)
-      .single()
-
-    if (configError || !config) {
-      return NextResponse.json(
-        { error: 'WhatsApp not configured. Please set up your WhatsApp integration first.' },
-        { status: 400 }
-      )
-    }
-
-    const accessToken = decrypt(config.access_token)
-
-    // Self-heal legacy CBC-encrypted tokens. Fire-and-forget: we
-    // return from the send without waiting, so a failed upgrade just
-    // means the next send tries again. The upgrade is idempotent —
-    // concurrent sends both produce valid GCM ciphertexts of the same
-    // plaintext, last write wins.
-    if (isLegacyFormat(config.access_token)) {
-      void supabase
-        .from('whatsapp_config')
-        .update({ access_token: encrypt(accessToken) })
-        .eq('id', config.id)
-        .then(({ error }) => {
-          if (error) {
-            console.warn(
-              '[whatsapp/send] access_token GCM upgrade failed:',
-              error.message,
-            )
-          }
-        })
-    }
-
-    // Resolve the reply target (if any) to its Meta message_id, which is
-    // what `context.message_id` on the outgoing Meta payload needs. The
-    // parent must belong to this same conversation — otherwise a caller
-    // could quote messages they can't see by guessing UUIDs.
-    let contextMessageId: string | undefined
-    if (reply_to_message_id) {
-      const { data: parent, error: parentError } = await supabase
-        .from('messages')
-        .select('message_id, conversation_id')
-        .eq('id', reply_to_message_id)
-        .eq('conversation_id', conversation_id)
-        .maybeSingle()
-
-      if (parentError || !parent) {
-        return NextResponse.json(
-          { error: 'reply_to_message_id not found in this conversation' },
-          { status: 400 }
-        )
-      }
-      if (!parent.message_id) {
-        // Parent never reached Meta (still in 'sending' or 'failed') — we
-        // can't quote it on WhatsApp. Send without context rather than
-        // dropping the message entirely.
-        console.warn(
-          '[whatsapp/send] reply target has no Meta message_id; sending without context'
-        )
-      } else {
-        contextMessageId = parent.message_id
-      }
-    }
-
-    // Send via Meta API — retry with phone-number variants if Meta rejects
-    // with "recipient not in allowed list" (common in sandbox / when a
-    // number was registered with/without a trunk 0). If an alternate
-    // format succeeds, we persist it back to the contact row so the
-    // next send goes through on the first attempt.
-    let waMessageId = ''
-    let workingPhone = sanitizedPhone
-
-    // For template sends, load the row so sendTemplateMessage can
-    // build header + button components from the template definition.
-    // Match on (user_id, name, language) — same triple the unique
-    // index enforces — so multi-language templates work correctly.
-    // Missing template falls through with `templateRow = null` and
-    // the legacy body-only path runs.
-    // Load the template row so sendTemplateMessage can build header
-    // + button components from the definition. isMessageTemplate
-    // guards against a malformed row (e.g. from a partial sync)
-    // crashing the send-builder later in the stack.
-    let templateRow: MessageTemplate | null = null
-    if (message_type === 'template' && template_name) {
-      const { data } = await supabase
-        .from('message_templates')
-        .select('*')
-        .eq('account_id', accountId)
-        .eq('name', template_name)
-        .eq('language', template_language || 'en_US')
-        .maybeSingle()
-      if (data && !isMessageTemplate(data)) {
-        return NextResponse.json(
-          {
-            error:
-              'Template row is malformed locally — run "Sync from Meta" in Settings to repair it.',
-          },
-          { status: 500 },
-        )
-      }
-      templateRow = data ?? null
-    }
-
-    const attempt = async (phone: string): Promise<string> => {
-      if (message_type === 'template') {
-        const result = await sendTemplateMessage({
-          phoneNumberId: config.phone_number_id,
-          accessToken,
-          to: phone,
-          templateName: template_name,
-          language: template_language || 'en_US',
-          template: templateRow ?? undefined,
-          messageParams: template_message_params ?? undefined,
-          // Legacy body-only fallback — only consulted when
-          // messageParams.body isn't set.
-          params: template_params || [],
-          contextMessageId,
-        })
-        return result.messageId
-      }
-      if (isMediaKind) {
-        // content_text doubles as the caption (ignored for audio inside
-        // sendMediaMessage). filename surfaces in the recipient's chat
-        // for documents only.
-        const result = await sendMediaMessage({
-          phoneNumberId: config.phone_number_id,
-          accessToken,
-          to: phone,
-          kind: message_type as MediaKind,
-          link: media_url,
-          caption: content_text || undefined,
-          filename: filename || undefined,
-          contextMessageId,
-        })
-        return result.messageId
-      }
-      const result = await sendTextMessage({
-        phoneNumberId: config.phone_number_id,
-        accessToken,
-        to: phone,
-        text: content_text,
-        contextMessageId,
-      })
-      return result.messageId
-    }
-
-    try {
-      const variants = phoneVariants(sanitizedPhone)
-      let lastError: unknown = null
-
-      for (const variant of variants) {
-        try {
-          waMessageId = await attempt(variant)
-          workingPhone = variant
-          lastError = null
-          break
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err)
-          // Only retry when the failure is specifically that the
-          // recipient isn't in Meta's allowed list. Any other error
-          // (bad token, invalid template, etc.) bubbles up immediately.
-          if (!isRecipientNotAllowedError(message)) {
-            throw err
-          }
-          lastError = err
-          console.warn(`[whatsapp/send] variant "${variant}" rejected by Meta, trying next…`)
-        }
-      }
-
-      if (lastError) throw lastError
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown Meta API error'
-      console.error('Meta API send failed for all variants:', message)
-      return NextResponse.json(
-        { error: `Meta API error: ${message}` },
-        { status: 502 }
-      )
-    }
-
-    // If a non-original variant succeeded, update the contact so future
-    // sends go straight through. sanitizePhoneForMeta on workingPhone
-    // will yield workingPhone itself, so re-storing preserves it.
-    if (workingPhone !== sanitizedPhone) {
-      console.log(
-        `[whatsapp/send] Auto-corrected contact phone: ${sanitizedPhone} → ${workingPhone}`
-      )
-      await supabase
-        .from('contacts')
-        .update({ phone: workingPhone })
-        .eq('id', contact.id)
-    }
-
-    // Insert message into DB — field names MUST match the messages schema
-    // (see supabase/migrations/001_initial_schema.sql):
-    //   conversation_id, sender_type, content_type, content_text,
-    //   media_url, template_name, message_id, status, created_at
-    const { data: messageRecord, error: msgError } = await supabase
-      .from('messages')
-      .insert({
-        conversation_id,
-        sender_type: 'agent',
-        content_type: message_type,
-        content_text: content_text || null,
-        media_url: media_url || null,
-        template_name: template_name || null,
-        message_id: waMessageId,
-        status: 'sent',
-        reply_to_message_id: reply_to_message_id || null,
-      })
-      .select()
-      .single()
-
-    if (msgError) {
-      console.error('Error inserting sent message:', msgError)
-      return NextResponse.json(
-        { error: `Message sent to Meta but failed to save to DB: ${msgError.message}` },
-        { status: 500 }
-      )
-    }
-
-    // Update conversation
-    await supabase
-      .from('conversations')
-      .update({
-        last_message_text: content_text || `[${message_type}]`,
-        last_message_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', conversation_id)
-
-    // Pause any active Flow run for this contact — the agent stepping
-    // in is the strongest "yield, human is here" signal. See PR #2
-    // plan for why we pause (not end): preserves diagnostic state +
-    // lets the agent or the 24h timeout sweep cleanly resolve the
-    // run later. For accounts with no active runs the UPDATE matches
-    // zero rows — cheap and harmless.
-    try {
-      const { error: pauseErr } = await supabaseAdmin()
-        .from('flow_runs')
-        .update({
-          status: 'paused_by_agent',
-          ended_at: new Date().toISOString(),
-          end_reason: 'agent_replied',
-        })
-        .eq('account_id', accountId)
-        .eq('contact_id', contact.id)
-        .eq('status', 'active')
-      if (pauseErr) {
-        // Best-effort — log + continue. The agent's message already
-        // landed at Meta; don't fail the response over a bookkeeping
-        // miss. Worst case: a stale active run gets caught by the
-        // stale-run cron sweep within 24h.
-        console.error('[flows] pause-on-agent-send failed:', pauseErr.message)
-      }
-    } catch (err) {
-      console.error(
-        '[flows] pause-on-agent-send threw:',
-        err instanceof Error ? err.message : err,
-      )
-    }
+    // The send core (shared with the public POST /api/v1/messages
+    // endpoint) does all validation, the Meta call, persistence, and
+    // the flow-run pause. We just translate body field names and map
+    // its typed errors back to this route's response shape.
+    const result = await sendMessageToConversation(supabase, accountId, {
+      conversationId: body.conversation_id,
+      messageType: body.message_type,
+      contentText: body.content_text,
+      mediaUrl: body.media_url,
+      filename: body.filename,
+      templateName: body.template_name,
+      templateLanguage: body.template_language,
+      templateParams: body.template_params,
+      templateMessageParams: body.template_message_params,
+      replyToMessageId: body.reply_to_message_id,
+    });
 
     return NextResponse.json({
       success: true,
-      message_id: messageRecord.id,
-      whatsapp_message_id: waMessageId,
-    })
+      message_id: result.messageId,
+      whatsapp_message_id: result.whatsappMessageId,
+    });
   } catch (error) {
-    console.error('Error in WhatsApp send POST:', error)
+    if (error instanceof SendMessageError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status }
+      );
+    }
+    console.error('Error in WhatsApp send POST:', error);
     return NextResponse.json(
       { error: 'Failed to send message' },
       { status: 500 }
-    )
+    );
   }
 }

--- a/src/lib/api/v1/respond.ts
+++ b/src/lib/api/v1/respond.ts
@@ -87,6 +87,23 @@ export function ok<T>(data: T, status = 200): NextResponse {
 }
 
 /**
+ * Failure envelope from an explicit (code, message, status). Use for
+ * domain errors whose codes live outside `ApiErrorCode` (e.g. the
+ * send pipeline's `meta_error` / `whatsapp_not_configured`) — the
+ * wire `code` is a free string, so any machine-meaningful value is
+ * fine. `headers` is rarely needed; omit unless you have a
+ * `Retry-After`-style set.
+ */
+export function fail(
+  code: string,
+  message: string,
+  status: number,
+  headers?: Record<string, string>
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status, headers });
+}
+
+/**
  * Map any thrown value to the failure envelope. `ApiError` keeps its
  * code/status/headers; anything else collapses to a generic 500 so we
  * never leak internal error text onto the public wire.

--- a/src/lib/whatsapp/resolve-conversation.test.ts
+++ b/src/lib/whatsapp/resolve-conversation.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { resolveConversationByPhone } from './resolve-conversation';
+import { SendMessageError } from './send-message';
+
+// ------------------------------------------------------------
+// Chainable Supabase stub, scripted per table. Terminal methods
+// (like/maybeSingle/single) resolve to configured data; the builder
+// itself is thenable so an awaited `update().eq()` resolves cleanly.
+// ------------------------------------------------------------
+type ContactRow = { id: string; phone: string; name?: string | null };
+
+interface Script {
+  config?: { user_id: string } | null; // whatsapp_config.maybeSingle
+  contactCandidates?: ContactRow[]; // contacts .like (same every call)
+  /** Per-call `.like` results — overrides contactCandidates. Lets a
+   *  test simulate "miss, then hit" for the unique-race path. */
+  contactCandidatesByCall?: ContactRow[][];
+  insertedContactId?: string; // contacts insert -> single
+  insertContactError?: { code?: string } | null;
+  existingConversation?: { id: string } | null; // conversations select.maybeSingle
+  insertedConversationId?: string; // conversations insert -> single
+}
+
+function makeDb(script: Script): SupabaseClient {
+  let table = '';
+  let mode: 'select' | 'insert' | 'update' = 'select';
+  let likeCalls = 0;
+
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    insert: () => {
+      mode = 'insert';
+      return builder;
+    },
+    update: () => {
+      mode = 'update';
+      return builder;
+    },
+    eq: () => builder,
+    like: () => {
+      const data = script.contactCandidatesByCall
+        ? (script.contactCandidatesByCall[likeCalls] ?? [])
+        : (script.contactCandidates ?? []);
+      likeCalls++;
+      return Promise.resolve({ data, error: null });
+    },
+    maybeSingle: () => {
+      if (table === 'whatsapp_config')
+        return Promise.resolve({ data: script.config ?? null, error: null });
+      if (table === 'conversations' && mode === 'select')
+        return Promise.resolve({
+          data: script.existingConversation ?? null,
+          error: null,
+        });
+      return Promise.resolve({ data: null, error: null });
+    },
+    single: () => {
+      if (table === 'contacts' && mode === 'insert') {
+        if (script.insertContactError)
+          return Promise.resolve({
+            data: null,
+            error: script.insertContactError,
+          });
+        return Promise.resolve({
+          data: { id: script.insertedContactId },
+          error: null,
+        });
+      }
+      if (table === 'conversations' && mode === 'insert')
+        return Promise.resolve({
+          data: { id: script.insertedConversationId },
+          error: null,
+        });
+      return Promise.resolve({ data: null, error: null });
+    },
+    // Thenable: `await db.from().update().eq()` lands here.
+    then: (resolve: (v: { data: null; error: null }) => void) =>
+      resolve({ data: null, error: null }),
+  };
+
+  return {
+    from: (t: string) => {
+      table = t;
+      mode = 'select';
+      return builder;
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe('resolveConversationByPhone', () => {
+  it('rejects an invalid phone before any DB call', async () => {
+    const db = {
+      from() {
+        throw new Error('should not query');
+      },
+    } as unknown as SupabaseClient;
+    await expect(
+      resolveConversationByPhone(db, 'acct', 'not-a-phone')
+    ).rejects.toBeInstanceOf(SendMessageError);
+  });
+
+  it('fails with whatsapp_not_configured when no config owner exists', async () => {
+    const db = makeDb({ config: null });
+    await resolveConversationByPhone(db, 'acct', '+14155550123').catch(
+      (e: SendMessageError) => {
+        expect(e.code).toBe('whatsapp_not_configured');
+        expect(e.status).toBe(400);
+      }
+    );
+    await expect(
+      resolveConversationByPhone(db, 'acct', '+14155550123')
+    ).rejects.toBeInstanceOf(SendMessageError);
+  });
+
+  it('returns the existing contact + conversation without creating', async () => {
+    const db = makeDb({
+      config: { user_id: 'owner-1' },
+      contactCandidates: [{ id: 'c1', phone: '14155550123' }],
+      existingConversation: { id: 'cv1' },
+    });
+    const res = await resolveConversationByPhone(
+      db,
+      'acct',
+      '+1 (415) 555-0123'
+    );
+    expect(res).toEqual({
+      conversationId: 'cv1',
+      contactId: 'c1',
+      contactCreated: false,
+    });
+  });
+
+  it('creates contact + conversation when none exist', async () => {
+    const db = makeDb({
+      config: { user_id: 'owner-1' },
+      contactCandidates: [],
+      insertedContactId: 'c2',
+      existingConversation: null,
+      insertedConversationId: 'cv2',
+    });
+    const res = await resolveConversationByPhone(
+      db,
+      'acct',
+      '+14155550199',
+      'Jane'
+    );
+    expect(res).toEqual({
+      conversationId: 'cv2',
+      contactId: 'c2',
+      contactCreated: true,
+    });
+  });
+
+  it('re-resolves an existing contact when the insert loses a unique race', async () => {
+    // First lookup misses (→ we attempt an insert), the insert hits a
+    // 23505 unique violation, and the post-race re-lookup now returns
+    // the row a concurrent writer created.
+    const db = makeDb({
+      config: { user_id: 'owner-1' },
+      contactCandidatesByCall: [[], [{ id: 'c-raced', phone: '14155550123' }]],
+      insertContactError: { code: '23505' },
+      existingConversation: { id: 'cv-raced' },
+    });
+    const res = await resolveConversationByPhone(db, 'acct', '+14155550123');
+    expect(res.contactId).toBe('c-raced');
+    expect(res.contactCreated).toBe(false);
+    expect(res.conversationId).toBe('cv-raced');
+  });
+});

--- a/src/lib/whatsapp/resolve-conversation.ts
+++ b/src/lib/whatsapp/resolve-conversation.ts
@@ -1,0 +1,158 @@
+// ============================================================
+// Resolve (or create) the conversation for a phone number.
+//
+// The dashboard composer always has a `conversation_id` in hand. The
+// public API doesn't — an external automation knows a *phone number*,
+// not an internal UUID. This helper bridges that: given an E.164
+// phone, it finds-or-creates the contact and its conversation so the
+// shared `sendMessageToConversation` core can run unchanged.
+//
+// It deliberately reuses the exact find-or-create logic the inbound
+// webhook uses (the `findExistingContact` dedupe helper, the
+// one-conversation-per-(account, contact) convention, the
+// account_id-tenancy / user_id-audit split) so a contact created via
+// the API is indistinguishable from one created by an inbound message.
+//
+// Audit user: created rows need a NOT NULL `user_id`. As with the
+// webhook (where there's no logged-in human either), we attribute
+// them to the WhatsApp config owner — a stable account-level default.
+// ============================================================
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { findExistingContact, isUniqueViolation } from '@/lib/contacts/dedupe';
+import { sanitizePhoneForMeta, isValidE164 } from '@/lib/whatsapp/phone-utils';
+import { SendMessageError } from '@/lib/whatsapp/send-message';
+
+export interface ResolvedConversation {
+  conversationId: string;
+  contactId: string;
+  /** True if this call created the contact (vs matched an existing one). */
+  contactCreated: boolean;
+}
+
+/**
+ * Find or create the contact + conversation for `phone` within
+ * `accountId`. Throws `SendMessageError` (shared with the send core,
+ * so the route maps one error family) on a bad phone, a missing
+ * WhatsApp config, or a DB failure.
+ */
+export async function resolveConversationByPhone(
+  db: SupabaseClient,
+  accountId: string,
+  phone: string,
+  name?: string | null
+): Promise<ResolvedConversation> {
+  const sanitized = sanitizePhoneForMeta(phone);
+  if (!isValidE164(sanitized)) {
+    throw new SendMessageError(
+      'bad_request',
+      "'to' must be a valid phone number in E.164 format (e.g. +14155550123)",
+      400
+    );
+  }
+
+  // Audit owner = the WhatsApp config owner. Resolving it first also
+  // means we fail fast (and create nothing) when the account has no
+  // WhatsApp connected — the same error the send would raise anyway.
+  const { data: config } = await db
+    .from('whatsapp_config')
+    .select('user_id')
+    .eq('account_id', accountId)
+    .maybeSingle();
+  const ownerUserId = config?.user_id as string | undefined;
+  if (!ownerUserId) {
+    throw new SendMessageError(
+      'whatsapp_not_configured',
+      'WhatsApp not configured. Please set up your WhatsApp integration first.',
+      400
+    );
+  }
+
+  // ---- contact -------------------------------------------------
+  let contactId: string;
+  let contactCreated = false;
+
+  const existing = await findExistingContact(db, accountId, sanitized);
+  if (existing) {
+    contactId = existing.id;
+    if (name && name !== existing.name) {
+      await db
+        .from('contacts')
+        .update({ name, updated_at: new Date().toISOString() })
+        .eq('id', existing.id);
+    }
+  } else {
+    const { data: created, error: createErr } = await db
+      .from('contacts')
+      .insert({
+        account_id: accountId,
+        user_id: ownerUserId,
+        phone: sanitized,
+        name: name || sanitized,
+      })
+      .select('id')
+      .single();
+
+    if (createErr || !created) {
+      // Lost a race against a concurrent inbound/API create — the
+      // unique index (migration 022) rejected the duplicate. Re-resolve.
+      if (isUniqueViolation(createErr)) {
+        const raced = await findExistingContact(db, accountId, sanitized);
+        if (raced) {
+          contactId = raced.id;
+        } else {
+          throw new SendMessageError(
+            'db_error',
+            'Failed to create contact',
+            500
+          );
+        }
+      } else {
+        console.error(
+          '[resolve-conversation] contact create error:',
+          createErr
+        );
+        throw new SendMessageError('db_error', 'Failed to create contact', 500);
+      }
+    } else {
+      contactId = created.id;
+      contactCreated = true;
+    }
+  }
+
+  // ---- conversation -------------------------------------------
+  // One conversation per (account, contact) — same convention as the
+  // webhook.
+  const { data: conv } = await db
+    .from('conversations')
+    .select('id')
+    .eq('account_id', accountId)
+    .eq('contact_id', contactId)
+    .maybeSingle();
+
+  if (conv?.id) {
+    return { conversationId: conv.id, contactId, contactCreated };
+  }
+
+  const { data: newConv, error: convErr } = await db
+    .from('conversations')
+    .insert({
+      account_id: accountId,
+      user_id: ownerUserId,
+      contact_id: contactId,
+    })
+    .select('id')
+    .single();
+
+  if (convErr || !newConv) {
+    console.error('[resolve-conversation] conversation create error:', convErr);
+    throw new SendMessageError(
+      'db_error',
+      'Failed to create conversation',
+      500
+    );
+  }
+
+  return { conversationId: newConv.id, contactId, contactCreated };
+}

--- a/src/lib/whatsapp/send-message.test.ts
+++ b/src/lib/whatsapp/send-message.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  sendMessageToConversation,
+  SendMessageError,
+  type SendMessageParams,
+} from './send-message';
+
+// A db that explodes if touched — these tests cover the param
+// validation that MUST short-circuit before any query runs.
+function noDb(): SupabaseClient {
+  return {
+    from() {
+      throw new Error('db should not be queried for invalid params');
+    },
+  } as unknown as SupabaseClient;
+}
+
+async function expectSendError(
+  params: SendMessageParams,
+  status: number,
+  messageMatch?: RegExp
+) {
+  await expect(
+    sendMessageToConversation(noDb(), 'acct-1', params)
+  ).rejects.toBeInstanceOf(SendMessageError);
+  await sendMessageToConversation(noDb(), 'acct-1', params).catch(
+    (e: SendMessageError) => {
+      expect(e.status).toBe(status);
+      if (messageMatch) expect(e.message).toMatch(messageMatch);
+    }
+  );
+}
+
+describe('sendMessageToConversation — param validation (pre-DB)', () => {
+  const base = { conversationId: 'cv-1' };
+
+  it('requires conversation_id and message_type', async () => {
+    await expectSendError({ conversationId: '', messageType: 'text' }, 400);
+    await expectSendError({ conversationId: 'cv-1', messageType: '' }, 400);
+  });
+
+  it('rejects an unsupported message_type', async () => {
+    await expectSendError(
+      { ...base, messageType: 'carrier-pigeon' },
+      400,
+      /Unsupported message_type/
+    );
+  });
+
+  it('requires content_text for text messages', async () => {
+    await expectSendError(
+      { ...base, messageType: 'text' },
+      400,
+      /content_text is required/
+    );
+  });
+
+  it('requires template_name for template messages', async () => {
+    await expectSendError(
+      { ...base, messageType: 'template' },
+      400,
+      /template_name is required/
+    );
+  });
+
+  it('requires media_url for media kinds', async () => {
+    for (const kind of ['image', 'video', 'document', 'audio']) {
+      await expectSendError(
+        { ...base, messageType: kind },
+        400,
+        /media_url is required/
+      );
+    }
+  });
+
+  it('rejects an over-long media caption (non-audio)', async () => {
+    await expectSendError(
+      {
+        ...base,
+        messageType: 'image',
+        mediaUrl: 'https://x/y.jpg',
+        contentText: 'a'.repeat(1025),
+      },
+      400,
+      /1024-character limit/
+    );
+  });
+
+  it('allows a long "caption" on audio (audio carries none) — so it reaches the DB', async () => {
+    // Audio is exempt from the caption cap, so validation passes and we
+    // proceed to the conversation lookup — proven by the stub throwing.
+    const spy = vi.fn(() => {
+      throw new Error('reached DB');
+    });
+    const db = { from: spy } as unknown as SupabaseClient;
+    await expect(
+      sendMessageToConversation(db, 'acct-1', {
+        ...base,
+        messageType: 'audio',
+        mediaUrl: 'https://x/y.ogg',
+        contentText: 'a'.repeat(2000),
+      })
+    ).rejects.toThrow('reached DB');
+    expect(spy).toHaveBeenCalledWith('conversations');
+  });
+});
+
+describe('SendMessageError', () => {
+  it('carries a machine code and an HTTP status', () => {
+    const e = new SendMessageError('meta_error', 'boom', 502);
+    expect(e.code).toBe('meta_error');
+    expect(e.status).toBe(502);
+    expect(e).toBeInstanceOf(Error);
+  });
+});

--- a/src/lib/whatsapp/send-message.ts
+++ b/src/lib/whatsapp/send-message.ts
@@ -1,0 +1,422 @@
+// ============================================================
+// Outbound message send — the core that both the dashboard's
+// `/api/whatsapp/send` route and the public `/api/v1/messages`
+// endpoint call.
+//
+// Given a conversation and message params, this:
+//   1. validates the params for the message type,
+//   2. loads the conversation + contact + WhatsApp config,
+//   3. sends to Meta (with phone-variant retry + contact auto-fix),
+//   4. persists the message + updates the conversation,
+//   5. pauses any active Flow run for the contact (agent stepped in).
+//
+// It is transport-agnostic: it takes a `SupabaseClient` and an
+// `accountId` and throws `SendMessageError` on failure. The callers
+// own auth, rate-limiting, body parsing, and mapping the error to
+// their respective response shapes (internal `{ error }` vs the v1
+// envelope). Behaviour is identical to the original inline route —
+// this is a straight extraction so the public endpoint can reuse it
+// without duplicating ~250 lines of Meta plumbing.
+// ============================================================
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  sendTextMessage,
+  sendTemplateMessage,
+  sendMediaMessage,
+  type MediaKind,
+} from '@/lib/whatsapp/meta-api';
+import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption';
+import { supabaseAdmin } from '@/lib/flows/admin-client';
+import {
+  sanitizePhoneForMeta,
+  isValidE164,
+  phoneVariants,
+  isRecipientNotAllowedError,
+} from '@/lib/whatsapp/phone-utils';
+import type { MessageTemplate } from '@/types';
+import { isMessageTemplate } from '@/lib/whatsapp/template-row-guard';
+
+export const MEDIA_KINDS = ['image', 'video', 'document', 'audio'] as const;
+export const VALID_MESSAGE_TYPES = [
+  'text',
+  'template',
+  ...MEDIA_KINDS,
+] as const;
+
+/**
+ * Typed failure with a machine `code` and a suggested HTTP `status`.
+ * Callers map it to their own response shape (`toErrorResponse` for
+ * the dashboard route, the v1 envelope for the public endpoint).
+ */
+export class SendMessageError extends Error {
+  readonly code: string;
+  readonly status: number;
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.name = 'SendMessageError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface SendMessageParams {
+  conversationId: string;
+  messageType: string;
+  contentText?: string | null;
+  mediaUrl?: string | null;
+  filename?: string | null;
+  templateName?: string | null;
+  templateLanguage?: string | null;
+  /** Legacy positional body params (only used if messageParams.body unset). */
+  templateParams?: string[];
+  /** Structured template params (header/body/buttons). */
+  templateMessageParams?: unknown;
+  replyToMessageId?: string | null;
+}
+
+export interface SendMessageResult {
+  /** Our `messages.id` (the persisted row). */
+  messageId: string;
+  /** Meta's `wamid` for the delivered message. */
+  whatsappMessageId: string;
+}
+
+/**
+ * Send a message in an existing conversation and persist it.
+ *
+ * `db` may be an RLS-scoped user client (dashboard) or the service-
+ * role client (public API) — every query is filtered by `accountId`
+ * either way, so tenancy holds regardless of which client is passed.
+ */
+export async function sendMessageToConversation(
+  db: SupabaseClient,
+  accountId: string,
+  params: SendMessageParams
+): Promise<SendMessageResult> {
+  const {
+    conversationId,
+    messageType,
+    contentText,
+    mediaUrl,
+    filename,
+    templateName,
+    templateLanguage,
+    templateParams,
+    templateMessageParams,
+    replyToMessageId,
+  } = params;
+
+  if (!conversationId || !messageType) {
+    throw new SendMessageError(
+      'bad_request',
+      'conversation_id and message_type are required',
+      400
+    );
+  }
+
+  const isMediaKind = (MEDIA_KINDS as readonly string[]).includes(messageType);
+
+  if (!(VALID_MESSAGE_TYPES as readonly string[]).includes(messageType)) {
+    throw new SendMessageError(
+      'bad_request',
+      `Unsupported message_type "${messageType}"`,
+      400
+    );
+  }
+
+  if (messageType === 'text' && !contentText) {
+    throw new SendMessageError(
+      'bad_request',
+      'content_text is required for text messages',
+      400
+    );
+  }
+
+  if (messageType === 'template' && !templateName) {
+    throw new SendMessageError(
+      'bad_request',
+      'template_name is required for template messages',
+      400
+    );
+  }
+
+  if (isMediaKind && !mediaUrl) {
+    throw new SendMessageError(
+      'bad_request',
+      `media_url is required for ${messageType} messages`,
+      400
+    );
+  }
+
+  // Meta caps media captions at 1024 chars (audio carries none).
+  if (
+    isMediaKind &&
+    messageType !== 'audio' &&
+    typeof contentText === 'string' &&
+    contentText.length > 1024
+  ) {
+    throw new SendMessageError(
+      'bad_request',
+      'Caption exceeds the 1024-character limit',
+      400
+    );
+  }
+
+  // Conversation + contact, account-scoped.
+  const { data: conversation, error: convError } = await db
+    .from('conversations')
+    .select('*, contact:contacts(*)')
+    .eq('id', conversationId)
+    .eq('account_id', accountId)
+    .single();
+
+  if (convError || !conversation) {
+    throw new SendMessageError('not_found', 'Conversation not found', 404);
+  }
+
+  const contact = conversation.contact;
+  if (!contact?.phone) {
+    throw new SendMessageError(
+      'bad_request',
+      'Contact phone number not found',
+      400
+    );
+  }
+
+  const sanitizedPhone = sanitizePhoneForMeta(contact.phone);
+  if (!isValidE164(sanitizedPhone)) {
+    throw new SendMessageError(
+      'bad_request',
+      'Invalid phone number format',
+      400
+    );
+  }
+
+  // WhatsApp config, account-scoped.
+  const { data: config, error: configError } = await db
+    .from('whatsapp_config')
+    .select('*')
+    .eq('account_id', accountId)
+    .single();
+
+  if (configError || !config) {
+    throw new SendMessageError(
+      'whatsapp_not_configured',
+      'WhatsApp not configured. Please set up your WhatsApp integration first.',
+      400
+    );
+  }
+
+  const accessToken = decrypt(config.access_token);
+
+  // Self-heal legacy CBC ciphertexts. Fire-and-forget; idempotent.
+  if (isLegacyFormat(config.access_token)) {
+    void db
+      .from('whatsapp_config')
+      .update({ access_token: encrypt(accessToken) })
+      .eq('id', config.id)
+      .then(({ error }: { error: { message: string } | null }) => {
+        if (error) {
+          console.warn(
+            '[send-message] access_token GCM upgrade failed:',
+            error.message
+          );
+        }
+      });
+  }
+
+  // Resolve the reply target to its Meta message_id. The parent must
+  // belong to this same conversation — otherwise a caller could quote
+  // messages they can't see by guessing UUIDs.
+  let contextMessageId: string | undefined;
+  if (replyToMessageId) {
+    const { data: parent, error: parentError } = await db
+      .from('messages')
+      .select('message_id, conversation_id')
+      .eq('id', replyToMessageId)
+      .eq('conversation_id', conversationId)
+      .maybeSingle();
+
+    if (parentError || !parent) {
+      throw new SendMessageError(
+        'bad_request',
+        'reply_to_message_id not found in this conversation',
+        400
+      );
+    }
+    if (!parent.message_id) {
+      console.warn(
+        '[send-message] reply target has no Meta message_id; sending without context'
+      );
+    } else {
+      contextMessageId = parent.message_id;
+    }
+  }
+
+  // Template row (for header + button components). isMessageTemplate
+  // guards against a malformed local row crashing the send-builder.
+  let templateRow: MessageTemplate | null = null;
+  if (messageType === 'template' && templateName) {
+    const { data } = await db
+      .from('message_templates')
+      .select('*')
+      .eq('account_id', accountId)
+      .eq('name', templateName)
+      .eq('language', templateLanguage || 'en_US')
+      .maybeSingle();
+    if (data && !isMessageTemplate(data)) {
+      throw new SendMessageError(
+        'template_malformed',
+        'Template row is malformed locally — run "Sync from Meta" in Settings to repair it.',
+        500
+      );
+    }
+    templateRow = data ?? null;
+  }
+
+  const attempt = async (phone: string): Promise<string> => {
+    if (messageType === 'template') {
+      const result = await sendTemplateMessage({
+        phoneNumberId: config.phone_number_id,
+        accessToken,
+        to: phone,
+        templateName: templateName!,
+        language: templateLanguage || 'en_US',
+        template: templateRow ?? undefined,
+        messageParams: templateMessageParams ?? undefined,
+        params: templateParams || [],
+        contextMessageId,
+      });
+      return result.messageId;
+    }
+    if (isMediaKind) {
+      const result = await sendMediaMessage({
+        phoneNumberId: config.phone_number_id,
+        accessToken,
+        to: phone,
+        kind: messageType as MediaKind,
+        link: mediaUrl!,
+        caption: contentText || undefined,
+        filename: filename || undefined,
+        contextMessageId,
+      });
+      return result.messageId;
+    }
+    const result = await sendTextMessage({
+      phoneNumberId: config.phone_number_id,
+      accessToken,
+      to: phone,
+      text: contentText!,
+      contextMessageId,
+    });
+    return result.messageId;
+  };
+
+  // Send via Meta — retry across phone-number variants if Meta rejects
+  // with "recipient not in allowed list"; persist a working variant
+  // back to the contact so the next send goes straight through.
+  let waMessageId = '';
+  let workingPhone = sanitizedPhone;
+  try {
+    const variants = phoneVariants(sanitizedPhone);
+    let lastError: unknown = null;
+
+    for (const variant of variants) {
+      try {
+        waMessageId = await attempt(variant);
+        workingPhone = variant;
+        lastError = null;
+        break;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!isRecipientNotAllowedError(message)) {
+          throw err;
+        }
+        lastError = err;
+        console.warn(
+          `[send-message] variant "${variant}" rejected by Meta, trying next…`
+        );
+      }
+    }
+
+    if (lastError) throw lastError;
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Unknown Meta API error';
+    console.error('[send-message] Meta send failed for all variants:', message);
+    throw new SendMessageError('meta_error', `Meta API error: ${message}`, 502);
+  }
+
+  if (workingPhone !== sanitizedPhone) {
+    console.log(
+      `[send-message] Auto-corrected contact phone: ${sanitizedPhone} → ${workingPhone}`
+    );
+    await db
+      .from('contacts')
+      .update({ phone: workingPhone })
+      .eq('id', contact.id);
+  }
+
+  // Persist the sent message. Field names MUST match the messages
+  // schema (see 001_initial_schema.sql).
+  const { data: messageRecord, error: msgError } = await db
+    .from('messages')
+    .insert({
+      conversation_id: conversationId,
+      sender_type: 'agent',
+      content_type: messageType,
+      content_text: contentText || null,
+      media_url: mediaUrl || null,
+      template_name: templateName || null,
+      message_id: waMessageId,
+      status: 'sent',
+      reply_to_message_id: replyToMessageId || null,
+    })
+    .select()
+    .single();
+
+  if (msgError) {
+    console.error('[send-message] error inserting sent message:', msgError);
+    throw new SendMessageError(
+      'db_error',
+      `Message sent to Meta but failed to save to DB: ${msgError.message}`,
+      500
+    );
+  }
+
+  await db
+    .from('conversations')
+    .update({
+      last_message_text: contentText || `[${messageType}]`,
+      last_message_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', conversationId);
+
+  // Pause any active Flow run for this contact — the agent stepping in
+  // is the strongest "yield, human is here" signal. Best-effort.
+  try {
+    const { error: pauseErr } = await supabaseAdmin()
+      .from('flow_runs')
+      .update({
+        status: 'paused_by_agent',
+        ended_at: new Date().toISOString(),
+        end_reason: 'agent_replied',
+      })
+      .eq('account_id', accountId)
+      .eq('contact_id', contact.id)
+      .eq('status', 'active');
+    if (pauseErr) {
+      console.error('[flows] pause-on-agent-send failed:', pauseErr.message);
+    }
+  } catch (err) {
+    console.error(
+      '[flows] pause-on-agent-send threw:',
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  return { messageId: messageRecord.id, whatsappMessageId: waMessageId };
+}


### PR DESCRIPTION
## What & why

The first **data endpoint** on the public API (#245): send a WhatsApp message (text / template / media) to a phone number with a `messages:send`-scoped key. The caller passes an **E.164 number**, not an internal id — the endpoint finds-or-creates the contact + conversation, then sends.

> ⚠️ **Stacked on #290** — base is `feat/public-api-groundwork`, so this diff shows only the send-endpoint changes. **Merge #290 first**; GitHub will auto-retarget this to `main`.

## What's in it

- **Extracted the send core** out of `/api/whatsapp/send` into `src/lib/whatsapp/send-message.ts` (`sendMessageToConversation(db, accountId, params)`), throwing typed `SendMessageError`. Takes any `SupabaseClient` (RLS user client *or* service-role), always account-scoped. The dashboard route now **delegates** to it — behaviour unchanged (~370 → ~90 lines).
- **`src/lib/whatsapp/resolve-conversation.ts`** — E.164 phone → find-or-create contact + conversation, reusing the inbound webhook's dedupe helper and the `account_id`-tenancy / `user_id`-audit split (config owner as audit user), so an API-created contact is indistinguishable from a webhook-created one.
- **`POST /api/v1/messages`** route + a `fail(code, message, status)` envelope helper, mapping the send pipeline's codes (`bad_request`, `whatsapp_not_configured`, `meta_error`, …) onto the v1 envelope.
- Tests (+13): send-message param validation + resolve-conversation find/create/unique-race paths. Docs + CHANGELOG.

## API

```
POST /api/v1/messages
Authorization: Bearer wacrm_live_xxx
{ "to": "+14155550123", "type": "text", "text": "Hi 👋" }
→ 201 { "data": { message_id, whatsapp_message_id, conversation_id, contact_id, contact_created } }
```

Also supports `template` and media (`image`/`video`/`document`/`audio`) + `reply_to_message_id`. See `docs/public-api.md`.

## Checks

`typecheck` clean · `lint` 0 errors · full suite green (476 tests).

## Review notes

- The send-core extraction is **behaviour-preserving** — the dashboard route's contract is unchanged.
- Not yet exercised against a live Meta/Supabase (needs the migration from #290 + a connected WhatsApp number). The `curl` above is the smoke test; `meta_error` (502) = request reached Meta and it rejected the send.

Part of #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)