### PR TITLE
Protect existing contact names from WhatsApp profile name overwrites

### DIFF
--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -889,12 +889,30 @@ async function findOrCreateContact(
   )
 
   if (existingContact) {
-    // Update name if it changed
-    if (name && name !== existingContact.name) {
-      await supabaseAdmin()
+    // Protect names that already exist. A contact may have been created
+    // beforehand via the web form + n8n with the person's real name; the
+    // WhatsApp `profile.name` is just whatever display name / nickname the
+    // sender set on their phone and must never clobber that. We therefore
+    // only write the WhatsApp name when the existing contact has NO name
+    // yet (null / empty / whitespace) — i.e. we backfill, never overwrite.
+    const existingName =
+      typeof existingContact.name === 'string'
+        ? existingContact.name.trim()
+        : existingContact.name
+    const hasExistingName = !!existingName
+
+    if (!hasExistingName && name) {
+      const { error: updateError } = await supabaseAdmin()
         .from('contacts')
         .update({ name, updated_at: new Date().toISOString() })
         .eq('id', existingContact.id)
+      if (updateError) {
+        console.error('Error backfilling contact name:', updateError)
+      } else {
+        // Reflect the backfilled name on the in-memory row we return so
+        // downstream consumers see the value we just persisted.
+        existingContact.name = name
+      }
     }
     return { contact: existingContact, wasCreated: false }
   }


### PR DESCRIPTION
The inbound WhatsApp webhook was overwriting a contact's name with the sender's WhatsApp profile.name (their display nickname) whenever it differed. This clobbered real names set beforehand via the web form + n8n.

findOrCreateContact now only writes the WhatsApp name when the existing contact has no name yet (null / empty / whitespace) — backfilling rather than overwriting. New contacts still get the profile name as before.


Claude-Session: https://claude.ai/code/session_017gawnNSpEEbRZcg2Mmcnh9

<!--
Heads up: this is a template, not a collaborative product. Most
changes belong in your fork. See CONTRIBUTING.md for which kinds of
upstream PRs tend to land (security, correctness, docs) vs. which
belong in a fork (new features, stack swaps, opinionated refactors).
If you haven't opened an issue yet for a non-trivial change, consider
doing that first to check alignment.

Keep this short and specific. The commit message is where the "why"
lives; this is where the reviewer gets the "what" and "how to try it".
-->

## Summary

<!-- One or two sentences. What does this PR do? -->

## What changed

<!-- Bullet list of the actual changes. Link file paths when useful. -->

## Test plan

<!--
How did you verify this works? How should the reviewer verify it?
Tick the boxes as you go.
-->

- [ ] `npm run typecheck` clean.
- [ ] `npm run lint` — no new errors beyond the pre-existing backlog.
- [ ] `npm run build` succeeds.
- [ ] Feature / fix manually exercised in the browser (or the reason it can't be).

## Related

<!-- Link the issue this closes, or "Part of #N" for multi-PR work. -->

<!--
Heads up:
- Security issues: do not disclose here; see .github/SECURITY.md.
- New deps: please justify briefly in the commit message or PR body.
- Runtime behaviour changes affecting forkers: update docs/*.
-->
