### PR TITLE
Prevent redundant profile fetches on refresh

### DIFF
--- a/src/components/settings/settings-overview.tsx
+++ b/src/components/settings/settings-overview.tsx
@@ -135,7 +135,7 @@ export function SettingsOverview({
     return () => {
       cancelled = true;
     };
-  }, [user, accountId, canManageMembers]);
+  }, [user?.id, accountId, canManageMembers]);
 
   const displayName = profile?.full_name || profile?.email || 'Your account';
   const initial = (profile?.full_name || profile?.email || 'U').charAt(0).toUpperCase();

--- a/src/components/settings/whatsapp-config.tsx
+++ b/src/components/settings/whatsapp-config.tsx
@@ -168,7 +168,7 @@ export function WhatsAppConfig() {
       return;
     }
     fetchConfig(accountId);
-  }, [authLoading, profileLoading, user, accountId, fetchConfig]);
+  }, [authLoading, profileLoading, user?.id, accountId, fetchConfig]);
 
   async function handleSave() {
     if (!phoneNumberId.trim()) {

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   useCallback,
   useMemo,
+  useRef,
   type ReactNode,
 } from "react";
 import { createClient } from "@/lib/supabase/client";
@@ -121,12 +122,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // window they're in — see the type doc above.
   const [profileLoading, setProfileLoading] = useState(true);
 
+  // Tracks the user ID we've successfully initiated/completed fetching
+  // a profile for. This prevents redundant re-fetches and toggling
+  // profileLoading back to true on window focus events/token refresh.
+  const lastFetchedUserIdRef = useRef<string | null>(null);
+
   // Shared across init, auth-state-change listener, and the exposed
   // refreshProfile() callback. Reads the current session's user id and
   // pulls the matching profile row along with its account summary.
   const fetchProfile = useCallback(async (userId: string) => {
     const supabase = createClient();
     setProfileLoading(true);
+    lastFetchedUserIdRef.current = userId;
     try {
       const { data, error } = await supabase
         .from("profiles")
@@ -143,6 +150,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           hint: error.hint,
           code: error.code,
         });
+        lastFetchedUserIdRef.current = null;
         return;
       }
 
@@ -206,9 +214,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           account_role: accountRole,
         });
         setAccount(accountRow);
+      } else {
+        lastFetchedUserIdRef.current = null;
       }
     } catch (err) {
       console.error("[AuthProvider] fetchProfile threw:", err);
+      lastFetchedUserIdRef.current = null;
     } finally {
       setProfileLoading(false);
     }
@@ -269,8 +280,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(currentUser);
 
       if (currentUser) {
-        fetchProfile(currentUser.id);
+        if (currentUser.id !== lastFetchedUserIdRef.current) {
+          fetchProfile(currentUser.id);
+        }
       } else {
+        lastFetchedUserIdRef.current = null;
         setProfile(null);
         setAccount(null);
         setProfileLoading(false);


### PR DESCRIPTION
### Summary
This PR prevents redundant user profile fetches, loading state resets, and form state resets when navigating settings tabs, refocusing the browser tab, or during auto-token-refreshes.

### Problem
1. Supabase's `onAuthStateChange` listener checks the session and fires on window focus/token refresh.
2. In `use-auth.tsx`, this callback was triggering `fetchProfile` unconditionally, toggling `profileLoading` from `false` -> `true` -> `false` even if the user ID remained the same.
3. This toggle of `profileLoading` caused dependent setting panels (like `<WhatsAppConfig />` and `<SettingsOverview />`) to unmount/remount, show loading spinners, and re-fetch config from database/Meta APIs, which cleared any unsaved user-typed input state.

### Solution
1. **AuthProvider Refactoring (`use-auth.tsx`)**: Introduced a `lastFetchedUserIdRef` to track the user ID for which a profile fetch has been initiated. We now check `currentUser.id !== lastFetchedUserIdRef.current` inside the `onAuthStateChange` callback before calling `fetchProfile`.
2. **Stable Dependents (`whatsapp-config.tsx` and `settings-overview.tsx`)**: Replaced the `user` object in their `useEffect` dependency arrays with the stable `user?.id` string, ensuring they are immune to user object identity changes.

### Verification
- Manual verification on local server (`npm run dev`) shows form inputs and layout states are preserved when switching browser tabs.
- Ran type-checks (`npx tsc --noEmit`) and unit tests successfully.
