### PR TITLE
fix(templates): scope template picker to account, not user

### DIFF
--- a/src/components/inbox/template-picker.tsx
+++ b/src/components/inbox/template-picker.tsx
@@ -104,10 +104,13 @@ export function TemplatePicker({
         return;
       }
 
+      // Scope by RLS (message_templates_select → is_account_member), NOT by
+      // user_id. Templates are account-owned, so filtering on the caller's
+      // user_id hid templates that a teammate created — leaving them unable
+      // to send approved templates in a shared account.
       const { data, error } = await supabase
         .from("message_templates")
         .select("*")
-        .eq("user_id", user.id)
         .eq("status", "APPROVED")
         .order("created_at", { ascending: false });
 


### PR DESCRIPTION
## Problem
The inbox/contact `TemplatePicker` (`src/components/inbox/template-picker.tsx`) fetched approved templates with `.eq("user_id", user.id)`. In a shared account (account-sharing, migration 017), a teammate only saw templates **they personally created** — templates created by other account members were hidden, so they couldn't send them. This affects both the Inbox composer and the new Contact-detail "Send template" flow that reuses this component.

## Fix
`message_templates` is account-owned and its RLS SELECT policy already scopes rows to account members (`is_account_member(account_id)`). The `user_id` filter was therefore redundant *and* over-restrictive. Removed it and rely on RLS — exactly what the broadcast template picker (`step1-choose-template.tsx`) already does.

## Verification
- eslint + typecheck clean on the changed file
- `npm test` → 476 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)