### PR TITLE
fix(settings): preserve WhatsApp credential drafts on tab refocus

### DIFF
--- a/src/components/settings/whatsapp-config.tsx
+++ b/src/components/settings/whatsapp-config.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import {
   Eye,
@@ -53,6 +53,13 @@ export function WhatsAppConfig() {
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('unknown');
   const [resetReason, setResetReason] = useState<ResetReason>(null);
   const [statusMessage, setStatusMessage] = useState<string>('');
+  // Guards against re-hydrating the form when the load effect below
+  // re-runs for reasons unrelated to actually switching accounts —
+  // e.g. Supabase's onAuthStateChange fires a token refresh (new
+  // `user` object, profileLoading flips true/false) when the browser
+  // tab regains focus. Without this, that churn calls fetchConfig()
+  // again and overwrites whatever the user typed but hadn't saved yet.
+  const loadedAccountIdRef = useRef<string | null>(null);
 
   const [phoneNumberId, setPhoneNumberId] = useState('');
   const [wabaId, setWabaId] = useState('');
@@ -164,9 +171,12 @@ export function WhatsAppConfig() {
     // once the profile arrives.
     if (authLoading || profileLoading) return;
     if (!user || !accountId) {
+      loadedAccountIdRef.current = null;
       setLoading(false);
       return;
     }
+    if (loadedAccountIdRef.current === accountId) return;
+    loadedAccountIdRef.current = accountId;
     fetchConfig(accountId);
   }, [authLoading, profileLoading, user, accountId, fetchConfig]);
 


### PR DESCRIPTION
## Summary

Fixes #307 — unsaved WhatsApp credential fields were being wiped when the browser tab regained focus (easy to hit while copying Meta credentials from another tab).

## Root cause

`WhatsAppConfig`'s load effect re-runs `fetchConfig(accountId)` — which overwrites the form's local state with the DB values — whenever `user` or `profileLoading` change. Supabase's `onAuthStateChange` listener (in `use-auth.tsx`) fires a token-refresh event when the tab regains focus, creating a new `user` object and toggling `profileLoading`, even though the signed-in account hasn't changed. That churn re-triggers the effect and stomps whatever the user typed but hadn't saved.

## What changed

- Added a `loadedAccountIdRef` guard so the load effect only calls `fetchConfig` once per distinct `accountId`, ignoring auth-state churn that doesn't actually change the account.
- Reset the ref when the user/account clears, so a genuine account switch (or sign-out/in) reloads correctly.
- Explicit reload paths — after save, registration verification, and reset — call `fetchConfig` directly and are unaffected.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings on the changed file
- [x] `npm test` — all 477 tests pass

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)