### PR TITLE
fix(webhook): process inbound WhatsApp messages in after() so they survive serverless freeze (#301)

### DIFF
--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextResponse, after } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption'
 import { getMediaUrl, downloadMedia } from '@/lib/whatsapp/meta-api'
@@ -11,6 +11,12 @@ import {
   handleTemplateWebhookChange,
   isTemplateWebhookField,
 } from '@/lib/whatsapp/template-webhook'
+
+// The `after()` callback in POST runs within this route's max duration.
+// Inbound processing can fan out to per-media Meta verification calls, so
+// give it headroom beyond the platform default (Vercel clamps this to the
+// plan's ceiling). Tune as needed.
+export const maxDuration = 60
 
 // Lazy-initialized to avoid build-time crash when env vars are missing
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -182,9 +188,26 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
   }
 
-  // Process asynchronously so we can ack Meta within their timeout.
-  processWebhook(body).catch((error) => {
-    console.error('Error processing webhook:', error)
+  // Process AFTER the response so we ack Meta within their ~20s timeout
+  // (a slow ack triggers Meta retries + duplicate inserts), while still
+  // guaranteeing the work runs to completion.
+  //
+  // This MUST use `after()` rather than a detached `processWebhook(body)`
+  // promise: on serverless platforms (we run on Vercel) the function can
+  // be frozen or terminated the moment the response is sent, so a floating
+  // promise's DB writes are not guaranteed to finish. That dropped a
+  // non-deterministic *subset* of inbound messages — contacts/conversations
+  // were created but the message insert never landed, leaving conversations
+  // that show in the inbox with an empty thread, and no logs to explain it
+  // (see issue #301). `after()` hands the callback to the runtime, which
+  // keeps the function alive until it resolves (within the route's
+  // maxDuration).
+  after(async () => {
+    try {
+      await processWebhook(body)
+    } catch (error) {
+      console.error('Error processing webhook:', error)
+    }
   })
 
   return NextResponse.json({ status: 'received' }, { status: 200 })


### PR DESCRIPTION
## Summary

Fixes #301 — inbox conversations showing empty and a subset of inbound customer messages never reaching the database.

### Root cause

The webhook `POST` handler ack'd Meta with `200` and then ran `processWebhook()` as a **detached promise**:

```ts
processWebhook(body).catch(...)
return NextResponse.json({ status: 'received' }, { status: 200 })
```

On Vercel (where this runs) a serverless function can be frozen or terminated the moment the response is sent, so the pending DB writes are not guaranteed to finish. Because `processMessage` writes in the order **contact → conversation → message**, a freeze mid-flight left the contact + conversation rows persisted but the message insert dropped — producing exactly the reported symptoms:

- **Issue 1:** conversations appear in the inbox (the list reads from `conversations`) but the thread is empty.
- **Issue 2:** a non-deterministic *subset* of messages missing from the DB, with no durable logs (the `console.*` calls inside the detached promise never flush either).

RLS was ruled out: migration 017 correctly scopes both the conversation list and the message thread via `is_account_member(...)`, so they stay consistent.

### Fix

Move the processing into Next.js `after()` (`next/server`), which keeps the function alive until the callback resolves — within the route's `maxDuration` — while still ack'ing Meta fast enough to avoid retry-driven duplicate inserts. Added `export const maxDuration = 60` for headroom, since processing can fan out to per-media Meta verification calls.

### Testing

- `tsc --noEmit` — clean
- `eslint` on the route — no new errors (one pre-existing unrelated `downloadMedia` unused warning)
- `vitest run` webhook-signature suite — 7 passing

### Follow-up (not in this PR)

The issue also asks for webhook observability ("no webhook logs available"). There's currently no persistent audit trail — every failure path only emits ephemeral `console.*`. A `webhook_logs` table (raw payload on receipt + processed/failed status) would make future incidents diagnosable. Happy to do this as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)