### PR TITLE
fix(settings): preserve WhatsApp credential drafts

### DIFF
--- a/src/components/settings/whatsapp-config.tsx
+++ b/src/components/settings/whatsapp-config.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import {
   Eye,
@@ -53,6 +53,7 @@ export function WhatsAppConfig() {
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('unknown');
   const [resetReason, setResetReason] = useState<ResetReason>(null);
   const [statusMessage, setStatusMessage] = useState<string>('');
+  const loadedAccountIdRef = useRef<string | null>(null);
 
   const [phoneNumberId, setPhoneNumberId] = useState('');
   const [wabaId, setWabaId] = useState('');
@@ -164,9 +165,12 @@ export function WhatsAppConfig() {
     // once the profile arrives.
     if (authLoading || profileLoading) return;
     if (!user || !accountId) {
+      loadedAccountIdRef.current = null;
       setLoading(false);
       return;
     }
+    if (loadedAccountIdRef.current === accountId) return;
+    loadedAccountIdRef.current = accountId;
     fetchConfig(accountId);
   }, [authLoading, profileLoading, user, accountId, fetchConfig]);
 


### PR DESCRIPTION
## Summary

Keep unsaved WhatsApp credential fields from being overwritten when the browser tab regains focus.

## What changed

- Track the account id that has already loaded the WhatsApp config.
- Skip repeated same-account config hydration so auth/profile refreshes do not reset in-progress form input.
- Still allow explicit reloads after save or registration verification.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — no new errors beyond the pre-existing warning backlog.
- [x] `TZ=UTC npm test` passes.
- [x] `npm run build` succeeds.
- [ ] Browser repro not re-run here; this change is limited to the rehydration path that was resetting the controlled inputs.

## Related

Closes #307