### PR TITLE
feat(kanban): customer journey funnel board + dashboard metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# supabase CLI local cache
+supabase/.temp

--- a/docs/uazapi-integration-plan.md
+++ b/docs/uazapi-integration-plan.md
@@ -1,0 +1,290 @@
+# Plano de Integração: Uazapi como segundo provedor de WhatsApp
+
+## Objetivo
+
+Adicionar a Uazapi (API não-oficial, conexão via QR code) como um **segundo
+provedor** de WhatsApp, coexistindo com a API Oficial (Meta Cloud API) já
+implementada. Uma conta poderá ter uma conexão Meta, uma conexão Uazapi, ou
+ambas simultaneamente. Todas as funcionalidades do sistema (inbox, dashboard,
+automações, flows, broadcasts, API pública v1, webhooks de saída) devem
+funcionar com qualquer provedor.
+
+## Decisões confirmadas com o usuário
+
+- **Escopo do MVP**: implementar primeiro as Fases 1-4 (schema, abstração de
+  provider, conexão via QR, envio/recebimento de texto e mídia). Automações,
+  Flows, broadcasts, backfill de histórico e API v1 (Fases 5-9) ficam para uma
+  segunda etapa, depois que o MVP estiver validado ponta a ponta.
+- **Provider padrão para outbound novo**: quando uma conta tiver Meta e
+  Uazapi conectados simultaneamente, **Uazapi é o canal padrão** para
+  mensagens novas (broadcast a contato frio, automação disparando para quem
+  nunca conversou). Meta só é usado quando a conversa já pertence a ela ou é
+  explicitamente escolhida.
+- **Mídia inbound da Uazapi**: usar o mesmo padrão de **proxy on-demand** já
+  usado para a Meta (`/api/whatsapp/media/:id`) — criar um equivalente
+  `/api/uazapi/media/:id` que chama `POST /message/download` sob demanda ao
+  carregar o inbox, em vez de subir a mídia para o Supabase Storage no
+  momento do recebimento. Sem armazenamento duplicado, mas depende da mídia
+  continuar acessível na Uazapi.
+- **Multi-tenant**: esta é uma **capability geral do produto**, não uma
+  customização de uma conta específica. Qualquer conta poderá conectar uma
+  instância Uazapi pelas Configurações, então o design de schema/RLS deve
+  tratar isso desde o início (sem hardcode de account_id).
+
+## Estado atual (baseline)
+
+- `whatsapp_config` é **1:1 com `account_id`** (`UNIQUE(account_id)`) —
+  hoje só existe espaço para uma conexão por conta.
+- As chamadas à Meta estão **hardcoded em 4 lugares**, sem nenhuma
+  abstração de provedor:
+  1. `src/lib/whatsapp/send-message.ts` — envio a partir do inbox / API v1.
+  2. `src/lib/automations/meta-send.ts` — passos `send_message` / `send_template` das automações.
+  3. `src/lib/flows/meta-send.ts` — nós do bot conversacional (texto, mídia, botões, listas).
+  4. `src/app/api/v1/broadcasts/route.ts` (`deliverBroadcast`) — disparo de campanhas.
+- O recebimento é feito em `src/app/api/whatsapp/webhook/route.ts` — handshake
+  `GET` (challenge com `verify_token`) + `POST` (HMAC `x-hub-signature-256`),
+  que faz find-or-create de contact/conversation, insere `messages`, atualiza
+  `broadcast_recipients`, dispara `automations`, `flows` e webhooks de saída.
+- **As tabelas core (`contacts`, `conversations`, `messages`, `broadcasts`,
+  etc.) já são agnósticas de provedor.** `messages.message_id` é um campo
+  genérico de texto — hoje guarda o `wamid` da Meta, mas não há nada que
+  impeça guardar o ID da Uazapi. **O dashboard lê essas tabelas diretamente
+  e não precisa de nenhuma mudança** — uma vez que mensagens Uazapi
+  entrem/saiam pelas mesmas tabelas, o dashboard "é alimentado pela Uazapi"
+  automaticamente.
+- Criptografia: AES-256-GCM (`src/lib/whatsapp/encryption.ts`) já usada para
+  `access_token` e `verify_token` — deve ser reutilizada para o token da
+  Uazapi.
+
+## Decisão arquitetural central: `WhatsAppProvider`
+
+Criar uma interface única em `src/lib/whatsapp/provider.ts`:
+
+```ts
+interface WhatsAppProvider {
+  sendText(params): Promise<{ externalMessageId: string }>
+  sendMedia(params): Promise<{ externalMessageId: string }>
+  sendTemplate(params): Promise<{ externalMessageId: string }> // Meta: template real; Uazapi: fallback texto
+  sendInteractive(params): Promise<{ externalMessageId: string }> // botões/listas
+  downloadMedia(params): Promise<{ url: string }>
+}
+```
+
+Duas implementações — `src/lib/whatsapp/providers/meta.ts` (wrapper do atual
+`meta-api.ts`) e `src/lib/whatsapp/providers/uazapi.ts` (novo) — resolvidas
+por uma factory `getProvider(config)` a partir da linha de
+`whatsapp_config` (ou tabela renomeada, ver schema abaixo).
+
+Os **4 call-sites acima** passam a chamar `provider.sendX()` em vez de
+`sendTextMessage()`/`sendMediaMessage()`/`sendTemplateMessage()` da Meta
+diretamente. Isso é o núcleo do trabalho — sem isso, cada nova funcionalidade
+continuaria acoplada à Meta.
+
+## Mudanças de schema
+
+### 1. `whatsapp_config` → múltiplos providers por conta
+
+Hoje: `UNIQUE(account_id)`. Precisa virar `UNIQUE(account_id, provider)`.
+
+```sql
+ALTER TABLE whatsapp_config
+  ADD COLUMN provider TEXT NOT NULL DEFAULT 'meta' CHECK (provider IN ('meta', 'uazapi'));
+
+ALTER TABLE whatsapp_config DROP CONSTRAINT whatsapp_config_account_id_key;
+ALTER TABLE whatsapp_config ADD CONSTRAINT whatsapp_config_account_provider_key UNIQUE (account_id, provider);
+
+-- Colunas Uazapi-específicas (ficam NULL para linhas provider='meta')
+ALTER TABLE whatsapp_config
+  ADD COLUMN uazapi_instance_token TEXT,       -- encrypted, AES-256-GCM
+  ADD COLUMN uazapi_base_url TEXT,             -- ex: https://nuvtex.uazapi.com (default do servidor)
+  ADD COLUMN uazapi_instance_name TEXT,
+  ADD COLUMN uazapi_connection_status TEXT,    -- 'disconnected' | 'connecting' | 'connected'
+  ADD COLUMN uazapi_last_qr_at TIMESTAMPTZ,
+  ADD COLUMN uazapi_connected_at TIMESTAMPTZ;
+```
+
+`phone_number_id` continua `UNIQUE` mas passa a ser `UNIQUE` parcial (só
+aplicável a `provider='meta'`), já que Uazapi não tem esse campo.
+
+### 2. Coluna de roteamento — `conversations.provider`
+
+Este é o ponto crítico apontado na revisão: **uma conversa precisa saber
+qual provedor a "possui"**, senão `sendMessageToConversation` não tem como
+decidir se chama Meta ou Uazapi.
+
+```sql
+ALTER TABLE conversations
+  ADD COLUMN provider TEXT NOT NULL DEFAULT 'meta' CHECK (provider IN ('meta', 'uazapi'));
+ALTER TABLE messages
+  ADD COLUMN provider TEXT CHECK (provider IN ('meta', 'uazapi'));
+```
+
+Regras de roteamento:
+- **Inbound**: o webhook de cada provedor estampa `provider` na conversa (na
+  criação) e na mensagem.
+- **Outbound em conversa existente**: lê `conversations.provider` — nunca
+  ambíguo.
+- **Outbound novo (broadcast, automação disparando para contato "frio",
+  primeira mensagem via API v1 por telefone)**: usa um provider padrão por
+  conta. **Decisão**: o padrão é `uazapi` quando a conta tiver as duas
+  conexões ativas (Meta só é usado para conversas que já pertencem a ela ou
+  quando explicitamente selecionado). Implementar como coluna
+  `whatsapp_config.is_default` (uma linha marcada `true` por conta) — a
+  linha Uazapi recebe `is_default = true` automaticamente ao conectar, se
+  não houver Meta já marcada como padrão. Se a conta tiver apenas um
+  provedor conectado, esse é o padrão implícito.
+
+### 3. Diferenças de capacidades — precisa estar explícito em código, não só na doc
+
+| Recurso | Meta | Uazapi | Tratamento |
+|---|---|---|---|
+| Templates aprovados / janela 24h | Sim | **Não existe** | `sendTemplate()` no provider Uazapi renderiza o template como texto simples e envia via `/send/text` (ou `/send/media` se tiver header de mídia). Passos `send_template` de automação/flow continuam funcionando, só sem restrição de janela. |
+| Botões / listas interativas | `interactive.button_reply`/`list_reply` | `POST /send/menu` (`button`/`list`/`poll`) | `sendInteractive()` mapeia o formato dos nós de Flow para o `choices` da Uazapi. Cuidado: Uazapi mistura reply-buttons com call/url/copy só com aviso de incompatibilidade web — mapear 1:1 quando possível. |
+| Registro/conexão | `register` + `subscribed_apps`, permanente | Login via QR feito **fora do wacrm**, direto no painel da Uazapi; sessão pode cair | wacrm só anexa o token e monitora `GET /instance/status` (leitura); nunca dispara o pareamento. Ver Fase 2. |
+| ID da mensagem | `wamid` simples | `owner:messageid` — formato composto obrigatório para reply/react/delete/pin | Persistir sempre o ID completo retornado pela Uazapi em `messages.message_id`/`external_message_id`. |
+| Download de mídia inbound | Meta entrega media ID, buscamos URL sob demanda via proxy | Uazapi exige `POST /message/download` explícito | **Decisão**: mesmo padrão de proxy on-demand já usado para a Meta. Novo endpoint `/api/uazapi/media/[messageId]/route.ts`, análogo a `/api/whatsapp/media/[id]`, que chama `provider.downloadMedia()` (→ `POST /message/download`) a cada request do inbox, sem persistir a mídia no Supabase Storage. `messages.media_url` guarda essa URL de proxy interna, igual ao fluxo Meta atual. |
+| Handshake de webhook | `GET` com `hub.verify_token` + `POST` HMAC | **Não existe handshake `GET`** | Endpoint Uazapi só implementa `POST`; autenticação por token de instância no payload (ver abaixo). |
+
+### 4. Autenticação do webhook Uazapi
+
+**Decisão final (validada contra a implementação de referência
+`modelo-agente-de-ia`, que já funciona em produção)**: endpoint **único e
+global** `POST /api/uazapi/webhook` — sem `configId` nem secret na URL.
+A Uazapi ecoa o `token` da própria instância no corpo de cada webhook
+(`{ instanceName, token, chat, message }`); o handler decripta e compara
+esse `token` contra `uazapi_instance_token` de cada linha
+`whatsapp_config` com `provider='uazapi'` (fallback: casar por
+`instanceName`). Isso elimina a necessidade de registrar uma URL
+diferente por instância — todas as contas apontam para a mesma URL.
+
+O scan é O(n) sobre as contas Uazapi conectadas (poucas nesta fase);
+revisitar com uma coluna indexada se isso deixar de ser verdade.
+
+## Novos módulos / arquivos
+
+```
+src/lib/whatsapp/
+  provider.ts                 # interface WhatsAppProvider + factory getProvider()
+  providers/
+    meta.ts                   # wrapper fino sobre meta-api.ts existente
+    uazapi.ts                 # novo client HTTP: send/text, send/media, send/menu,
+                               #   message/download, message/presence, instance/*
+  uazapi-instance.ts           # gestão de ciclo de vida: create/connect/status/disconnect
+
+src/app/api/uazapi/
+  webhook/route.ts             # POST — endpoint único e global; resolve a instância pelo token ecoado no payload
+  instance/route.ts            # POST attach token (valida via GET status + configura webhook), GET status, DELETE (remove credenciais salvas)
+  backfill/route.ts            # POST — dispara backfill inicial (ver fase 6)
+
+supabase/migrations/
+  0XX_uazapi_provider_support.sql   # schema descrito acima
+```
+
+## Fases de implementação
+
+> **Escopo do MVP (decisão confirmada)**: implementar e validar ponta a
+> ponta as **Fases 1-4** primeiro (schema, provider, conexão/QR, envio e
+> recebimento de texto/mídia). As Fases 5-9 (paridade de automações/flows,
+> broadcasts, backfill de histórico, API pública v1, UI de seleção de
+> provider em campanhas) ficam para depois — o objetivo do MVP é ter uma
+> conversa completa (enviar, receber, aparecer no inbox e no dashboard)
+> funcionando com Uazapi, coexistindo com Meta.
+
+### Fase 1 — Schema + abstração de provider (sem UI ainda)
+1. Migration: `whatsapp_config.provider`, colunas Uazapi, `UNIQUE(account_id, provider)`, `conversations.provider`, `messages.provider`.
+2. Criar `WhatsAppProvider` interface e `providers/meta.ts` (só encapsula o que já existe — **zero mudança de comportamento para contas Meta**).
+3. Criar `providers/uazapi.ts` com os métodos: `sendText`, `sendMedia`, `sendTemplate` (→ texto), `sendInteractive` (→ `/send/menu`), `downloadMedia` (→ `/message/download`), `reactToMessage`, `markRead`.
+4. `getProvider(configRow)` factory.
+
+### Fase 2 — Anexar instância Uazapi (sem QR)
+
+> **Decisão confirmada**: o wacrm **não gerencia o ciclo de vida da
+> sessão WhatsApp da Uazapi de forma alguma** — nem cria a instância
+> (`POST /instance/create`), nem faz o pareamento por QR
+> (`POST /instance/connect`), nem desconecta a sessão
+> (`POST /instance/disconnect`). Tudo isso é feito **diretamente no
+> painel da Uazapi** pelo usuário/operador. O papel do wacrm se limita
+> a: (1) receber e guardar as credenciais (token de instância), e
+> (2) receber mensagens via webhook que a Uazapi chama. Isso elimina a
+> dependência de `UAZAPI_ADMIN_TOKEN` e qualquer UI de QR code.
+
+1. UI em Configurações: card "Uazapi connection" ao lado da conexão Meta existente, com campos **Instance token** (obrigatório), **Base URL** (opcional, default `https://nuvtex.uazapi.com`) e **Instance name** (opcional).
+2. Fluxo: usuário loga a instância no WhatsApp direto no painel da Uazapi → cola o token no wacrm → `POST /api/uazapi/instance` valida via `GET /instance/status` (só leitura, nunca `/instance/connect`) → grava `uazapi_instance_token` (encriptado) → configura o webhook (`POST /webhook`) apontando para a URL global `/api/uazapi/webhook` (mesma para todas as instâncias/contas).
+3. Estado exibido na UI: **Connected** (sessão logada — mostra nome da instância, base URL, conectado desde), **Token attached but not logged into WhatsApp** (token válido mas sessão não logada — orienta o usuário a logar no painel da Uazapi e clicar em "Refresh status"), ou **Not connected** (nenhum token anexado ainda).
+4. "Detach" (`DELETE /api/uazapi/instance`) apenas remove as credenciais salvas no wacrm — **não** desloga a sessão WhatsApp na Uazapi (isso é gerenciado externamente).
+
+### Fase 3 — Envio (outbound)
+1. Reescrever os 4 call-sites para usar `provider.sendX()`:
+   - `send-message.ts` — resolve provider a partir de `conversations.provider` (ou da config, se `provider` ainda não setado na conversa legada — default `meta`).
+   - `automations/meta-send.ts` → renomear para `automations/provider-send.ts`, resolvendo provider por contato/conversa.
+   - `flows/meta-send.ts` → idem, `flows/provider-send.ts`. Mapear nós `send_buttons`/`send_list` para `sendInteractive()`.
+   - `broadcasts` (`deliverBroadcast`) — cada broadcast roda contra **um provider só** (escolhido na criação da campanha, já que templates só existem de fato na Meta); para Uazapi, broadcast usa texto/mídia livre. Antes de disparar campanha em massa via Uazapi, checar `GET /instance/wa_messages_limits` — risco de ban por ser API não-oficial; expor esse limite na UI de campanha.
+2. Manter a lógica de phone-variant retry só para Meta (não é um problema conhecido da Uazapi, mas manter a validação E.164/sanitização comum).
+
+### Fase 4 — Recebimento (inbound)
+1. Handler global `/api/uazapi/webhook/route.ts` (uma única URL, sem `configId`/secret):
+   - Resolve a instância decriptando `uazapi_instance_token` de cada linha `provider='uazapi'` e comparando com o `token` ecoado no payload (fallback: `instanceName`).
+   - Parseia payload flat `{ instanceName, token, chat, message }` — formato confirmado contra a implementação de referência (`modelo-agente-de-ia`), não o `{event, instance, data}` da doc da skill.
+   - Reaproveita `findExistingContact`/dedupe existentes (agnóstico de provider).
+   - `findOrCreateContact` / `findOrCreateConversation` — estampando `provider='uazapi'` na criação da conversation.
+   - Mapeia tipos de mensagem Uazapi → `content_type` permitido (mesmo `ALLOWED_CONTENT_TYPES` já existente).
+   - Para mídia: chama `provider.downloadMedia()` e persiste URL (storage ou proxy).
+   - Dispara os mesmos `runAutomationsForTrigger`, `dispatchInboundToFlows`, `dispatchWebhookEvent` já usados pelo webhook Meta — **nenhuma automação/flow precisa saber de qual provider veio a mensagem**, elas operam sobre `contact_id`/`conversation_id`.
+2. Extrair a lógica comum de `processMessage` do webhook Meta (find-or-create contact/conversation, disparo de automations/flows/outbound-webhooks) para um helper compartilhado `src/lib/whatsapp/inbound-dispatch.ts`, chamado pelos dois handlers de webhook — evita duplicar ~150 linhas de lógica de negócio entre Meta e Uazapi.
+3. Status de mensagem: Uazapi não tem exatamente a mesma escada de status da Meta (webhook de `messages` não separa status como a Meta faz); mapear o que a Uazapi expõe (evento `messages` com `ack`/status, se disponível) para o mesmo `messages.status`/`broadcast_recipients` — verificar payload real via `uazapi search-docs`.
+
+### Fase 5 — Automações e Flows (paridade de capacidades)
+1. Passo `send_template` (automations/flows): quando o provider ativo é Uazapi, renderiza o corpo do template como texto simples (sem variáveis de aprovação Meta) via `provider.sendTemplate()`.
+2. Nós `send_buttons`/`send_list` do Flow: `sendInteractive()` traduz para `/send/menu` (`type: button|list`), preservando IDs para que `interactive_reply_id` continue funcionando igual ao fluxo Meta.
+3. `http_fetch` e outros nós agnósticos: sem mudança.
+
+### Fase 6 — Backfill inicial (o "dashboard alimentado pela Uazapi" além do live)
+Diferente do handshake Meta, ao conectar uma instância Uazapi que já tem
+histórico de conversas no WhatsApp, vale trazer esse histórico para o CRM:
+1. Endpoint `POST /api/uazapi/backfill` (ou automático pós-conexão):
+   - `POST /chat/find` — lista chats existentes.
+   - `POST /contacts/list` — contatos.
+   - `POST /message/find` por chat — últimas N mensagens.
+2. Faz upsert em `contacts`/`conversations`/`messages` (marcando `provider='uazapi'`, `sender_type` inferido por `fromMe`).
+3. Roda em background (job assíncrono, não bloqueia a UI de conexão) — importante logar contagem de itens importados e falhas parciais.
+
+### Fase 7 — API pública v1 e webhooks de saída
+1. `src/app/api/v1/messages` — ao enviar por telefone (`resolveConversationByPhone`), se a conversa ainda não existir, decide provider pelo default da conta; resposta inclui `provider` usado.
+2. `src/app/api/v1/broadcasts` — permite indicar `provider` na criação (obrigatório se a conta tem os dois conectados).
+3. Payloads de webhook de saída (`message.received`, `message.status_updated`, `conversation.created`) passam a incluir `provider` no payload — consumidores externos que hoje assumem Meta continuam funcionando (campo novo, não-breaking).
+4. Documentar em `docs/public-api.md`.
+
+### Fase 8 — UI / Configurações
+1. Tela de Configurações mostra duas seções: "WhatsApp Oficial (Meta)" (existente) e "WhatsApp via Uazapi" (nova) — cada uma com seu próprio status de conexão.
+2. Inbox: badge discreto por conversa indicando o provider (ícone), útil quando os dois estão ativos.
+3. Criação de Broadcast/Automação: seletor de provider quando a conta tiver mais de um conectado.
+
+### Fase 9 — Testes e rollout
+1. Testes unitários do provider Uazapi (mock HTTP) — igual ao padrão de testes já existente para `meta-api.ts` (verificar `vitest.config.ts`).
+2. Teste manual ponta a ponta: conectar instância de teste, enviar/receber texto, mídia, botão/lista, verificar dashboard e automações.
+3. Feature flag por conta (`accounts.uazapi_enabled` ou similar) para rollout gradual antes de expor a todos os clientes.
+4. Monitorar `wa_messages_limits` e taxa de erro do provider Uazapi nos logs — é API não-oficial, risco de ban da instância deve ser comunicado ao usuário na UI (aviso ao configurar).
+
+## Riscos e avisos a comunicar ao usuário final
+
+- Uazapi é **API não-oficial** (conexão via sessão WhatsApp Web) — risco de
+  bloqueio de número em uso excessivo/bulk sending. Checar
+  `GET /instance/wa_messages_limits` antes de campanhas e expor isso na UI.
+- Sessões Uazapi podem cair (logout remoto, troca de celular). Como o wacrm
+  não gerencia o pareamento, a UI mostra um alerta "token anexado mas não
+  logado no WhatsApp" e orienta o usuário a resolver **direto no painel da
+  Uazapi**, depois clicar em "Refresh status" — não é "configure uma vez e
+  esqueça" como a Meta.
+- Templates aprovados e a janela de 24h só existem na Meta — comunicar essa
+  diferença ao usuário ao escolher provider para campanhas.
+
+## Resumo do que muda vs. o que não muda
+
+- **Não muda**: schema das tabelas core (`contacts`, `messages`,
+  `conversations`, `broadcasts`, `automations`, `flows`) além das colunas
+  `provider` aditivas; queries do dashboard; engine de automações/flows
+  (agnósticos de provider); criptografia AES-256-GCM (reutilizada).
+- **Muda**: `whatsapp_config` (multi-provider), os 4 call-sites de envio
+  (via `WhatsAppProvider`), novo webhook `/api/uazapi/webhook`, novo cliente
+  HTTP Uazapi, UI de conexão/configuração, roteamento por
+  `conversations.provider`.

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -9,11 +9,15 @@ import {
   UserPlus,
   DollarSign,
   Send,
+  Filter,
+  Clock,
+  TrendingUp,
 } from 'lucide-react'
 
 import {
   loadActivity,
   loadConversationsSeries,
+  loadFunnelMetrics,
   loadMetrics,
   loadPipelineDonut,
   loadResponseTime,
@@ -21,6 +25,7 @@ import {
 import type {
   ActivityItem,
   ConversationsSeriesPoint,
+  FunnelMetricsBundle,
   MetricsBundle,
   PipelineDonutData,
   ResponseTimeSummary,
@@ -40,6 +45,9 @@ export default function DashboardPage() {
   const { defaultCurrency } = useAuth()
   const [metrics, setMetrics] = useState<MetricsBundle | null>(null)
   const [metricsLoading, setMetricsLoading] = useState(true)
+
+  const [funnelMetrics, setFunnelMetrics] = useState<FunnelMetricsBundle | null>(null)
+  const [funnelMetricsLoading, setFunnelMetricsLoading] = useState(true)
 
   const [range, setRange] = useState<RangeDays>(30)
   // Keep a cache per range so switching tabs doesn't re-fetch what we
@@ -71,6 +79,11 @@ export default function DashboardPage() {
       .then((m) => setMetrics(m))
       .catch((err) => console.error('[dashboard] metrics failed:', err))
       .finally(() => setMetricsLoading(false))
+
+    void loadFunnelMetrics(db)
+      .then((m) => setFunnelMetrics(m))
+      .catch((err) => console.error('[dashboard] funnel metrics failed:', err))
+      .finally(() => setFunnelMetricsLoading(false))
 
     void loadConversationsSeries(db, 30)
       .then((s) => setSeries((prev) => ({ ...prev, 30: s })))
@@ -177,6 +190,50 @@ export default function DashboardPage() {
             />
           </>
         )}
+      </div>
+
+      {/* Customer journey funnel (Kanban) */}
+      <div>
+        <h2 className="mb-3 text-sm font-semibold text-foreground">Customer Journey Funnel</h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {funnelMetricsLoading || !funnelMetrics ? (
+            Array.from({ length: 3 }).map((_, i) => <SkeletonCard key={i} />)
+          ) : (
+            <>
+              <MetricCard
+                title="New Leads Today"
+                value={funnelMetrics.newLeadsToday.current.toLocaleString()}
+                icon={Filter}
+                delta={{
+                  sign:
+                    funnelMetrics.newLeadsToday.current - funnelMetrics.newLeadsToday.previous,
+                  label: deltaLabel(
+                    funnelMetrics.newLeadsToday.current - funnelMetrics.newLeadsToday.previous,
+                    'vs yesterday',
+                  ),
+                }}
+              />
+              <MetricCard
+                title="Stalled Leads"
+                value={funnelMetrics.stalledLeads.toLocaleString()}
+                icon={Clock}
+                subtitle="In the same stage 3+ days"
+              />
+              <MetricCard
+                title="Lead → Customer Rate"
+                value={
+                  funnelMetrics.leadConversionRate === null
+                    ? '—'
+                    : `${funnelMetrics.leadConversionRate.toFixed(0)}%`
+                }
+                icon={TrendingUp}
+                subtitle={`${funnelMetrics.leadConversionCohortSize} lead${
+                  funnelMetrics.leadConversionCohortSize === 1 ? '' : 's'
+                } in the last 30 days`}
+              />
+            </>
+          )}
+        </div>
       </div>
 
       {/* Quick actions */}

--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -387,6 +387,25 @@ export default function InboxPage() {
     setResyncToken((n) => n + 1);
   }, []);
 
+  /**
+   * "New conversation" just sent the first message to a phone number
+   * with no prior history — deep-link into it the same way clicking a
+   * dashboard "recent conversations" row does: set `?c=`, then bump
+   * resyncToken so ConversationList refetches and picks up the new
+   * row. handleConversationsLoaded's existing deep-link check auto-
+   * selects it once that refetch lands, so no separate select call is
+   * needed here — and it stays correct even if the realtime INSERT for
+   * this same conversation arrives first or last.
+   */
+  const handleConversationCreated = useCallback(
+    (conversationId: string) => {
+      autoSelectedForDeepLinkRef.current = null;
+      router.replace(`/inbox?c=${conversationId}`, { scroll: false });
+      setResyncToken((n) => n + 1);
+    },
+    [router]
+  );
+
   const handleConversationsLoaded = useCallback(
     (loaded: Conversation[]) => {
       setConversations(loaded);
@@ -577,6 +596,7 @@ export default function InboxPage() {
             conversations={conversations}
             onConversationsLoaded={handleConversationsLoaded}
             resyncToken={resyncToken}
+            onConversationCreated={handleConversationCreated}
           />
         </div>
 

--- a/src/app/(dashboard)/kanban/page.tsx
+++ b/src/app/(dashboard)/kanban/page.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { ContactJourney, FunnelStage } from "@/types";
+import { ensureFunnelStages } from "@/lib/journey/funnel-stages";
+import { KanbanBoard } from "@/components/kanban/kanban-board";
+import { LeadDetailSheet } from "@/components/kanban/lead-detail-sheet";
+import { AddLeadForm } from "@/components/kanban/add-lead-form";
+import { GatedButton } from "@/components/ui/gated-button";
+import { Filter, Plus } from "lucide-react";
+import { toast } from "sonner";
+import { useCan } from "@/hooks/use-can";
+import { useAuth } from "@/hooks/use-auth";
+
+export default function KanbanPage() {
+  const supabase = createClient();
+  const canAddLead = useCan("send-messages");
+  const { accountId } = useAuth();
+
+  const [stages, setStages] = useState<FunnelStage[]>([]);
+  const [journeys, setJourneys] = useState<ContactJourney[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [addLeadOpen, setAddLeadOpen] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [selectedJourney, setSelectedJourney] = useState<ContactJourney | null>(null);
+
+  // Guard against double-seeding (React StrictMode double-effect in dev).
+  const seedAttempted = useRef(false);
+
+  const loadStages = useCallback(async (): Promise<FunnelStage[]> => {
+    if (!accountId) return [];
+    const rows = await ensureFunnelStages(supabase, accountId);
+    return rows as FunnelStage[];
+  }, [supabase, accountId]);
+
+  // Journeys + their contact/stage, plus each contact's conversation
+  // preview attached in JS (see ContactJourney.conversation — no DB
+  // join because conversations.contact_id has no unique constraint).
+  const loadJourneys = useCallback(async (): Promise<ContactJourney[]> => {
+    if (!accountId) return [];
+    const { data: journeyRows, error } = await supabase
+      .from("contact_journey")
+      .select("*, contact:contacts(*), stage:funnel_stages(*)")
+      .eq("account_id", accountId)
+      .order("entered_stage_at", { ascending: false });
+    if (error) {
+      console.error("Failed to load journeys:", error.message);
+      return [];
+    }
+    const rows = (journeyRows ?? []) as ContactJourney[];
+    if (rows.length === 0) return rows;
+
+    const contactIds = rows.map((r) => r.contact_id);
+    const { data: conversations } = await supabase
+      .from("conversations")
+      .select("id, contact_id, last_message_text, last_message_at")
+      .in("contact_id", contactIds);
+
+    const convByContact = new Map(
+      (conversations ?? []).map((c) => [c.contact_id, c]),
+    );
+    return rows.map((r) => ({
+      ...r,
+      conversation: convByContact.get(r.contact_id),
+    }));
+  }, [supabase, accountId]);
+
+  // Initial load + seed-if-empty
+  useEffect(() => {
+    if (!accountId) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      let stageList = await loadStages();
+
+      if (stageList.length === 0 && !seedAttempted.current) {
+        seedAttempted.current = true;
+        stageList = await loadStages();
+      }
+
+      const journeyList = await loadJourneys();
+      if (cancelled) return;
+      setStages(stageList);
+      setJourneys(journeyList);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [accountId, loadStages, loadJourneys]);
+
+  const refreshJourneys = useCallback(async () => {
+    setJourneys(await loadJourneys());
+  }, [loadJourneys]);
+
+  const createDealForJourney = useCallback(
+    async (journey: ContactJourney) => {
+      if (!accountId) return;
+      const { data: pipeline } = await supabase
+        .from("pipelines")
+        .select("id")
+        .eq("account_id", accountId)
+        .order("created_at")
+        .limit(1)
+        .maybeSingle();
+      if (!pipeline) {
+        toast.error("No pipeline found — create one in Pipelines first");
+        return;
+      }
+      const { data: firstStage } = await supabase
+        .from("pipeline_stages")
+        .select("id")
+        .eq("pipeline_id", pipeline.id)
+        .order("position")
+        .limit(1)
+        .maybeSingle();
+      if (!firstStage) {
+        toast.error("Selected pipeline has no stages");
+        return;
+      }
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const user = session?.user;
+      if (!user) return;
+
+      const contactLabel = journey.contact?.name || journey.contact?.phone || "Lead";
+      const { error } = await supabase.from("deals").insert({
+        user_id: user.id,
+        account_id: accountId,
+        pipeline_id: pipeline.id,
+        stage_id: firstStage.id,
+        contact_id: journey.contact_id,
+        title: `${contactLabel} — opportunity`,
+        value: 0,
+      });
+      if (error) {
+        toast.error("Failed to create deal");
+        return;
+      }
+      toast.success("Deal created in Pipelines");
+    },
+    [supabase, accountId],
+  );
+
+  const handleJourneyMoved = useCallback(
+    async (journeyId: string, newStageId: string) => {
+      const journey = journeys.find((j) => j.id === journeyId);
+      if (!journey || journey.stage_id === newStageId) return;
+
+      // Optimistic update — board already animated; just persist.
+      setJourneys((prev) =>
+        prev.map((j) =>
+          j.id === journeyId
+            ? { ...j, stage_id: newStageId, entered_stage_at: new Date().toISOString() }
+            : j,
+        ),
+      );
+      setSelectedJourney((prev) =>
+        prev && prev.id === journeyId ? { ...prev, stage_id: newStageId } : prev,
+      );
+
+      const { error } = await supabase
+        .from("contact_journey")
+        .update({ stage_id: newStageId, entered_stage_at: new Date().toISOString() })
+        .eq("id", journeyId);
+
+      if (error) {
+        toast.error("Failed to move lead");
+        refreshJourneys();
+        return;
+      }
+
+      await supabase.from("contact_journey_transitions").insert({
+        contact_journey_id: journeyId,
+        account_id: journey.account_id,
+        from_stage_id: journey.stage_id,
+        to_stage_id: newStageId,
+      });
+
+      // Convenience bridge to the Pipeline board: entering "Negotiating"
+      // is usually the point a real opportunity exists. Not required or
+      // kept in sync afterwards — just a one-time offer to save a
+      // context switch.
+      const targetStage = stages.find((s) => s.id === newStageId);
+      if (targetStage?.key === "negotiating") {
+        toast("Lead is negotiating", {
+          description: "Create an opportunity for this lead in Pipelines?",
+          action: {
+            label: "Create Deal",
+            onClick: () => createDealForJourney(journey),
+          },
+        });
+      }
+    },
+    [supabase, journeys, stages, refreshJourneys, createDealForJourney],
+  );
+
+  const handleOpenJourney = useCallback((journey: ContactJourney) => {
+    setSelectedJourney(journey);
+    setDetailOpen(true);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="h-8 w-48 animate-pulse rounded bg-muted" />
+          <div className="h-9 w-28 animate-pulse rounded-lg bg-muted" />
+        </div>
+        <div className="flex gap-3">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="h-96 w-72 animate-pulse rounded-xl bg-muted/50" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Filter className="h-4 w-4 text-primary" />
+          <h1 className="text-lg font-semibold text-foreground">Kanban</h1>
+          <span className="text-sm text-muted-foreground">
+            Customer journey — from first message to customer
+          </span>
+        </div>
+
+        <GatedButton
+          canAct={canAddLead}
+          gateReason="add leads"
+          onClick={() => setAddLeadOpen(true)}
+          className="bg-primary text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Add Lead
+        </GatedButton>
+      </div>
+
+      {/* Board */}
+      <KanbanBoard
+        stages={stages}
+        journeys={journeys}
+        onJourneyMoved={handleJourneyMoved}
+        onOpenJourney={handleOpenJourney}
+      />
+
+      <LeadDetailSheet
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        journey={selectedJourney}
+        stages={stages}
+        onMoved={handleJourneyMoved}
+      />
+
+      <AddLeadForm
+        open={addLeadOpen}
+        onOpenChange={setAddLeadOpen}
+        stages={stages}
+        existingContactIds={new Set(journeys.map((j) => j.contact_id))}
+        onCreated={refreshJourneys}
+      />
+    </div>
+  );
+}

--- a/src/app/api/uazapi/instance/route.ts
+++ b/src/app/api/uazapi/instance/route.ts
@@ -1,0 +1,308 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { encrypt, decrypt } from '@/lib/whatsapp/encryption'
+import { getInstanceStatus, configureWebhook } from '@/lib/whatsapp/uazapi-instance'
+
+const DEFAULT_BASE_URL = process.env.UAZAPI_BASE_URL || 'https://nuvtex.uazapi.com'
+
+/**
+ * Resolve the caller's account_id from their profile — same helper
+ * shape as `/api/whatsapp/config` (kept separate to avoid coupling
+ * the two provider routes together).
+ */
+async function resolveAccountId(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('account_id')
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (error || !data?.account_id) return null
+  return data.account_id as string
+}
+
+/**
+ * Single global webhook URL — every instance across every account
+ * points here. Uazapi echoes the instance's own token back in each
+ * delivery, which the webhook route matches against the encrypted
+ * token on file; there's no per-instance path or query secret to
+ * construct (see src/app/api/uazapi/webhook/route.ts).
+ */
+function webhookUrl(): string {
+  const site = process.env.NEXT_PUBLIC_SITE_URL?.trim().replace(/\/+$/, '')
+  if (!site) {
+    throw new Error(
+      'NEXT_PUBLIC_SITE_URL must be set to register a Uazapi webhook (Uazapi needs an absolute, publicly reachable URL).'
+    )
+  }
+  return `${site}/api/uazapi/webhook`
+}
+
+/**
+ * GET /api/uazapi/instance
+ *
+ * Reports the saved instance's live status (as seen by Uazapi) and
+ * metadata — purely informational, shown in Settings.
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const accountId = await resolveAccountId(supabase, user.id)
+    if (!accountId) {
+      return NextResponse.json(
+        { connected: false, reason: 'no_account', message: 'Your profile is not linked to an account.' },
+        { status: 200 },
+      )
+    }
+
+    const { data: config } = await supabase
+      .from('whatsapp_config')
+      .select('*')
+      .eq('account_id', accountId)
+      .eq('provider', 'uazapi')
+      .maybeSingle()
+
+    if (!config?.uazapi_instance_token) {
+      return NextResponse.json({ connected: false, reason: 'no_config' })
+    }
+
+    const baseUrl = config.uazapi_base_url || DEFAULT_BASE_URL
+
+    try {
+      const status = await getInstanceStatus({
+        baseUrl,
+        instanceToken: decrypt(config.uazapi_instance_token),
+      })
+
+      const newStatus = status.connected && status.loggedIn ? 'connected' : 'disconnected'
+      if (newStatus !== config.status) {
+        await supabase
+          .from('whatsapp_config')
+          .update({
+            uazapi_connection_status: newStatus,
+            status: newStatus,
+            connected_at: newStatus === 'connected' ? (config.connected_at ?? new Date().toISOString()) : null,
+            uazapi_connected_at: newStatus === 'connected' ? (config.uazapi_connected_at ?? new Date().toISOString()) : null,
+          })
+          .eq('id', config.id)
+      }
+
+      return NextResponse.json({
+        connected: status.connected,
+        loggedIn: status.loggedIn,
+        instance_name: config.uazapi_instance_name,
+        base_url: baseUrl,
+        connected_at: newStatus === 'connected' ? (config.uazapi_connected_at ?? new Date().toISOString()) : null,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown Uazapi API error'
+      return NextResponse.json({
+        connected: false,
+        reason: 'uazapi_api_error',
+        message,
+        instance_name: config.uazapi_instance_name,
+        base_url: baseUrl,
+      })
+    }
+  } catch (error) {
+    console.error('Error in Uazapi instance GET:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/uazapi/instance
+ *
+ * Attaches wacrm to a Uazapi instance token. The instance itself is
+ * created AND logged into WhatsApp entirely outside wacrm (directly
+ * in the Uazapi panel) — this route only:
+ *   1. verifies the token is valid (GET /instance/status),
+ *   2. saves it (encrypted) so outbound sends can use it,
+ *   3. registers our webhook URL so Uazapi calls us on inbound events.
+ * No QR code, no pairing flow — wacrm never drives the WhatsApp
+ * session lifecycle.
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const accountId = await resolveAccountId(supabase, user.id)
+    if (!accountId) {
+      return NextResponse.json({ error: 'Your profile is not linked to an account.' }, { status: 403 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const instanceToken: string | undefined = body.instance_token?.trim() || undefined
+    const baseUrl: string = body.base_url?.trim() || DEFAULT_BASE_URL
+    const instanceName: string | undefined = body.instance_name?.trim() || undefined
+
+    if (!instanceToken) {
+      return NextResponse.json(
+        { error: 'instance_token is required — create and log in the instance in the Uazapi panel first, then paste its token here.' },
+        { status: 400 },
+      )
+    }
+
+    // Verify the token actually works before saving anything, same
+    // principle as Meta's verifyPhoneNumber-before-save in
+    // /api/whatsapp/config.
+    let status
+    try {
+      status = await getInstanceStatus({ baseUrl, instanceToken })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown Uazapi API error'
+      return NextResponse.json(
+        { error: `Could not verify that instance token against ${baseUrl}: ${message}` },
+        { status: 400 },
+      )
+    }
+
+    const { data: existing } = await supabase
+      .from('whatsapp_config')
+      .select('*')
+      .eq('account_id', accountId)
+      .eq('provider', 'uazapi')
+      .maybeSingle()
+
+    const connected = status.connected && status.loggedIn
+    const connectionStatus = connected ? 'connected' : 'disconnected'
+    const nowIso = new Date().toISOString()
+
+    let configId: string
+    if (existing) {
+      configId = existing.id
+      const { error: updateError } = await supabase
+        .from('whatsapp_config')
+        .update({
+          uazapi_instance_token: encrypt(instanceToken),
+          uazapi_base_url: baseUrl,
+          uazapi_instance_name: instanceName ?? existing.uazapi_instance_name,
+          uazapi_connection_status: connectionStatus,
+          status: connectionStatus,
+          connected_at: connected ? nowIso : null,
+          uazapi_connected_at: connected ? nowIso : null,
+        })
+        .eq('id', configId)
+      if (updateError) {
+        console.error('Error updating Uazapi whatsapp_config:', updateError)
+        return NextResponse.json({ error: 'Failed to save Uazapi configuration' }, { status: 500 })
+      }
+    } else {
+      // First Uazapi connection for this account steals the default
+      // outbound slot from an existing Meta row, per the confirmed
+      // decision (Uazapi is the default provider whenever it's present).
+      const { data: metaConfig } = await supabase
+        .from('whatsapp_config')
+        .select('id')
+        .eq('account_id', accountId)
+        .eq('provider', 'meta')
+        .eq('is_default', true)
+        .maybeSingle()
+      if (metaConfig) {
+        await supabase.from('whatsapp_config').update({ is_default: false }).eq('id', metaConfig.id)
+      }
+
+      const { data: inserted, error: insertError } = await supabase
+        .from('whatsapp_config')
+        .insert({
+          account_id: accountId,
+          user_id: user.id,
+          provider: 'uazapi',
+          uazapi_instance_token: encrypt(instanceToken),
+          uazapi_base_url: baseUrl,
+          uazapi_instance_name: instanceName ?? null,
+          uazapi_connection_status: connectionStatus,
+          is_default: true,
+          status: connectionStatus,
+          connected_at: connected ? nowIso : null,
+          uazapi_connected_at: connected ? nowIso : null,
+        })
+        .select('id')
+        .single()
+
+      if (insertError || !inserted) {
+        console.error('Error inserting Uazapi whatsapp_config:', insertError)
+        return NextResponse.json({ error: 'Failed to save Uazapi configuration' }, { status: 500 })
+      }
+      configId = inserted.id
+    }
+
+    // Best-effort — the webhook needs a stable public URL, which only
+    // exists once NEXT_PUBLIC_SITE_URL is configured. A failure here
+    // doesn't block saving the credentials; the user just needs to
+    // retry once the env var is set (surfaced via `webhook_configured: false`).
+    let webhookConfigured = false
+    try {
+      await configureWebhook({
+        baseUrl,
+        instanceToken,
+        url: webhookUrl(),
+        events: ['messages', 'connection'],
+      })
+      webhookConfigured = true
+    } catch (err) {
+      console.warn('[uazapi/instance] webhook configuration failed:', err instanceof Error ? err.message : err)
+    }
+
+    return NextResponse.json({
+      connected,
+      loggedIn: connected,
+      instance_name: instanceName ?? existing?.uazapi_instance_name ?? null,
+      base_url: baseUrl,
+      webhook_configured: webhookConfigured,
+    })
+  } catch (error) {
+    console.error('Error in Uazapi instance POST:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE /api/uazapi/instance
+ *
+ * Detaches wacrm from the instance — removes the saved credentials so
+ * wacrm stops sending/receiving through it. Does NOT touch the actual
+ * Uazapi instance or its WhatsApp session (no `/instance/disconnect`
+ * call) — that lifecycle is entirely managed in the Uazapi panel.
+ */
+export async function DELETE() {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const accountId = await resolveAccountId(supabase, user.id)
+    if (!accountId) {
+      return NextResponse.json({ error: 'Your profile is not linked to an account.' }, { status: 403 })
+    }
+
+    const { error: deleteError } = await supabase
+      .from('whatsapp_config')
+      .delete()
+      .eq('account_id', accountId)
+      .eq('provider', 'uazapi')
+
+    if (deleteError) {
+      console.error('Error deleting Uazapi whatsapp_config:', deleteError)
+      return NextResponse.json({ error: 'Failed to delete configuration' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error in Uazapi instance DELETE:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/uazapi/media/[messageId]/route.ts
+++ b/src/app/api/uazapi/media/[messageId]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getProviderFromConfig, type WhatsAppConfigRow } from '@/lib/whatsapp/providers/factory'
+
+/**
+ * On-demand media proxy for Uazapi, mirroring
+ * `/api/whatsapp/media/[mediaId]` for Meta. `messageId` is the full
+ * `owner:messageid` externalMessageId returned when the message was
+ * received — Uazapi has no persistent CDN URL, so every fetch re-runs
+ * `POST /message/download`.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ messageId: string }> }
+) {
+  try {
+    const { messageId } = await params
+    if (!messageId) {
+      return NextResponse.json({ error: 'Message ID is required' }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('account_id')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    const accountId = profile?.account_id as string | undefined
+    if (!accountId) {
+      return NextResponse.json({ error: 'Your profile is not linked to an account.' }, { status: 403 })
+    }
+
+    const { data: config, error: configError } = await supabase
+      .from('whatsapp_config')
+      .select('*')
+      .eq('account_id', accountId)
+      .eq('provider', 'uazapi')
+      .single()
+
+    if (configError || !config) {
+      return NextResponse.json({ error: 'Uazapi not configured' }, { status: 400 })
+    }
+
+    const provider = getProviderFromConfig(config as WhatsAppConfigRow)
+    // decodeURIComponent — the `owner:messageid` id is passed URL-encoded
+    // by the media_url stored on the message row (see the inbound
+    // webhook, which builds `/api/uazapi/media/${encodeURIComponent(id)}`).
+    const { buffer, contentType } = await provider.downloadMedia({
+      mediaRef: decodeURIComponent(messageId),
+    })
+
+    return new Response(new Uint8Array(buffer), {
+      status: 200,
+      headers: {
+        'Content-Type': contentType || 'application/octet-stream',
+        // Shorter than Meta's proxy cache — re-downloading from Uazapi
+        // is cheap and this avoids serving a stale error response
+        // indefinitely if the first fetch raced a not-yet-synced media.
+        'Cache-Control': 'private, max-age=3600',
+      },
+    })
+  } catch (error) {
+    console.error('Error in Uazapi media GET:', error)
+    return NextResponse.json({ error: 'Failed to fetch media' }, { status: 500 })
+  }
+}

--- a/src/app/api/uazapi/webhook/route.ts
+++ b/src/app/api/uazapi/webhook/route.ts
@@ -6,6 +6,7 @@ import { findExistingContact, isUniqueViolation } from '@/lib/contacts/dedupe'
 import { runAutomationsForTrigger } from '@/lib/automations/engine'
 import { dispatchInboundToFlows } from '@/lib/flows/engine'
 import { dispatchWebhookEvent } from '@/lib/webhooks/deliver'
+import { enterFunnelIfNew } from '@/lib/journey/enter-funnel'
 
 // Mirrors the Meta webhook route's maxDuration — inbound processing can
 // fan out to a media download + automations/flows dispatch.
@@ -344,6 +345,13 @@ async function processInbound(accountId: string, configOwnerUserId: string, body
         conversation_id: conversation.id,
       },
     }).catch((err) => console.error('[uazapi-webhook] automations dispatch failed:', err))
+  }
+
+  // Sales-funnel Kanban entry point — see the Meta webhook's identical
+  // hook for the full rationale. Idempotent; failures are logged inside
+  // and never throw.
+  if (isFirstInboundMessage) {
+    await enterFunnelIfNew(db, accountId, contactId)
   }
 
   await dispatchWebhookEvent(db, accountId, 'message.received', {

--- a/src/app/api/uazapi/webhook/route.ts
+++ b/src/app/api/uazapi/webhook/route.ts
@@ -81,10 +81,34 @@ function normalizeInbound(body: any): NormalizedInbound | null {
   if (!msg) return null
   const chat = body?.chat ?? {}
 
-  const chatid: string = msg.chatid || msg.sender_pn || msg.sender || ''
-  const senderPhoneRaw: string = msg.sender || msg.sender_pn || chatid.split('@')[0] || ''
-  let fromPhone = normalizePhone(senderPhoneRaw || chatid)
+  // WhatsApp has been migrating chats to `@lid` (a privacy-preserving
+  // "linked ID") instead of the phone-number-based `@s.whatsapp.net`
+  // JID. When that happens, `chatid`/`sender` carry the LID (a numeric
+  // string that looks like a phone number but isn't one — see issue
+  // where a reply created a duplicate contact whose "phone" was a LID
+  // and every outbound send to it then failed with "not on WhatsApp").
+  // `sender_pn` is Uazapi's dedicated phone-number field and must be
+  // preferred whenever present; `chatid`/`sender` are LID-safe
+  // fallbacks only for group-detection and for the (rare) delivery
+  // that has no `sender_pn` at all.
+  const chatid: string = msg.chatid || msg.sender || ''
+  const senderPhoneRaw: string = msg.sender_pn || msg.sender || chatid.split('@')[0] || ''
+  let fromPhone = normalizePhone(senderPhoneRaw)
   if (!fromPhone) fromPhone = normalizePhone(chat.phone || '')
+
+  // TEMP DIAGNOSTIC — remove once the LID-vs-phone field mapping above
+  // is confirmed against a few real deliveries. Only fires when there's
+  // no dedicated phone field to fall back on, so the happy path stays
+  // silent.
+  if (!msg.sender_pn) {
+    console.warn('[uazapi-webhook] no sender_pn on inbound message — raw fields:', {
+      chatid: msg.chatid,
+      sender: msg.sender,
+      sender_pn: msg.sender_pn,
+      chat_phone: chat.phone,
+      resolved_fromPhone: fromPhone,
+    })
+  }
   if (!fromPhone) return null
 
   const isGroup = Boolean(msg.isGroup ?? chat.wa_isGroup ?? chatid.includes('@g.us'))

--- a/src/app/api/uazapi/webhook/route.ts
+++ b/src/app/api/uazapi/webhook/route.ts
@@ -1,0 +1,332 @@
+import { NextResponse, after } from 'next/server'
+import { supabaseAdmin } from '@/lib/flows/admin-client'
+import { decrypt } from '@/lib/whatsapp/encryption'
+import { normalizePhone } from '@/lib/whatsapp/phone-utils'
+import { findExistingContact, isUniqueViolation } from '@/lib/contacts/dedupe'
+import { runAutomationsForTrigger } from '@/lib/automations/engine'
+import { dispatchInboundToFlows } from '@/lib/flows/engine'
+import { dispatchWebhookEvent } from '@/lib/webhooks/deliver'
+
+// Mirrors the Meta webhook route's maxDuration — inbound processing can
+// fan out to a media download + automations/flows dispatch.
+export const maxDuration = 60
+
+/**
+ * Single global endpoint — every Uazapi instance across every account
+ * points here (see /api/uazapi/instance → configureWebhook). There's
+ * no per-instance path or query-string secret; instead, Uazapi echoes
+ * the instance's own `token` back in every webhook payload, and that
+ * token is the credential — matched here against the encrypted
+ * `uazapi_instance_token` on file. This mirrors the working pattern
+ * from the reference implementation (modelo-agente-de-ia's
+ * `/webhook/uazapi`), which resolves the instance the same way.
+ *
+ * Uazapi accounts are few relative to Meta ones at this stage, so a
+ * linear decrypt-and-compare over `provider='uazapi'` rows is cheap;
+ * revisit (e.g. a keyed lookup column) if that stops being true.
+ */
+async function resolveConfigByToken(payloadToken: string | undefined, instanceName: string | undefined) {
+  const db = supabaseAdmin()
+  const { data: configs } = await db
+    .from('whatsapp_config')
+    .select('*')
+    .eq('provider', 'uazapi')
+    .not('uazapi_instance_token', 'is', null)
+
+  if (!configs || configs.length === 0) return null
+
+  if (payloadToken) {
+    for (const config of configs) {
+      try {
+        if (decrypt(config.uazapi_instance_token) === payloadToken) return config
+      } catch {
+        // Malformed/undecryptable row — skip it and keep checking others.
+      }
+    }
+  }
+
+  // Fallback — payload's instanceName label, in case the token round-trip
+  // ever fails (Uazapi always includes it too, per the documented shape).
+  if (instanceName) {
+    const byName = configs.find((c) => c.uazapi_instance_name === instanceName)
+    if (byName) return byName
+  }
+
+  return null
+}
+
+/**
+ * Uazapi's real webhook payload (confirmed against a working reference
+ * implementation) is flat: `{ instanceName, token, chat: {...}, message: {...} }`.
+ * `message.type` is often the generic `"media"` with the real kind in
+ * `message.mediaType` (ptt/audio/image/...); text-like values
+ * (text/chat/conversation/extendedTextMessage) mean plain text.
+ */
+interface NormalizedInbound {
+  externalId: string
+  fromPhone: string
+  senderName: string
+  isGroup: boolean
+  fromMe: boolean
+  type: string
+  text: string | null
+  timestampMs: number
+}
+
+const TEXT_LIKE_TYPES = new Set(['text', 'chat', 'conversation', 'extendedtextmessage'])
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeInbound(body: any): NormalizedInbound | null {
+  const msg = body?.message
+  if (!msg) return null
+  const chat = body?.chat ?? {}
+
+  const chatid: string = msg.chatid || msg.sender_pn || msg.sender || ''
+  const senderPhoneRaw: string = msg.sender || msg.sender_pn || chatid.split('@')[0] || ''
+  let fromPhone = normalizePhone(senderPhoneRaw || chatid)
+  if (!fromPhone) fromPhone = normalizePhone(chat.phone || '')
+  if (!fromPhone) return null
+
+  const isGroup = Boolean(msg.isGroup ?? chat.wa_isGroup ?? chatid.includes('@g.us'))
+  const fromMe = Boolean(msg.fromMe)
+
+  const rawType: string = (msg.type || '').toLowerCase()
+  const mediaType: string = (msg.mediaType || '').toLowerCase()
+  const type = TEXT_LIKE_TYPES.has(rawType) ? 'text' : mediaType || rawType || 'text'
+
+  const text: string | null = msg.text ?? msg.body ?? msg.content ?? msg.caption ?? null
+  const timestampRaw = msg.timestamp ?? msg.messageTimestamp
+  const timestampMs =
+    typeof timestampRaw === 'number'
+      ? (timestampRaw > 1e12 ? timestampRaw : timestampRaw * 1000)
+      : Date.now()
+
+  return {
+    externalId: msg.messageid || msg.id || '',
+    fromPhone,
+    senderName: chat.name || msg.senderName || fromPhone,
+    isGroup,
+    fromMe,
+    type,
+    text,
+    timestampMs,
+  }
+}
+
+const ALLOWED_CONTENT_TYPES = new Set([
+  'text', 'image', 'document', 'audio', 'video', 'location', 'template', 'interactive',
+])
+
+function mapContentType(uazapiType: string): string {
+  if (ALLOWED_CONTENT_TYPES.has(uazapiType)) return uazapiType
+  if (uazapiType === 'sticker') return 'image'
+  if (uazapiType === 'ptt' || uazapiType === 'myaudio') return 'audio'
+  return 'text'
+}
+
+export async function POST(request: Request) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const payload = body as { token?: string; instanceName?: string } | null
+  const config = await resolveConfigByToken(payload?.token, payload?.instanceName)
+  if (!config) {
+    console.warn('[uazapi-webhook] no matching instance for token/instanceName', {
+      instanceName: payload?.instanceName,
+    })
+    // 200, not 401 — an unrecognized token is most likely a stale/rotated
+    // instance rather than an attack, and Uazapi has no retry-on-4xx
+    // guarantee we want to rely on; swallow it quietly like the message-
+    // type skip branches below.
+    return NextResponse.json({ status: 'unrecognized_instance' }, { status: 200 })
+  }
+
+  // Ack immediately; process after the response is sent (same rationale
+  // as the Meta webhook — see src/app/api/whatsapp/webhook/route.ts).
+  after(async () => {
+    try {
+      await processInbound(config.account_id, config.user_id, body)
+    } catch (error) {
+      console.error('[uazapi-webhook] error processing inbound:', error)
+    }
+  })
+
+  return NextResponse.json({ status: 'received' }, { status: 200 })
+}
+
+async function processInbound(accountId: string, configOwnerUserId: string, body: unknown) {
+  const inbound = normalizeInbound(body)
+  if (!inbound) return
+
+  // Groups and our own outbound echoes are not customer messages.
+  if (inbound.isGroup || inbound.fromMe) return
+
+  const db = supabaseAdmin()
+
+  const existingContact = await findExistingContact(db, accountId, inbound.fromPhone)
+  let contactId: string
+  let wasCreated = false
+
+  if (existingContact) {
+    contactId = existingContact.id
+    if (inbound.senderName && inbound.senderName !== existingContact.name) {
+      await db
+        .from('contacts')
+        .update({ name: inbound.senderName, updated_at: new Date().toISOString() })
+        .eq('id', contactId)
+    }
+  } else {
+    const { data: newContact, error: createError } = await db
+      .from('contacts')
+      .insert({
+        account_id: accountId,
+        user_id: configOwnerUserId,
+        phone: inbound.fromPhone,
+        name: inbound.senderName || inbound.fromPhone,
+      })
+      .select()
+      .single()
+
+    if (createError) {
+      if (isUniqueViolation(createError)) {
+        const raced = await findExistingContact(db, accountId, inbound.fromPhone)
+        if (!raced) return
+        contactId = raced.id
+      } else {
+        console.error('[uazapi-webhook] error creating contact:', createError)
+        return
+      }
+    } else {
+      contactId = newContact.id
+      wasCreated = true
+    }
+  }
+
+  // One conversation per (account, contact) regardless of provider —
+  // matches the Meta webhook's lookup. `provider` is stamped only at
+  // creation time; an existing conversation keeps whichever provider
+  // opened it.
+  const { data: existingConv } = await db
+    .from('conversations')
+    .select('*')
+    .eq('account_id', accountId)
+    .eq('contact_id', contactId)
+    .maybeSingle()
+
+  let conversation = existingConv
+  let conversationCreated = false
+  if (!conversation) {
+    const { data: newConv, error: convError } = await db
+      .from('conversations')
+      .insert({
+        account_id: accountId,
+        user_id: configOwnerUserId,
+        contact_id: contactId,
+        provider: 'uazapi',
+      })
+      .select()
+      .single()
+    if (convError || !newConv) {
+      console.error('[uazapi-webhook] error creating conversation:', convError)
+      return
+    }
+    conversation = newConv
+    conversationCreated = true
+  }
+
+  if (conversationCreated) {
+    await dispatchWebhookEvent(db, accountId, 'conversation.created', {
+      conversation_id: conversation.id,
+      contact_id: contactId,
+    })
+  }
+
+  const contentType = mapContentType(inbound.type)
+  const isMediaKind = ['image', 'video', 'document', 'audio'].includes(contentType)
+  const mediaUrl = isMediaKind && inbound.externalId
+    ? `/api/uazapi/media/${encodeURIComponent(inbound.externalId)}`
+    : null
+
+  const { count: priorCustomerMsgCount } = await db
+    .from('messages')
+    .select('id', { count: 'exact', head: true })
+    .eq('conversation_id', conversation.id)
+    .eq('sender_type', 'customer')
+  const isFirstInboundMessage = (priorCustomerMsgCount ?? 0) === 0
+
+  const { error: msgError } = await db.from('messages').insert({
+    conversation_id: conversation.id,
+    sender_type: 'customer',
+    content_type: contentType,
+    content_text: inbound.text,
+    media_url: mediaUrl,
+    message_id: inbound.externalId || null,
+    status: 'delivered',
+    created_at: new Date(inbound.timestampMs).toISOString(),
+    provider: 'uazapi',
+  })
+
+  if (msgError) {
+    console.error('[uazapi-webhook] error inserting message:', msgError)
+    return
+  }
+
+  await db
+    .from('conversations')
+    .update({
+      last_message_text: inbound.text || `[${contentType}]`,
+      last_message_at: new Date().toISOString(),
+      unread_count: (conversation.unread_count || 0) + 1,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', conversation.id)
+
+  const flowResult = await dispatchInboundToFlows({
+    accountId,
+    userId: configOwnerUserId,
+    contactId,
+    conversationId: conversation.id,
+    message: {
+      kind: 'text',
+      text: inbound.text ?? '',
+      meta_message_id: inbound.externalId,
+    },
+    isFirstInboundMessage,
+  })
+  const flowConsumed = flowResult.consumed
+
+  const automationTriggers: (
+    | 'new_contact_created'
+    | 'first_inbound_message'
+    | 'new_message_received'
+    | 'keyword_match'
+  )[] = []
+  if (!flowConsumed) {
+    automationTriggers.push('new_message_received', 'keyword_match')
+  }
+  if (wasCreated) automationTriggers.unshift('new_contact_created')
+  if (isFirstInboundMessage) automationTriggers.unshift('first_inbound_message')
+  for (const triggerType of automationTriggers) {
+    runAutomationsForTrigger({
+      accountId,
+      triggerType,
+      contactId,
+      context: {
+        message_text: inbound.text ?? '',
+        conversation_id: conversation.id,
+      },
+    }).catch((err) => console.error('[uazapi-webhook] automations dispatch failed:', err))
+  }
+
+  await dispatchWebhookEvent(db, accountId, 'message.received', {
+    conversation_id: conversation.id,
+    contact_id: contactId,
+    whatsapp_message_id: inbound.externalId,
+    content_type: contentType,
+    text: inbound.text,
+  })
+}

--- a/src/app/api/whatsapp/broadcast/route.ts
+++ b/src/app/api/whatsapp/broadcast/route.ts
@@ -138,6 +138,7 @@ export async function POST(request: Request) {
       .from('whatsapp_config')
       .select('*')
       .eq('account_id', accountId)
+      .eq('provider', 'meta')
       .single()
 
     if (configError || !config) {

--- a/src/app/api/whatsapp/config/route.ts
+++ b/src/app/api/whatsapp/config/route.ts
@@ -89,6 +89,7 @@ export async function GET() {
       .from('whatsapp_config')
       .select('phone_number_id, access_token, status')
       .eq('account_id', accountId)
+      .eq('provider', 'meta')
       .maybeSingle()
 
     if (configError) {
@@ -269,13 +270,16 @@ export async function POST(request: Request) {
       )
     }
 
-    // Look up any pre-existing row for this account so we know whether
-    // this number is already registered with Meta — if so we can skip
+    // Look up any pre-existing Meta row for this account so we know
+    // whether this number is already registered — if so we can skip
     // /register when the user didn't provide a PIN this time around.
+    // Scoped to provider='meta': an account may also have a Uazapi row
+    // (migration 029) and this lookup must not cross-match it.
     const { data: existing } = await supabase
       .from('whatsapp_config')
       .select('id, registered_at, phone_number_id')
       .eq('account_id', accountId)
+      .eq('provider', 'meta')
       .maybeSingle()
 
     const sameNumber =
@@ -371,6 +375,7 @@ export async function POST(request: Request) {
         .from('whatsapp_config')
         .update(baseRow)
         .eq('account_id', accountId)
+        .eq('provider', 'meta')
 
       if (updateError) {
         console.error('Error updating whatsapp_config:', updateError)
@@ -380,15 +385,30 @@ export async function POST(request: Request) {
         )
       }
     } else {
+      // First-provider-connected becomes the default outbound provider.
+      // If a Uazapi row already claimed `is_default` for this account,
+      // it stays default (per the confirmed decision: Uazapi is the
+      // default when both are connected) — Meta only becomes default
+      // when it's the account's first connection.
+      const { data: anyDefault } = await supabase
+        .from('whatsapp_config')
+        .select('id')
+        .eq('account_id', accountId)
+        .eq('is_default', true)
+        .maybeSingle()
+
       // Insert with both columns: `account_id` is the tenancy key
-      // (NOT NULL post-017, UNIQUE so duplicates trip the constraint
-      // up-front), `user_id` is the audit column identifying which
-      // member of the account saved the config.
+      // (NOT NULL post-017, UNIQUE per (account_id, provider) as of
+      // migration 029 so duplicates trip the constraint up-front),
+      // `user_id` is the audit column identifying which member of the
+      // account saved the config.
       const { error: insertError } = await supabase
         .from('whatsapp_config')
         .insert({
           account_id: accountId,
           user_id: user.id,
+          provider: 'meta',
+          is_default: !anyDefault,
           ...baseRow,
         })
 
@@ -463,6 +483,7 @@ export async function DELETE() {
       .from('whatsapp_config')
       .delete()
       .eq('account_id', accountId)
+      .eq('provider', 'meta')
 
     if (deleteError) {
       console.error('Error deleting whatsapp_config:', deleteError)

--- a/src/app/api/whatsapp/config/verify-registration/route.ts
+++ b/src/app/api/whatsapp/config/verify-registration/route.ts
@@ -59,6 +59,7 @@ export async function GET() {
     .from('whatsapp_config')
     .select('*')
     .eq('account_id', accountId)
+    .eq('provider', 'meta')
     .maybeSingle()
 
   if (!config) {

--- a/src/app/api/whatsapp/media/[mediaId]/route.ts
+++ b/src/app/api/whatsapp/media/[mediaId]/route.ts
@@ -48,11 +48,17 @@ export async function GET(
       )
     }
 
-    // Fetch and decrypt WhatsApp config
+    // Fetch and decrypt WhatsApp config. Scoped to provider='meta' —
+    // this route only ever serves Meta media ids (see the Uazapi
+    // equivalent at /api/uazapi/media/[messageId]); an account can now
+    // hold both a Meta and a Uazapi row (migration 029), so an
+    // unscoped `.single()` here would throw "multiple rows" once both
+    // are connected.
     const { data: config, error: configError } = await supabase
       .from('whatsapp_config')
       .select('*')
       .eq('account_id', accountId)
+      .eq('provider', 'meta')
       .single()
 
     if (configError || !config) {

--- a/src/app/api/whatsapp/react/route.ts
+++ b/src/app/api/whatsapp/react/route.ts
@@ -113,6 +113,7 @@ export async function POST(request: Request) {
       .from('whatsapp_config')
       .select('phone_number_id, access_token')
       .eq('account_id', accountId)
+      .eq('provider', 'meta')
       .single();
 
     if (configError || !config) {

--- a/src/app/api/whatsapp/react/route.ts
+++ b/src/app/api/whatsapp/react/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { sendReactionMessage } from '@/lib/whatsapp/meta-api';
-import { decrypt } from '@/lib/whatsapp/encryption';
 import { sanitizePhoneForMeta } from '@/lib/whatsapp/phone-utils';
+import { getProviderFromConfig, type WhatsAppConfigRow } from '@/lib/whatsapp/providers/factory';
 import {
   checkRateLimit,
   rateLimitResponse,
@@ -14,7 +13,8 @@ import {
  *
  * Body: { message_id: <internal UUID>, emoji: <single emoji or "" to remove> }
  *
- * Sends the reaction to Meta and mirrors it into `message_reactions`
+ * Sends the reaction through whichever provider owns the message's
+ * conversation (Meta or Uazapi) and mirrors it into `message_reactions`
  * (delete on empty emoji). Customer-side reactions are handled by the
  * webhook — this route only writes `actor_type = 'agent'` rows.
  */
@@ -86,7 +86,7 @@ export async function POST(request: Request) {
 
     const { data: conversation, error: convError } = await supabase
       .from('conversations')
-      .select('id, account_id, contact:contacts(phone)')
+      .select('id, account_id, provider, contact:contacts(phone)')
       .eq('id', targetMessage.conversation_id)
       .eq('account_id', accountId)
       .maybeSingle();
@@ -108,12 +108,15 @@ export async function POST(request: Request) {
       );
     }
 
-    // WhatsApp config + access token. Account-scoped post-multi-user.
+    // WhatsApp config, scoped to whichever provider owns this
+    // conversation — an account can hold both a Meta and a Uazapi row
+    // (migration 029), so this must not assume Meta.
+    const conversationProvider = (conversation.provider as string | null) || 'meta';
     const { data: config, error: configError } = await supabase
       .from('whatsapp_config')
-      .select('phone_number_id, access_token')
+      .select('*')
       .eq('account_id', accountId)
-      .eq('provider', 'meta')
+      .eq('provider', conversationProvider)
       .single();
 
     if (configError || !config) {
@@ -123,23 +126,21 @@ export async function POST(request: Request) {
       );
     }
 
-    const accessToken = decrypt(config.access_token);
+    const provider = getProviderFromConfig(config as WhatsAppConfigRow);
     const sanitizedPhone = sanitizePhoneForMeta(contact.phone);
 
     try {
-      await sendReactionMessage({
-        phoneNumberId: config.phone_number_id,
-        accessToken,
+      await provider.reactToMessage({
         to: sanitizedPhone,
-        targetMessageId: targetMessage.message_id,
+        targetExternalId: targetMessage.message_id,
         emoji,
       });
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : 'Unknown Meta API error';
-      console.error('[whatsapp/react] Meta send failed:', message);
+        err instanceof Error ? err.message : `Unknown ${provider.name} API error`;
+      console.error(`[whatsapp/react] ${provider.name} send failed:`, message);
       return NextResponse.json(
-        { error: `Meta API error: ${message}` },
+        { error: `${provider.name} API error: ${message}` },
         { status: 502 },
       );
     }

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -10,9 +10,10 @@ import {
   validateSendMessageParams,
   SendMessageError,
 } from '@/lib/whatsapp/send-message'
+import { resolveConversationByPhone } from '@/lib/whatsapp/resolve-conversation'
 
 // The dashboard's outbound-send endpoint. It owns auth, per-user rate
-// limiting, and the two ways the UI targets a thread — an existing
+// limiting, and the three ways the UI targets a thread — an existing
 // `conversation_id` (inbox) or a `contact_id` (Contact detail →
 // find-or-create the conversation). The actual Meta plumbing (validate
 // → send → persist → pause flows) lives in the shared
@@ -65,8 +66,18 @@ export async function POST(request: Request) {
       // `conversation_id` targets an existing thread (inbox). `contact_id`
       // lets a caller initiate from a contact that may have no conversation
       // yet (Contact detail → Send template) — we find-or-create one below.
+      // `phone` is the third path — the inbox's "New conversation" flow,
+      // where the caller has a raw phone number and no contact/conversation
+      // exists yet at all.
       conversation_id: conversationIdInput,
       contact_id,
+      phone,
+      contact_name,
+      /** Which WhatsApp connection to use for a brand-new (`phone`-path)
+       *  conversation — 'meta' | 'uazapi'. Ignored by the other two paths
+       *  (they target a conversation that already has a provider). Omit
+       *  to use the account's default. */
+      provider,
       message_type,
       content_text,
       media_url,
@@ -78,11 +89,11 @@ export async function POST(request: Request) {
       reply_to_message_id,
     } = body
 
-    if ((!conversationIdInput && !contact_id) || !message_type) {
+    if ((!conversationIdInput && !contact_id && !phone) || !message_type) {
       return NextResponse.json(
         {
           error:
-            'Either conversation_id or contact_id, plus message_type, are required',
+            'Either conversation_id, contact_id, or phone, plus message_type, are required',
         },
         { status: 400 }
       )
@@ -126,6 +137,26 @@ export async function POST(request: Request) {
         )
       }
       conversationId = data.id
+    } else if (phone) {
+      // "New conversation" path — no existing contact/conversation.
+      // Reuses the same find-or-create the public API's phone-based
+      // send uses, so a contact started here is indistinguishable from
+      // one created via /api/v1/messages or an inbound webhook.
+      try {
+        const resolved = await resolveConversationByPhone(
+          supabase,
+          accountId,
+          phone,
+          typeof contact_name === 'string' ? contact_name : null,
+          provider === 'meta' || provider === 'uazapi' ? provider : undefined
+        )
+        conversationId = resolved.conversationId
+      } catch (err) {
+        if (err instanceof SendMessageError) {
+          return NextResponse.json({ error: err.message }, { status: err.status })
+        }
+        throw err
+      }
     } else {
       // contact_id path: verify the contact is in this account first so a
       // caller can't open a conversation against someone else's contact.
@@ -187,6 +218,7 @@ export async function POST(request: Request) {
         success: true,
         message_id: result.messageId,
         whatsapp_message_id: result.whatsappMessageId,
+        conversation_id: conversationId,
       })
     } catch (err) {
       if (err instanceof SendMessageError) {

--- a/src/app/api/whatsapp/templates/[id]/route.ts
+++ b/src/app/api/whatsapp/templates/[id]/route.ts
@@ -142,6 +142,7 @@ export async function PATCH(
         .from('whatsapp_config')
         .select('*')
         .eq('account_id', accountId)
+        .eq('provider', 'meta')
         .single()
       if (configError || !config) {
         return NextResponse.json(
@@ -282,6 +283,7 @@ export async function DELETE(
         .from('whatsapp_config')
         .select('*')
         .eq('account_id', accountId)
+        .eq('provider', 'meta')
         .single()
       if (configError || !config || !config.waba_id) {
         return NextResponse.json(

--- a/src/app/api/whatsapp/templates/submit/route.ts
+++ b/src/app/api/whatsapp/templates/submit/route.ts
@@ -153,6 +153,7 @@ export async function POST(request: Request) {
         .from('whatsapp_config')
         .select('*')
         .eq('account_id', accountId)
+        .eq('provider', 'meta')
         .single()
       if (configError || !config) {
         return NextResponse.json(

--- a/src/app/api/whatsapp/templates/sync/route.ts
+++ b/src/app/api/whatsapp/templates/sync/route.ts
@@ -154,6 +154,7 @@ export async function POST() {
       .from('whatsapp_config')
       .select('*')
       .eq('account_id', accountId)
+      .eq('provider', 'meta')
       .single()
 
     if (configError || !config) {

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -8,6 +8,7 @@ import { verifyMetaWebhookSignature } from '@/lib/whatsapp/webhook-signature'
 import { runAutomationsForTrigger } from '@/lib/automations/engine'
 import { dispatchInboundToFlows } from '@/lib/flows/engine'
 import { dispatchWebhookEvent } from '@/lib/webhooks/deliver'
+import { enterFunnelIfNew } from '@/lib/journey/enter-funnel'
 import {
   handleTemplateWebhookChange,
   isTemplateWebhookField,
@@ -782,6 +783,17 @@ async function processMessage(
         conversation_id: conversation.id,
       },
     }).catch((err) => console.error('[automations] dispatch failed:', err))
+  }
+
+  // Sales-funnel Kanban entry point: a lead's first-ever inbound message
+  // (same signal as the `first_inbound_message` automation trigger above,
+  // a superset of `wasCreated` that also catches manually-imported
+  // contacts messaging for the first time) drops them into the funnel's
+  // first stage. Idempotent — no-ops if a journey row already exists.
+  // Awaited for the same `after()`-lifetime reason as dispatchWebhookEvent
+  // below; failures are logged inside and never throw.
+  if (isFirstInboundMessage) {
+    await enterFunnelIfNew(supabaseAdmin(), accountId, contactRecord.id)
   }
 
   // message.received webhook (public API). Awaited — not fire-and-forget

--- a/src/components/inbox/conversation-list.tsx
+++ b/src/components/inbox/conversation-list.tsx
@@ -9,7 +9,9 @@ import {
 } from "@/lib/inbox/conversations";
 import { cn } from "@/lib/utils";
 import type { Conversation, ConversationStatus, Tag } from "@/types";
-import { Search, ChevronDown, X } from "lucide-react";
+import { Search, ChevronDown, X, MessageSquarePlus } from "lucide-react";
+import { NewConversationDialog } from "@/components/inbox/new-conversation-dialog";
+import { Button } from "@/components/ui/button";
 import { formatDistanceToNow } from "date-fns";
 import { Input } from "@/components/ui/input";
 import {
@@ -33,6 +35,13 @@ interface ConversationListProps {
    * or the tab was throttled. Optional so existing callers keep working.
    */
   resyncToken?: number;
+  /**
+   * Called with a conversation id right after "New conversation" sends
+   * its first message — the parent selects it and deep-links `?c=` so
+   * the freshly created thread opens immediately instead of waiting
+   * for the next realtime INSERT to be clicked manually.
+   */
+  onConversationCreated?: (conversationId: string) => void;
 }
 
 const STATUS_COLORS: Record<ConversationStatus, string> = {
@@ -57,8 +66,10 @@ export function ConversationList({
   conversations,
   onConversationsLoaded,
   resyncToken = 0,
+  onConversationCreated,
 }: ConversationListProps) {
   const [search, setSearch] = useState("");
+  const [newConvOpen, setNewConvOpen] = useState(false);
   const [filter, setFilter] = useState<InboxFilter>("all");
   const [loading, setLoading] = useState(true);
   // Contact-based filters (issue #272). Tags use OR logic (a conversation
@@ -221,14 +232,24 @@ export function ConversationList({
     <div className="flex h-full w-full flex-col border-r border-border bg-card lg:w-80">
       {/* Search + Filter */}
       <div className="space-y-2 border-b border-border p-3">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            value={search}
-            onChange={handleSearchChange}
-            placeholder="Search conversations..."
-            className="border-border bg-muted pl-9 text-sm text-foreground placeholder-muted-foreground focus:border-primary/50"
-          />
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={handleSearchChange}
+              placeholder="Search conversations..."
+              className="border-border bg-muted pl-9 text-sm text-foreground placeholder-muted-foreground focus:border-primary/50"
+            />
+          </div>
+          <Button
+            size="icon"
+            onClick={() => setNewConvOpen(true)}
+            className="shrink-0 bg-primary hover:bg-primary/90 text-primary-foreground"
+            title="New conversation"
+          >
+            <MessageSquarePlus className="size-4" />
+          </Button>
         </div>
 
         <div className="flex flex-wrap items-center gap-1">
@@ -413,6 +434,14 @@ export function ConversationList({
           </div>
         )}
       </ScrollArea>
+
+      <NewConversationDialog
+        open={newConvOpen}
+        onOpenChange={setNewConvOpen}
+        onCreated={(conversationId) => {
+          onConversationCreated?.(conversationId);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/inbox/message-composer.tsx
+++ b/src/components/inbox/message-composer.tsx
@@ -96,6 +96,14 @@ interface MessageComposerProps {
   onSend: (text: string, replyToId?: string) => void;
   onSendMedia: (payload: SendMediaPayload) => void;
   onOpenTemplates: () => void;
+  /**
+   * Templates are a Meta-only concept (approved templates + the 24h
+   * re-engagement window). Uazapi has neither — hide both entry points
+   * into the template picker for non-Meta conversations rather than
+   * offering a feature that doesn't apply. Defaults to true so any
+   * caller that hasn't been updated keeps the existing Meta behaviour.
+   */
+  showTemplates?: boolean;
   replyTo?: ReplyDraft | null;
   onClearReply?: () => void;
 }
@@ -117,6 +125,7 @@ export function MessageComposer({
   onSend,
   onSendMedia,
   onOpenTemplates,
+  showTemplates = true,
   replyTo,
   onClearReply,
 }: MessageComposerProps) {
@@ -391,17 +400,21 @@ export function MessageComposer({
       {sessionExpired && (
         <div className="mb-2 flex items-center justify-between rounded-lg bg-amber-500/10 px-3 py-2">
           <p className="text-xs text-amber-400">
-            24-hour session expired. Use a template to re-engage.
+            {showTemplates
+              ? "24-hour session expired. Use a template to re-engage."
+              : "24-hour session expired. Wait for the contact to message again."}
           </p>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs text-amber-400 hover:text-amber-300"
-            onClick={onOpenTemplates}
-          >
-            <LayoutTemplate className="mr-1 h-3 w-3" />
-            Templates
-          </Button>
+          {showTemplates && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-amber-400 hover:text-amber-300"
+              onClick={onOpenTemplates}
+            >
+              <LayoutTemplate className="mr-1 h-3 w-3" />
+              Templates
+            </Button>
+          )}
         </div>
       )}
 
@@ -511,17 +524,19 @@ export function MessageComposer({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <GatedButton
-            variant="ghost"
-            size="sm"
-            canAct={!readOnly}
-            gateReason="send messages"
-            title={readOnly ? undefined : "Send template"}
-            className="h-9 w-9 shrink-0 p-0 text-muted-foreground hover:text-foreground"
-            onClick={onOpenTemplates}
-          >
-            <LayoutTemplate className="h-4 w-4" />
-          </GatedButton>
+          {showTemplates && (
+            <GatedButton
+              variant="ghost"
+              size="sm"
+              canAct={!readOnly}
+              gateReason="send messages"
+              title={readOnly ? undefined : "Send template"}
+              className="h-9 w-9 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+              onClick={onOpenTemplates}
+            >
+              <LayoutTemplate className="h-4 w-4" />
+            </GatedButton>
+          )}
 
           <textarea
             ref={textareaRef}

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -219,8 +219,17 @@ export function MessageThread({
     };
   }, []);
 
-  // 24-hour session timer
+  // The 24-hour re-engagement window is a Meta Cloud API rule (free-form
+  // text outside it gets rejected server-side, hence the template
+  // requirement) — it doesn't exist for Uazapi, which sends free-form
+  // text at any time. Conversations default to 'meta' pre-migration-029,
+  // so anything explicitly NOT 'uazapi' is treated as Meta-gated.
+  const isOfficialProvider = (conversation?.provider ?? "meta") !== "uazapi";
+
+  // 24-hour session timer — only meaningful (and only blocks sending)
+  // for Meta conversations.
   const sessionInfo = useMemo(() => {
+    if (!isOfficialProvider) return { expired: false, remaining: "" };
     if (!messages.length) return { expired: false, remaining: "" };
 
     // Find last customer message
@@ -244,7 +253,7 @@ export function MessageThread({
         : `${Math.floor(hoursLeft * 60)}m remaining`;
 
     return { expired, remaining };
-  }, [messages]);
+  }, [messages, isOfficialProvider]);
 
   // Store latest callback in a ref so fetchMessages doesn't need to
   // depend on `onMessagesLoaded` — otherwise parent re-renders cause
@@ -841,18 +850,21 @@ export function MessageThread({
             <h2 className="truncate text-sm font-semibold text-foreground">{displayName}</h2>
             <p className="truncate text-xs text-muted-foreground">{contact.phone}</p>
           </div>
-          {/* Session timer badge — hidden on the narrowest phones so
-              the name + back arrow keep their room. */}
-          <Badge
-            variant="outline"
-            className={cn(
-              "ml-1 hidden gap-1 border-border text-[10px] sm:inline-flex sm:ml-2",
-              sessionInfo.expired ? "text-red-400" : "text-primary"
-            )}
-          >
-            <Clock className="h-3 w-3" />
-            {sessionInfo.remaining}
-          </Badge>
+          {/* Session timer badge — Meta-only (the 24h window doesn't
+              exist for Uazapi, see isOfficialProvider), hidden on the
+              narrowest phones so the name + back arrow keep their room. */}
+          {isOfficialProvider && (
+            <Badge
+              variant="outline"
+              className={cn(
+                "ml-1 hidden gap-1 border-border text-[10px] sm:inline-flex sm:ml-2",
+                sessionInfo.expired ? "text-red-400" : "text-primary"
+              )}
+            >
+              <Clock className="h-3 w-3" />
+              {sessionInfo.remaining}
+            </Badge>
+          )}
         </div>
 
         <div className="flex items-center gap-2">
@@ -1077,15 +1089,22 @@ export function MessageThread({
         onSend={handleSend}
         onSendMedia={handleSendMedia}
         onOpenTemplates={handleOpenTemplates}
+        showTemplates={isOfficialProvider}
         replyTo={replyTo}
         onClearReply={() => setReplyTo(null)}
       />
 
-      <TemplatePicker
-        open={templateModalOpen}
-        onOpenChange={setTemplateModalOpen}
-        onSelect={handleSendTemplate}
-      />
+      {/* Templates are Meta-only (approved-template + 24h-window
+          concept) — the picker stays mounted but unreachable for
+          Uazapi conversations since MessageComposer hides every entry
+          point into it when showTemplates is false. */}
+      {isOfficialProvider && (
+        <TemplatePicker
+          open={templateModalOpen}
+          onOpenChange={setTemplateModalOpen}
+          onSelect={handleSendTemplate}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/inbox/new-conversation-dialog.tsx
+++ b/src/components/inbox/new-conversation-dialog.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+// ============================================================
+// NewConversationDialog
+//
+// Lets an agent start a thread with a phone number that has no
+// history yet — the inbox equivalent of resolveConversationByPhone
+// (the same helper the public API's phone-based send uses). Submits
+// through /api/whatsapp/send with a `phone` (instead of
+// conversation_id/contact_id), which finds-or-creates the contact +
+// conversation and sends the first message in one round trip.
+//
+// Provider selection only shows up when the account has BOTH Meta and
+// Uazapi connected — with a single provider there's nothing to choose.
+// ============================================================
+
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Loader2, MessageSquarePlus } from 'lucide-react';
+
+import { createClient } from '@/lib/supabase/client';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { sanitizePhoneForMeta, isValidE164 } from '@/lib/whatsapp/phone-utils';
+
+interface NewConversationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the new/matched conversation's id after a successful send. */
+  onCreated: (conversationId: string) => void;
+}
+
+type ProviderOption = 'meta' | 'uazapi';
+
+export function NewConversationDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: NewConversationDialogProps) {
+  const [phone, setPhone] = useState('');
+  const [name, setName] = useState('');
+  const [text, setText] = useState('');
+  const [provider, setProvider] = useState<ProviderOption | ''>('');
+  const [availableProviders, setAvailableProviders] = useState<ProviderOption[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Only offer a provider choice when the account has more than one
+  // connected — otherwise it's a pointless extra field.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const supabase = createClient();
+      const { data: authData } = await supabase.auth.getUser();
+      const userId = authData.user?.id;
+      if (!userId) return;
+      const { data: acct } = await supabase
+        .from('profiles')
+        .select('account_id')
+        .eq('user_id', userId)
+        .maybeSingle();
+      const accountId = acct?.account_id as string | undefined;
+      if (!accountId) return;
+      const { data: configs } = await supabase
+        .from('whatsapp_config')
+        .select('provider, is_default, status')
+        .eq('account_id', accountId)
+        .eq('status', 'connected');
+      if (cancelled || !configs) return;
+      const providers = configs.map((c) => c.provider as ProviderOption);
+      setAvailableProviders(providers);
+      const defaultProvider = configs.find((c) => c.is_default)?.provider as
+        | ProviderOption
+        | undefined;
+      setProvider(defaultProvider || providers[0] || '');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  function reset() {
+    setPhone('');
+    setName('');
+    setText('');
+    setProvider('');
+    setAvailableProviders([]);
+    setSubmitting(false);
+  }
+
+  async function handleSubmit() {
+    const sanitized = sanitizePhoneForMeta(phone);
+    if (!isValidE164(sanitized)) {
+      toast.error('Enter a valid phone number, e.g. +14155550123');
+      return;
+    }
+    if (!text.trim()) {
+      toast.error('Write a message to send.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/whatsapp/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          phone: sanitized,
+          contact_name: name.trim() || undefined,
+          provider: provider || undefined,
+          message_type: 'text',
+          content_text: text.trim(),
+        }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to send message');
+        return;
+      }
+
+      toast.success('Message sent.');
+      onCreated(data.conversation_id);
+      onOpenChange(false);
+    } catch (err) {
+      console.error('[NewConversationDialog] send failed:', err);
+      toast.error('Could not reach the server. Try again?');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="bg-popover border-border sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-popover-foreground">
+            <MessageSquarePlus className="size-4 text-primary" />
+            New conversation
+          </DialogTitle>
+          <DialogDescription className="text-muted-foreground">
+            Message a phone number that isn&apos;t in your contacts yet. It&apos;ll
+            appear in the conversation list right after you send.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label className="text-muted-foreground">Phone number</Label>
+            <Input
+              placeholder="+14155550123"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              className="bg-muted border-border text-foreground placeholder:text-muted-foreground"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-muted-foreground">
+              Name <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              placeholder="For your contacts list"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="bg-muted border-border text-foreground placeholder:text-muted-foreground"
+            />
+          </div>
+
+          {availableProviders.length > 1 && (
+            <div className="space-y-2">
+              <Label className="text-muted-foreground">Send via</Label>
+              <Select
+                value={provider}
+                onValueChange={(v) => v && setProvider(v as ProviderOption)}
+              >
+                <SelectTrigger className="w-full bg-muted border-border text-foreground">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableProviders.includes('meta') && (
+                    <SelectItem value="meta">Meta (official)</SelectItem>
+                  )}
+                  {availableProviders.includes('uazapi') && (
+                    <SelectItem value="uazapi">Uazapi</SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label className="text-muted-foreground">Message</Label>
+            <Textarea
+              placeholder="Type the first message…"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              className="bg-muted border-border text-foreground placeholder:text-muted-foreground min-h-24"
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="bg-popover border-border">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            className="border-border text-muted-foreground hover:bg-muted"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="bg-primary hover:bg-primary/90 text-primary-foreground"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Sending…
+              </>
+            ) : (
+              'Send'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/kanban/add-lead-form.tsx
+++ b/src/components/kanban/add-lead-form.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useAuth } from "@/hooks/use-auth";
+import type { Contact, FunnelStage } from "@/types";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+
+interface AddLeadFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  stages: FunnelStage[];
+  existingContactIds: Set<string>;
+  onCreated: () => void;
+}
+
+/**
+ * Manually drop an existing contact into the funnel — the exception
+ * path to the normal "first inbound message" auto-entry, for contacts
+ * who were imported/added but never messaged (or a lead the team wants
+ * to track from an offline channel).
+ */
+export function AddLeadForm({
+  open,
+  onOpenChange,
+  stages,
+  existingContactIds,
+  onCreated,
+}: AddLeadFormProps) {
+  const supabase = createClient();
+  const { accountId } = useAuth();
+
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [contactId, setContactId] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const { data } = await supabase.from("contacts").select("*").order("name");
+      if (cancelled) return;
+      setContacts((data ?? []) as Contact[]);
+      setContactId("");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, supabase]);
+
+  const availableContacts = contacts.filter((c) => !existingContactIds.has(c.id));
+
+  async function handleSave() {
+    if (!contactId || !accountId) return;
+    const firstStage = [...stages].sort((a, b) => a.position - b.position)[0];
+    if (!firstStage) {
+      toast.error("No funnel stages configured yet");
+      return;
+    }
+    setSaving(true);
+
+    const { data: created, error } = await supabase
+      .from("contact_journey")
+      .insert({ account_id: accountId, contact_id: contactId, stage_id: firstStage.id })
+      .select("id")
+      .single();
+
+    if (error || !created) {
+      toast.error("Failed to add lead");
+      setSaving(false);
+      return;
+    }
+
+    await supabase.from("contact_journey_transitions").insert({
+      contact_journey_id: created.id,
+      account_id: accountId,
+      from_stage_id: null,
+      to_stage_id: firstStage.id,
+    });
+
+    setSaving(false);
+    toast.success("Lead added to funnel");
+    onOpenChange(false);
+    onCreated();
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="bg-popover border-border text-popover-foreground sm:max-w-sm w-full p-0"
+      >
+        <div className="flex h-full flex-col">
+          <SheetHeader className="border-b border-border/50 p-4">
+            <SheetTitle className="text-popover-foreground">Add Lead</SheetTitle>
+          </SheetHeader>
+
+          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            <div className="grid gap-2">
+              <Label className="text-muted-foreground">Contact</Label>
+              <select
+                value={contactId}
+                onChange={(e) => setContactId(e.target.value)}
+                className="h-9 w-full rounded-lg border border-border bg-muted px-2.5 text-sm text-foreground outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+              >
+                <option value="">Select a contact</option>
+                {availableContacts.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name || c.phone}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                Enters the funnel at its first stage ({stages[0]?.name ?? "—"}).
+              </p>
+            </div>
+          </div>
+
+          <div className="border-t border-border/50 bg-popover/80 p-4">
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                className="flex-1 border-border bg-transparent text-muted-foreground hover:bg-muted"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSave}
+                disabled={saving || !contactId}
+                className="flex-1 bg-primary text-primary-foreground hover:bg-primary/90"
+              >
+                {saving ? "Adding..." : "Add Lead"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  useDraggable,
+  closestCorners,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import type { ContactJourney, FunnelStage } from "@/types";
+import { LeadCard } from "./lead-card";
+
+interface KanbanBoardProps {
+  stages: FunnelStage[];
+  journeys: ContactJourney[];
+  onJourneyMoved: (journeyId: string, newStageId: string) => void;
+  onOpenJourney: (journey: ContactJourney) => void;
+}
+
+export function KanbanBoard({
+  stages,
+  journeys,
+  onJourneyMoved,
+  onOpenJourney,
+}: KanbanBoardProps) {
+  const [activeJourneyId, setActiveJourneyId] = useState<string | null>(null);
+
+  const sortedStages = useMemo(
+    () => [...stages].sort((a, b) => a.position - b.position),
+    [stages],
+  );
+
+  const journeysByStage = useMemo(() => {
+    const map = new Map<string, ContactJourney[]>();
+    for (const stage of sortedStages) map.set(stage.id, []);
+    for (const journey of journeys) {
+      const bucket = map.get(journey.stage_id);
+      if (bucket) bucket.push(journey);
+    }
+    return map;
+  }, [sortedStages, journeys]);
+
+  const sensors = useSensors(
+    // 5px activation distance avoids clicks being interpreted as drags.
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor),
+  );
+
+  const activeJourney = activeJourneyId
+    ? journeys.find((j) => j.id === activeJourneyId) ?? null
+    : null;
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveJourneyId(String(event.active.id));
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveJourneyId(null);
+    const { active, over } = event;
+    if (!over) return;
+    const journeyId = String(active.id);
+    const targetStageId = String(over.id);
+
+    const journey = journeys.find((j) => j.id === journeyId);
+    if (!journey || journey.stage_id === targetStageId) return;
+    if (!sortedStages.some((s) => s.id === targetStageId)) return;
+
+    onJourneyMoved(journeyId, targetStageId);
+  }
+
+  function handleDragCancel() {
+    setActiveJourneyId(null);
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div className="kanban-scroll flex snap-x snap-mandatory gap-3 overflow-x-auto pb-4 lg:snap-none">
+        {sortedStages.map((stage) => {
+          const stageJourneys = journeysByStage.get(stage.id) ?? [];
+          return (
+            <StageColumn
+              key={stage.id}
+              stage={stage}
+              journeys={stageJourneys}
+              onOpenJourney={onOpenJourney}
+            />
+          );
+        })}
+      </div>
+
+      <DragOverlay
+        dropAnimation={{
+          duration: 200,
+          easing: "cubic-bezier(0.2, 0, 0, 1)",
+        }}
+      >
+        {activeJourney ? (
+          <div className="opacity-90">
+            <LeadCard
+              journey={activeJourney}
+              stage={
+                sortedStages.find((s) => s.id === activeJourney.stage_id) ?? null
+              }
+              onOpen={() => {}}
+              isOverlay
+            />
+          </div>
+        ) : null}
+      </DragOverlay>
+
+      <style jsx>{`
+        .kanban-scroll {
+          scroll-behavior: smooth;
+        }
+        @media (hover: none), (pointer: coarse) {
+          .kanban-scroll::-webkit-scrollbar {
+            height: 0;
+            display: none;
+          }
+          .kanban-scroll {
+            scrollbar-width: none;
+          }
+        }
+        @media (hover: hover) and (pointer: fine) {
+          .kanban-scroll {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+          }
+          .kanban-scroll::-webkit-scrollbar {
+            height: 8px;
+          }
+          .kanban-scroll::-webkit-scrollbar-track {
+            background: transparent;
+          }
+          .kanban-scroll::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 9999px;
+          }
+          .kanban-scroll::-webkit-scrollbar-thumb:hover {
+            background-color: var(--muted-foreground);
+          }
+        }
+      `}</style>
+    </DndContext>
+  );
+}
+
+function StageColumn({
+  stage,
+  journeys,
+  onOpenJourney,
+}: {
+  stage: FunnelStage;
+  journeys: ContactJourney[];
+  onOpenJourney: (journey: ContactJourney) => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: stage.id });
+
+  return (
+    <div className="flex w-[85vw] min-w-[260px] max-w-[320px] shrink-0 snap-start flex-col rounded-xl border border-border bg-card/60 p-4 lg:w-auto lg:max-w-none lg:flex-1 lg:basis-[260px] lg:shrink lg:snap-none">
+      {/* 3px colored top border — sits above the column's padding */}
+      <div
+        className="-mx-4 -mt-4 h-[3px] rounded-t-xl"
+        style={{ backgroundColor: stage.color }}
+      />
+      <div className="flex items-center justify-between pt-3">
+        <h3 className="truncate text-sm font-semibold text-foreground">
+          {stage.name}
+        </h3>
+        <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+          {journeys.length}
+        </span>
+      </div>
+
+      <div
+        ref={setNodeRef}
+        className={`mt-3 flex flex-1 flex-col gap-2 rounded-lg transition-all ${
+          isOver
+            ? "bg-primary/5 outline outline-2 outline-dashed outline-primary outline-offset-2"
+            : ""
+        }`}
+      >
+        {journeys.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center rounded-lg border-2 border-dashed border-border py-10 text-xs text-muted-foreground">
+            No leads here
+          </div>
+        ) : (
+          journeys.map((journey) => (
+            <DraggableLeadCard
+              key={journey.id}
+              journey={journey}
+              stage={stage}
+              onOpen={onOpenJourney}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DraggableLeadCard({
+  journey,
+  stage,
+  onOpen,
+}: {
+  journey: ContactJourney;
+  stage: FunnelStage;
+  onOpen: (journey: ContactJourney) => void;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: journey.id,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      style={{ opacity: isDragging ? 0.3 : 1, touchAction: "none" }}
+    >
+      <LeadCard journey={journey} stage={stage} onOpen={onOpen} />
+    </div>
+  );
+}

--- a/src/components/kanban/lead-card.tsx
+++ b/src/components/kanban/lead-card.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { ContactJourney, FunnelStage } from "@/types";
+import { MessageCircle } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { STALE_AFTER_MS } from "@/lib/journey/funnel-stages";
+
+interface LeadCardProps {
+  journey: ContactJourney;
+  stage: FunnelStage | null;
+  onOpen: (journey: ContactJourney) => void;
+  isOverlay?: boolean;
+}
+
+function initials(name?: string, fallback?: string) {
+  const source = (name || fallback || "?").trim();
+  if (!source) return "?";
+  return source.charAt(0).toUpperCase();
+}
+
+export function LeadCard({ journey, stage, onOpen, isOverlay }: LeadCardProps) {
+  const contact = journey.contact;
+  const contactLabel = contact?.name || contact?.phone || "Unknown contact";
+  const enteredAt = new Date(journey.entered_stage_at);
+  const isStale = new Date().getTime() - enteredAt.getTime() > STALE_AFTER_MS;
+  const lastMessage = journey.conversation?.last_message_text;
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        if (isOverlay) return;
+        e.stopPropagation();
+        onOpen(journey);
+      }}
+      className={`group relative w-full cursor-pointer rounded-xl border border-border/50 bg-muted/70 pl-4 pr-3 py-3 text-left shadow-sm transition-all ${
+        isOverlay
+          ? "shadow-xl"
+          : "hover:-translate-y-0.5 hover:border-border hover:bg-muted hover:shadow-lg"
+      }`}
+    >
+      {/* 4px left accent bar using stage color */}
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 h-full w-1 rounded-l-xl"
+        style={{ backgroundColor: stage?.color ?? "#94a3b8" }}
+      />
+
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-foreground">
+            {initials(contact?.name, contact?.phone)}
+          </span>
+          <h4 className="text-sm font-semibold leading-snug text-foreground break-words">
+            {contactLabel}
+          </h4>
+        </div>
+        <span
+          className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+            isStale
+              ? "bg-red-500/15 text-red-400"
+              : "bg-muted text-muted-foreground"
+          }`}
+        >
+          {formatDistanceToNow(enteredAt, { addSuffix: true })}
+        </span>
+      </div>
+
+      {lastMessage && (
+        <div className="mt-2 flex items-start gap-1.5">
+          <MessageCircle className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
+          <p className="line-clamp-2 text-xs text-muted-foreground">{lastMessage}</p>
+        </div>
+      )}
+
+      {contact?.phone && (
+        <p className="mt-2 text-[11px] text-muted-foreground">{contact.phone}</p>
+      )}
+    </button>
+  );
+}

--- a/src/components/kanban/lead-detail-sheet.tsx
+++ b/src/components/kanban/lead-detail-sheet.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import type { ContactJourney, FunnelStage } from "@/types";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { MessageSquare } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { useCan } from "@/hooks/use-can";
+
+interface LeadDetailSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  journey: ContactJourney | null;
+  stages: FunnelStage[];
+  onMoved: (journeyId: string, newStageId: string) => void;
+}
+
+export function LeadDetailSheet({
+  open,
+  onOpenChange,
+  journey,
+  stages,
+  onMoved,
+}: LeadDetailSheetProps) {
+  const canMove = useCan("send-messages");
+
+  if (!journey) return null;
+  const contact = journey.contact;
+  const sortedStages = [...stages].sort((a, b) => a.position - b.position);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="bg-popover border-border text-popover-foreground sm:max-w-md w-full p-0"
+      >
+        <div className="flex h-full flex-col">
+          <SheetHeader className="border-b border-border/50 p-4">
+            <SheetTitle className="text-popover-foreground">
+              {contact?.name || contact?.phone || "Lead"}
+            </SheetTitle>
+          </SheetHeader>
+
+          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            {contact?.phone && (
+              <div className="grid gap-1">
+                <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Phone
+                </span>
+                <span className="text-sm text-foreground">{contact.phone}</span>
+              </div>
+            )}
+
+            <div className="grid gap-1">
+              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                In current stage since
+              </span>
+              <span className="text-sm text-foreground">
+                {formatDistanceToNow(new Date(journey.entered_stage_at), {
+                  addSuffix: true,
+                })}
+              </span>
+            </div>
+
+            {journey.conversation?.last_message_text && (
+              <div className="grid gap-1">
+                <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Last message
+                </span>
+                <p className="text-sm text-foreground">
+                  {journey.conversation.last_message_text}
+                </p>
+              </div>
+            )}
+
+            <div className="grid gap-2">
+              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Stage
+              </span>
+              <select
+                value={journey.stage_id}
+                disabled={!canMove}
+                onChange={(e) => onMoved(journey.id, e.target.value)}
+                className="h-9 w-full rounded-lg border border-border bg-muted px-2.5 text-sm text-foreground outline-none focus:border-primary focus:ring-1 focus:ring-primary disabled:opacity-50"
+              >
+                {sortedStages.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {journey.conversation?.id && (
+              <Link
+                href={`/inbox?c=${journey.conversation.id}`}
+                className="inline-flex items-center gap-1.5 self-start rounded-md bg-primary/10 px-2 py-1.5 text-xs text-primary hover:bg-primary/20"
+              >
+                <MessageSquare className="h-3 w-3" />
+                View conversation
+              </Link>
+            )}
+          </div>
+
+          <div className="border-t border-border/50 bg-popover/80 p-4">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="w-full border-border bg-transparent text-muted-foreground hover:bg-muted"
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import { useUnreadNotifications } from "@/hooks/use-unread-notifications";
 import {
   Bell,
   Crown,
+  Filter,
   GitBranch,
   LayoutDashboard,
   LogOut,
@@ -94,6 +95,7 @@ const navItems: NavItem[] = [
   { href: "/notifications", label: "Notifications", icon: Bell },
   { href: "/contacts", label: "Contacts", icon: Users },
   { href: "/pipelines", label: "Pipelines", icon: GitBranch },
+  { href: "/kanban", label: "Kanban", icon: Filter },
   { href: "/broadcasts", label: "Broadcasts", icon: Radio },
   { href: "/automations", label: "Automations", icon: Zap },
   { href: "/flows", label: "Flows", icon: Workflow, beta: true },

--- a/src/components/settings/settings-overview.tsx
+++ b/src/components/settings/settings-overview.tsx
@@ -121,6 +121,7 @@ export function SettingsOverview({
           .from('whatsapp_config')
           .select('phone_number_id')
           .eq('account_id', acctId)
+          .eq('provider', 'meta')
           .maybeSingle(),
         fetch('/api/whatsapp/config', { cache: 'no-store' }).then((r) => r.json()),
       ]);

--- a/src/components/settings/uazapi-config.tsx
+++ b/src/components/settings/uazapi-config.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  Loader2,
+  RotateCcw,
+  Unplug,
+  KeyRound,
+} from 'lucide-react';
+import { useAuth } from '@/hooks/use-auth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+
+type ConnectionState = 'unknown' | 'not_created' | 'not_logged_in' | 'connected';
+
+interface InstanceStatusResponse {
+  connected?: boolean;
+  loggedIn?: boolean;
+  instance_name?: string;
+  base_url?: string;
+  connected_at?: string;
+  reason?: string;
+  message?: string;
+}
+
+/**
+ * Uazapi connection panel — the counterpart to Meta's credential form
+ * (`whatsapp-config.tsx`). An account can have both connected at once
+ * (migration 029); this panel only manages the Uazapi row.
+ *
+ * wacrm never drives the WhatsApp session lifecycle for Uazapi — no
+ * instance creation, no QR/pairing flow, no disconnect call. The
+ * instance is created AND logged into WhatsApp entirely in the Uazapi
+ * panel; this form only attaches to its token so wacrm can send
+ * through it and receive inbound events via webhook.
+ */
+export function UazapiConfig() {
+  const { user, accountId, loading: authLoading, profileLoading } = useAuth();
+
+  const [loading, setLoading] = useState(true);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [state, setState] = useState<ConnectionState>('unknown');
+  const [instanceName, setInstanceName] = useState<string>('');
+  const [instanceBaseUrl, setInstanceBaseUrl] = useState<string>('');
+  const [connectedAt, setConnectedAt] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const [tokenInput, setTokenInput] = useState('');
+  const [baseUrlInput, setBaseUrlInput] = useState('');
+  const [instanceNameInput, setInstanceNameInput] = useState('');
+  const [attaching, setAttaching] = useState(false);
+
+  const loadedAccountIdRef = useRef<string | null>(null);
+
+  const fetchStatus = useCallback(async (): Promise<InstanceStatusResponse | null> => {
+    try {
+      const res = await fetch('/api/uazapi/instance', { cache: 'no-store' });
+      return (await res.json()) as InstanceStatusResponse;
+    } catch (err) {
+      console.error('[uazapi-config] status fetch failed:', err);
+      return null;
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const data = await fetchStatus();
+    if (!data) return;
+
+    setInstanceName(data.instance_name || '');
+    setInstanceBaseUrl(data.base_url || '');
+    setConnectedAt(data.connected_at || null);
+
+    if (data.connected && data.loggedIn) {
+      setState('connected');
+      setErrorMessage('');
+    } else if (data.reason === 'no_config' || data.reason === 'no_account') {
+      setState('not_created');
+    } else {
+      // Token is attached but Uazapi reports the WhatsApp session as
+      // not logged in (or the status check itself failed) — the fix
+      // lives in the Uazapi panel, not here.
+      setState('not_logged_in');
+      if (data.message) setErrorMessage(data.message);
+    }
+  }, [fetchStatus]);
+
+  useEffect(() => {
+    if (authLoading || profileLoading) return;
+    if (!user || !accountId) {
+      setLoading(false);
+      return;
+    }
+    if (loadedAccountIdRef.current === accountId) return;
+    loadedAccountIdRef.current = accountId;
+
+    (async () => {
+      setLoading(true);
+      await refresh();
+      setLoading(false);
+    })();
+  }, [authLoading, profileLoading, user?.id, accountId, refresh]);
+
+  async function handleAttach() {
+    if (!tokenInput.trim()) {
+      toast.error('Instance token is required.');
+      return;
+    }
+    setAttaching(true);
+    setErrorMessage('');
+    try {
+      const res = await fetch('/api/uazapi/instance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instance_token: tokenInput.trim(),
+          base_url: baseUrlInput.trim() || undefined,
+          instance_name: instanceNameInput.trim() || undefined,
+        }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setErrorMessage(data.error || 'Failed to attach instance');
+        toast.error(data.error || 'Failed to attach instance');
+        return;
+      }
+
+      if (!data.webhook_configured) {
+        toast.warning(
+          'Instance attached, but the webhook could not be configured automatically — set NEXT_PUBLIC_SITE_URL and try again to receive inbound messages.',
+          { duration: 10000 },
+        );
+      } else {
+        toast.success(
+          data.connected
+            ? 'Instance attached and connected.'
+            : 'Instance attached. It is not logged into WhatsApp yet — log in via the Uazapi panel.',
+        );
+      }
+
+      setTokenInput('');
+      await refresh();
+    } catch (err) {
+      console.error('[uazapi-config] attach failed:', err);
+      setErrorMessage('Failed to reach the server.');
+      toast.error('Failed to reach the server.');
+    } finally {
+      setAttaching(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    if (!confirm('Detach this Uazapi instance from wacrm? Your WhatsApp session in Uazapi stays untouched — you can re-attach the same token any time.')) {
+      return;
+    }
+    setDisconnecting(true);
+    try {
+      const res = await fetch('/api/uazapi/instance', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to detach');
+        return;
+      }
+      toast.success('Uazapi instance detached.');
+      setState('not_created');
+      setInstanceName('');
+      setInstanceBaseUrl('');
+      setConnectedAt(null);
+    } catch (err) {
+      console.error('[uazapi-config] detach failed:', err);
+      toast.error('Failed to detach.');
+    } finally {
+      setDisconnecting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="size-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-foreground flex items-center gap-2">
+          <KeyRound className="size-4" />
+          Uazapi connection
+        </CardTitle>
+        <CardDescription className="text-muted-foreground">
+          Connect a second WhatsApp number via Uazapi (unofficial API). Create the
+          instance and log it into WhatsApp directly in your Uazapi panel first — wacrm
+          only attaches to its token to send messages and receive inbound events via
+          webhook. Runs alongside your Meta connection above; each conversation sticks
+          to whichever provider it started on.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {state === 'connected' && (
+          <Alert className="border-emerald-500/35 bg-emerald-500/10">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="size-4 text-emerald-600 dark:text-emerald-400" />
+              <AlertTitle className="text-emerald-700 dark:text-emerald-300 mb-0">
+                Connected{instanceName ? ` — ${instanceName}` : ''}
+              </AlertTitle>
+            </div>
+            <AlertDescription className="text-muted-foreground mt-1">
+              WhatsApp session is active. Uazapi is the default provider for new
+              conversations on this account.
+            </AlertDescription>
+            <dl className="mt-3 grid gap-1.5 border-t border-emerald-500/20 pt-3 text-xs">
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">Instance</dt>
+                <dd className="font-mono text-foreground">{instanceName || '—'}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">Server</dt>
+                <dd className="font-mono text-foreground break-all">{instanceBaseUrl || '—'}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">Connected since</dt>
+                <dd className="text-foreground">
+                  {connectedAt ? new Date(connectedAt).toLocaleString() : '—'}
+                </dd>
+              </div>
+            </dl>
+          </Alert>
+        )}
+
+        {state === 'not_logged_in' && (
+          <Alert className="border-amber-500/40 bg-amber-500/10">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
+              <AlertTitle className="text-amber-700 dark:text-amber-300 mb-0">
+                Token attached, but not logged into WhatsApp
+              </AlertTitle>
+            </div>
+            <AlertDescription className="text-muted-foreground mt-1">
+              {errorMessage ||
+                'wacrm saved this token, but Uazapi reports the WhatsApp session isn’t connected. Log the instance into WhatsApp in the Uazapi panel, then click "Refresh status".'}
+            </AlertDescription>
+            <dl className="mt-3 grid gap-1.5 border-t border-amber-500/20 pt-3 text-xs">
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">Instance</dt>
+                <dd className="font-mono text-foreground">{instanceName || '—'}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">Server</dt>
+                <dd className="font-mono text-foreground break-all">{instanceBaseUrl || '—'}</dd>
+              </div>
+            </dl>
+          </Alert>
+        )}
+
+        {state === 'not_created' && (
+          <Alert className="bg-card border-border">
+            <div className="flex items-center gap-2">
+              <XCircle className="size-4 text-muted-foreground" />
+              <AlertTitle className="text-foreground mb-0">Not connected</AlertTitle>
+            </div>
+            <AlertDescription className="text-muted-foreground">
+              {errorMessage || 'Paste your Uazapi instance token below to attach it.'}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {state === 'connected' ? (
+          <div className="flex flex-wrap gap-3">
+            <Button
+              variant="outline"
+              onClick={handleDisconnect}
+              disabled={disconnecting}
+              className="border-red-900 text-red-400 hover:text-red-300 hover:bg-red-950/40"
+            >
+              {disconnecting ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Detaching…
+                </>
+              ) : (
+                <>
+                  <Unplug className="size-4" />
+                  Detach
+                </>
+              )}
+            </Button>
+          </div>
+        ) : (
+          <>
+            {state === 'not_logged_in' && (
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  variant="outline"
+                  onClick={refresh}
+                  className="border-border text-muted-foreground hover:text-foreground hover:bg-muted"
+                >
+                  <RotateCcw className="size-4" />
+                  Refresh status
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={handleDisconnect}
+                  disabled={disconnecting}
+                  className="border-red-900 text-red-400 hover:text-red-300 hover:bg-red-950/40"
+                >
+                  {disconnecting ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Detaching…
+                    </>
+                  ) : (
+                    <>
+                      <Unplug className="size-4" />
+                      Detach
+                    </>
+                  )}
+                </Button>
+              </div>
+            )}
+
+            <div className="space-y-3 rounded-lg border border-border bg-card/60 p-4">
+              <div className="space-y-2">
+                <Label className="text-muted-foreground">Instance token</Label>
+                <Input
+                  type="password"
+                  placeholder="Paste your Uazapi instance token"
+                  value={tokenInput}
+                  onChange={(e) => setTokenInput(e.target.value)}
+                  className="bg-muted border-border text-foreground placeholder:text-muted-foreground"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Create the instance and log it into WhatsApp in your{' '}
+                  <a
+                    href="https://uazapi.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:text-primary/80"
+                  >
+                    Uazapi panel
+                  </a>{' '}
+                  first, then copy its token here.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label className="text-muted-foreground">
+                  Base URL <span className="text-muted-foreground">(optional)</span>
+                </Label>
+                <Input
+                  placeholder="https://nuvtex.uazapi.com"
+                  value={baseUrlInput}
+                  onChange={(e) => setBaseUrlInput(e.target.value)}
+                  className="bg-muted border-border text-foreground placeholder:text-muted-foreground"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Leave blank to use the server default (
+                  <code className="text-foreground">https://nuvtex.uazapi.com</code>).
+                  Override it if your instance lives on a different Uazapi server or
+                  self-hosted URL.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label className="text-muted-foreground">
+                  Instance name <span className="text-muted-foreground">(optional)</span>
+                </Label>
+                <Input
+                  placeholder="For your own reference"
+                  value={instanceNameInput}
+                  onChange={(e) => setInstanceNameInput(e.target.value)}
+                  className="bg-muted border-border text-foreground placeholder:text-muted-foreground"
+                />
+              </div>
+              <Button
+                onClick={handleAttach}
+                disabled={attaching}
+                className="bg-primary hover:bg-primary/90 text-primary-foreground"
+              >
+                {attaching ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Verifying…
+                  </>
+                ) : (
+                  <>
+                    <KeyRound className="size-4" />
+                    Attach instance
+                  </>
+                )}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/settings/whatsapp-config.tsx
+++ b/src/components/settings/whatsapp-config.tsx
@@ -22,6 +22,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { SettingsPanelHead } from './settings-panel-head';
+import { UazapiConfig } from './uazapi-config';
 import {
   Accordion,
   AccordionItem,
@@ -100,11 +101,15 @@ export function WhatsAppConfig() {
       // original author) to `account_id` so every member of the
       // account sees the same saved configuration. UNIQUE(account_id)
       // on the table guarantees the .maybeSingle() return type
-      // remains accurate.
+      // remains accurate. Scoped to provider='meta' — this panel only
+      // manages the Meta row; migration 029 added a coexisting Uazapi
+      // row per account, which an unscoped query would ambiguously
+      // match too.
       const { data, error } = await supabase
         .from('whatsapp_config')
         .select('*')
         .eq('account_id', acctId)
+        .eq('provider', 'meta')
         .maybeSingle();
 
       if (error) {
@@ -850,6 +855,14 @@ export function WhatsAppConfig() {
           </CardContent>
         </Card>
       </div>
+    </div>
+
+    {/* Second provider — coexists with the Meta connection above.
+        Each conversation sticks to whichever provider opened it;
+        Uazapi becomes the default for brand-new outbound once
+        connected (see /api/uazapi/instance). */}
+    <div className="mt-6 max-w-2xl">
+      <UazapiConfig />
     </div>
     </section>
   );

--- a/src/lib/api/v1/contacts.ts
+++ b/src/lib/api/v1/contacts.ts
@@ -73,12 +73,16 @@ export async function resolveAuditUserId(
   db: SupabaseClient,
   accountId: string
 ): Promise<string> {
-  const { data: config } = await db
+  // `.limit(1)` (not `.maybeSingle()`) — an account can now hold both a
+  // Meta and a Uazapi row (migration 029); either one's owner works
+  // equally well as the audit default, so just take whichever sorts
+  // first rather than throwing on "multiple rows returned".
+  const { data: configs } = await db
     .from('whatsapp_config')
     .select('user_id')
     .eq('account_id', accountId)
-    .maybeSingle();
-  const configOwner = config?.user_id as string | undefined;
+    .limit(1);
+  const configOwner = configs?.[0]?.user_id as string | undefined;
   if (configOwner) return configOwner;
 
   const { data: account } = await db

--- a/src/lib/automations/meta-send.ts
+++ b/src/lib/automations/meta-send.ts
@@ -87,6 +87,7 @@ async function sendViaMeta(input: SendInput): Promise<{ whatsapp_message_id: str
     .from('whatsapp_config')
     .select('*')
     .eq('account_id', input.accountId)
+    .eq('provider', 'meta')
     .single()
   if (configErr || !config) {
     throw new Error('WhatsApp not configured for this account')

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -7,9 +7,11 @@ import {
   mondayIndex,
   startOfLocalDay,
 } from './date-utils'
+import { STALE_AFTER_MS } from '@/lib/journey/funnel-stages'
 import type {
   ActivityItem,
   ConversationsSeriesPoint,
+  FunnelMetricsBundle,
   MetricsBundle,
   PipelineDonutData,
   PipelineStageSlice,
@@ -96,6 +98,70 @@ export async function loadMetrics(db: DB): Promise<MetricsBundle> {
       current: messagesToday.count ?? 0,
       previous: messagesYesterday.count ?? 0,
     },
+  }
+}
+
+// --- 1b. Sales-funnel (Kanban) metrics ---------------------------------
+
+export async function loadFunnelMetrics(db: DB): Promise<FunnelMetricsBundle> {
+  const todayStart = startOfLocalDay().toISOString()
+  const yesterdayStart = daysAgoStart(1).toISOString()
+  const thirtyDaysAgo = daysAgoStart(29).toISOString()
+  const staleThreshold = new Date(Date.now() - STALE_AFTER_MS).toISOString()
+
+  const [stagesRes, newLeadsToday, newLeadsYesterday, cohortRes] = await Promise.all([
+    db.from('funnel_stages').select('id, key'),
+    db.from('contact_journey').select('id', { count: 'exact', head: true }).gte('created_at', todayStart),
+    db
+      .from('contact_journey')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', yesterdayStart)
+      .lt('created_at', todayStart),
+    // Cohort = every lead that entered the funnel in the last 30 days.
+    // `created_at` is a one-time stamp (one row per contact), unlike
+    // `entered_stage_at` which resets on every move — exactly the
+    // "when did this lead first show up" signal a conversion-rate
+    // cohort needs.
+    db.from('contact_journey').select('id').gte('created_at', thirtyDaysAgo),
+  ])
+
+  const stages = (stagesRes.data ?? []) as { id: string; key: string }[]
+  const customerStageId = stages.find((s) => s.key === 'customer')?.id ?? null
+  const terminalStageIds = stages.filter((s) => s.key === 'customer' || s.key === 'cold').map((s) => s.id)
+
+  const nonTerminalStageIds = stages.map((s) => s.id).filter((id) => !terminalStageIds.includes(id))
+  const stalledRes = nonTerminalStageIds.length
+    ? await db
+        .from('contact_journey')
+        .select('id', { count: 'exact', head: true })
+        .in('stage_id', nonTerminalStageIds)
+        .lt('entered_stage_at', staleThreshold)
+    : { count: 0 }
+
+  const cohortIds = ((cohortRes.data ?? []) as { id: string }[]).map((r) => r.id)
+  let converted = 0
+  if (customerStageId && cohortIds.length > 0) {
+    // Distinct count, not row count — a journey that bounced through
+    // "customer" more than once (e.g. churned back to Cold and won
+    // again) would otherwise be counted twice.
+    const { data: convertedRows } = await db
+      .from('contact_journey_transitions')
+      .select('contact_journey_id')
+      .eq('to_stage_id', customerStageId)
+      .in('contact_journey_id', cohortIds)
+    converted = new Set(
+      ((convertedRows ?? []) as { contact_journey_id: string }[]).map((r) => r.contact_journey_id),
+    ).size
+  }
+
+  return {
+    newLeadsToday: {
+      current: newLeadsToday.count ?? 0,
+      previous: newLeadsYesterday.count ?? 0,
+    },
+    stalledLeads: stalledRes.count ?? 0,
+    leadConversionRate: cohortIds.length > 0 ? (converted / cohortIds.length) * 100 : null,
+    leadConversionCohortSize: cohortIds.length,
   }
 }
 

--- a/src/lib/dashboard/types.ts
+++ b/src/lib/dashboard/types.ts
@@ -34,6 +34,21 @@ export interface PipelineDonutData {
   totalValue: number
 }
 
+export interface FunnelMetricsBundle {
+  newLeadsToday: MetricDelta
+  /** Leads sitting in a non-terminal stage past the stale threshold (see STALE_AFTER_MS). */
+  stalledLeads: number
+  /**
+   * % of leads that entered the funnel in the last 30 days and have
+   * since reached the "customer" stage. Null when the cohort is empty
+   * (nothing to divide by) rather than 0, so the UI can show "—"
+   * instead of a misleading 0%.
+   */
+  leadConversionRate: number | null
+  /** Cohort size behind `leadConversionRate` — shown as its subtitle. */
+  leadConversionCohortSize: number
+}
+
 export interface ResponseTimeBucket {
   /** 0 = Mon … 6 = Sun (Monday-first). */
   dow: number

--- a/src/lib/flows/meta-send.ts
+++ b/src/lib/flows/meta-send.ts
@@ -81,6 +81,7 @@ export async function engineSendText(
     .from('whatsapp_config')
     .select('*')
     .eq('account_id', args.accountId)
+    .eq('provider', 'meta')
     .single()
   if (configErr || !config) {
     throw new Error('WhatsApp not configured for this account')
@@ -190,6 +191,7 @@ export async function engineSendMedia(
     .from('whatsapp_config')
     .select('*')
     .eq('account_id', args.accountId)
+    .eq('provider', 'meta')
     .single()
   if (configErr || !config) {
     throw new Error('WhatsApp not configured for this account')
@@ -342,6 +344,7 @@ async function sendInteractiveViaMeta(
     .from('whatsapp_config')
     .select('*')
     .eq('account_id', input.accountId)
+    .eq('provider', 'meta')
     .single()
   if (configErr || !config) {
     throw new Error('WhatsApp not configured for this account')

--- a/src/lib/journey/enter-funnel.ts
+++ b/src/lib/journey/enter-funnel.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { ensureFunnelStages } from "./funnel-stages";
+
+/**
+ * Drops a brand-new contact into the first funnel stage the moment
+ * they send their first inbound message — the sales-funnel Kanban's
+ * counterpart to the `new_contact_created` automation trigger. Called
+ * from the WhatsApp and Uazapi webhooks right after `findOrCreateContact`
+ * reports `wasCreated: true`; both webhooks already run against
+ * `supabaseAdmin()`, so this bypasses RLS the same way the rest of the
+ * inbound path does.
+ *
+ * Idempotent: does nothing if a journey row already exists for this
+ * contact (defends against re-delivery/races on the same webhook
+ * event; `contact_journey` has a UNIQUE (account_id, contact_id)).
+ */
+export async function enterFunnelIfNew(
+  db: SupabaseClient,
+  accountId: string,
+  contactId: string,
+): Promise<void> {
+  const { data: existingJourney } = await db
+    .from("contact_journey")
+    .select("id")
+    .eq("account_id", accountId)
+    .eq("contact_id", contactId)
+    .maybeSingle();
+  if (existingJourney) return;
+
+  const stages = await ensureFunnelStages(db, accountId);
+  const firstStage = stages[0];
+  if (!firstStage) return;
+
+  const { data: journey, error } = await db
+    .from("contact_journey")
+    .insert({
+      account_id: accountId,
+      contact_id: contactId,
+      stage_id: firstStage.id,
+    })
+    .select("id")
+    .single();
+
+  if (error || !journey) {
+    // Unique violation means a concurrent delivery won the race — that
+    // insert already logged its own transition, nothing left to do.
+    if (error && error.code !== "23505") {
+      console.error("[enter-funnel] failed to create contact_journey:", error.message);
+    }
+    return;
+  }
+
+  const { error: transitionError } = await db.from("contact_journey_transitions").insert({
+    contact_journey_id: journey.id,
+    account_id: accountId,
+    from_stage_id: null,
+    to_stage_id: firstStage.id,
+  });
+  if (transitionError) {
+    console.error(
+      "[enter-funnel] failed to log initial transition:",
+      transitionError.message,
+    );
+  }
+}

--- a/src/lib/journey/funnel-stages.ts
+++ b/src/lib/journey/funnel-stages.ts
@@ -1,0 +1,86 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Fixed sales-funnel stages (migration 030). Unlike `pipeline_stages`,
+ * these are not user-configurable yet — every account gets the same
+ * list, lazily seeded into `funnel_stages` the first time it's needed
+ * (either an inbound message via `enterFunnelIfNew`, or the /kanban
+ * page load — whichever happens first for a given account).
+ *
+ * `key` is the stable machine name the rest of the app keys off of
+ * (e.g. picking "the first stage" for a brand-new lead); `position`
+ * is what the board sorts columns by.
+ */
+export const DEFAULT_FUNNEL_STAGES = [
+  { key: "new_lead", name: "New Lead", color: "#3b82f6", position: 0 },
+  { key: "engaged", name: "Engaged", color: "#06b6d4", position: 1 },
+  { key: "qualified", name: "Qualified", color: "#eab308", position: 2 },
+  { key: "negotiating", name: "Negotiating", color: "#f97316", position: 3 },
+  { key: "customer", name: "Customer", color: "#22c55e", position: 4 },
+  { key: "cold", name: "Cold / Lost", color: "#64748b", position: 5 },
+] as const;
+
+// Stalled-lead signal: a card sitting in the same stage past this
+// threshold gets flagged — on the Kanban card (aging badge) and in the
+// "Stalled Leads" dashboard metric alike, so both surfaces agree on
+// what "cooling off" means.
+export const STALE_AFTER_MS = 3 * 24 * 60 * 60 * 1000;
+
+export interface FunnelStageRow {
+  id: string;
+  account_id: string;
+  key: string;
+  name: string;
+  position: number;
+  color: string;
+  created_at: string;
+}
+
+/**
+ * Returns `accountId`'s funnel stages, ordered by position — seeding
+ * the default list first if the account has none yet. Safe to call
+ * from either the webhook (service-role client) or the browser client
+ * (agent+ per the `funnel_stages_insert` RLS policy).
+ */
+export async function ensureFunnelStages(
+  db: SupabaseClient,
+  accountId: string,
+): Promise<FunnelStageRow[]> {
+  const { data: existing } = await db
+    .from("funnel_stages")
+    .select("*")
+    .eq("account_id", accountId)
+    .order("position");
+
+  if (existing && existing.length > 0) return existing as FunnelStageRow[];
+
+  const payload = DEFAULT_FUNNEL_STAGES.map((s) => ({
+    account_id: accountId,
+    key: s.key,
+    name: s.name,
+    color: s.color,
+    position: s.position,
+  }));
+
+  const { error } = await db.from("funnel_stages").insert(payload);
+  if (error) {
+    // Lost a race against a concurrent seed attempt (e.g. two inbound
+    // messages for a brand-new account at once) — the (account_id, key)
+    // unique index rejected the duplicate. Re-select the winner's rows.
+    const { data: raced } = await db
+      .from("funnel_stages")
+      .select("*")
+      .eq("account_id", accountId)
+      .order("position");
+    if (raced && raced.length > 0) return raced as FunnelStageRow[];
+    console.error("[funnel-stages] failed to seed default stages:", error.message);
+    return [];
+  }
+
+  const { data: seeded } = await db
+    .from("funnel_stages")
+    .select("*")
+    .eq("account_id", accountId)
+    .order("position");
+  return (seeded ?? []) as FunnelStageRow[];
+}

--- a/src/lib/whatsapp/broadcast-core.ts
+++ b/src/lib/whatsapp/broadcast-core.ts
@@ -115,6 +115,7 @@ export async function createBroadcast(
     .from('whatsapp_config')
     .select('*')
     .eq('account_id', accountId)
+    .eq('provider', 'meta')
     .single();
   if (configError || !config) {
     throw new BroadcastError(

--- a/src/lib/whatsapp/providers/factory.ts
+++ b/src/lib/whatsapp/providers/factory.ts
@@ -1,0 +1,44 @@
+/**
+ * Provider factory — turns a `whatsapp_config` row into the matching
+ * `WhatsAppProvider` implementation. Every outbound call site should
+ * go through this instead of reading `access_token` / `uazapi_*`
+ * columns directly, so provider-specific plumbing stays in one place.
+ */
+
+import { decrypt } from '../encryption'
+import { MetaProvider } from './meta'
+import { UazapiProvider } from './uazapi'
+import type { WhatsAppProvider } from './types'
+
+/**
+ * Minimal shape read from `whatsapp_config` — matches the columns
+ * added in migration 029. Callers can pass the full Supabase row;
+ * extra fields are ignored.
+ */
+export interface WhatsAppConfigRow {
+  provider: string
+  phone_number_id?: string | null
+  access_token?: string | null
+  uazapi_instance_token?: string | null
+  uazapi_base_url?: string | null
+}
+
+export function getProviderFromConfig(config: WhatsAppConfigRow): WhatsAppProvider {
+  if (config.provider === 'uazapi') {
+    if (!config.uazapi_instance_token || !config.uazapi_base_url) {
+      throw new Error('Uazapi config is missing instance_token or base_url')
+    }
+    return new UazapiProvider({
+      instanceToken: decrypt(config.uazapi_instance_token),
+      baseUrl: config.uazapi_base_url,
+    })
+  }
+
+  if (!config.phone_number_id || !config.access_token) {
+    throw new Error('Meta config is missing phone_number_id or access_token')
+  }
+  return new MetaProvider({
+    phoneNumberId: config.phone_number_id,
+    accessToken: decrypt(config.access_token),
+  })
+}

--- a/src/lib/whatsapp/providers/meta.ts
+++ b/src/lib/whatsapp/providers/meta.ts
@@ -13,11 +13,13 @@ import type {
   DownloadMediaArgs,
   DownloadMediaResult,
   SendResult,
+  ReactArgs,
 } from './types'
 import {
   sendTextMessage,
   sendMediaMessage,
   sendTemplateMessage,
+  sendReactionMessage,
   getMediaUrl,
   downloadMedia as downloadMetaMedia,
   type MediaKind,
@@ -85,5 +87,15 @@ export class MetaProvider implements WhatsAppProvider {
       accessToken: this.config.accessToken,
     })
     return { buffer, contentType }
+  }
+
+  async reactToMessage(args: ReactArgs): Promise<void> {
+    await sendReactionMessage({
+      phoneNumberId: this.config.phoneNumberId,
+      accessToken: this.config.accessToken,
+      to: args.to,
+      targetMessageId: args.targetExternalId,
+      emoji: args.emoji,
+    })
   }
 }

--- a/src/lib/whatsapp/providers/meta.ts
+++ b/src/lib/whatsapp/providers/meta.ts
@@ -1,0 +1,89 @@
+/**
+ * Meta provider — thin adapter over `meta-api.ts` implementing the
+ * provider-agnostic `WhatsAppProvider` interface. Behaviour for Meta
+ * accounts is unchanged; this only renames/reshapes the return values
+ * so callers can treat Meta and Uazapi identically.
+ */
+
+import type {
+  WhatsAppProvider,
+  SendTextArgs,
+  SendMediaArgs,
+  SendTemplateArgs,
+  DownloadMediaArgs,
+  DownloadMediaResult,
+  SendResult,
+} from './types'
+import {
+  sendTextMessage,
+  sendMediaMessage,
+  sendTemplateMessage,
+  getMediaUrl,
+  downloadMedia as downloadMetaMedia,
+  type MediaKind,
+} from '../meta-api'
+import type { MessageTemplate } from '@/types'
+import type { SendTimeParams } from '../template-send-builder'
+
+export interface MetaProviderConfig {
+  phoneNumberId: string
+  accessToken: string
+}
+
+export class MetaProvider implements WhatsAppProvider {
+  readonly name = 'meta' as const
+
+  constructor(private readonly config: MetaProviderConfig) {}
+
+  async sendText(args: SendTextArgs): Promise<SendResult> {
+    const result = await sendTextMessage({
+      phoneNumberId: this.config.phoneNumberId,
+      accessToken: this.config.accessToken,
+      to: args.to,
+      text: args.text,
+      contextMessageId: args.replyToExternalId,
+    })
+    return { externalMessageId: result.messageId }
+  }
+
+  async sendMedia(args: SendMediaArgs): Promise<SendResult> {
+    const result = await sendMediaMessage({
+      phoneNumberId: this.config.phoneNumberId,
+      accessToken: this.config.accessToken,
+      to: args.to,
+      kind: args.kind as MediaKind,
+      link: args.link,
+      caption: args.caption,
+      filename: args.filename,
+      contextMessageId: args.replyToExternalId,
+    })
+    return { externalMessageId: result.messageId }
+  }
+
+  async sendTemplate(args: SendTemplateArgs): Promise<SendResult> {
+    const result = await sendTemplateMessage({
+      phoneNumberId: this.config.phoneNumberId,
+      accessToken: this.config.accessToken,
+      to: args.to,
+      templateName: args.templateName,
+      language: args.language || 'en_US',
+      params: args.params,
+      template: args.templateRow as MessageTemplate | undefined,
+      messageParams: args.messageParams as SendTimeParams | undefined,
+      contextMessageId: args.replyToExternalId,
+    })
+    return { externalMessageId: result.messageId }
+  }
+
+  async downloadMedia(args: DownloadMediaArgs): Promise<DownloadMediaResult> {
+    const { url } = await getMediaUrl({
+      mediaId: args.mediaRef,
+      accessToken: this.config.accessToken,
+    })
+    const { buffer, contentType } = await downloadMetaMedia({
+      downloadUrl: url,
+      accessToken: this.config.accessToken,
+    })
+    return { buffer, contentType }
+  }
+}

--- a/src/lib/whatsapp/providers/types.ts
+++ b/src/lib/whatsapp/providers/types.ts
@@ -67,6 +67,14 @@ export interface DownloadMediaResult {
   contentType: string
 }
 
+export interface ReactArgs {
+  to: string
+  /** externalMessageId of the message being reacted to. */
+  targetExternalId: string
+  /** Single emoji, or empty string to remove an existing reaction. */
+  emoji: string
+}
+
 export interface WhatsAppProvider {
   readonly name: 'meta' | 'uazapi'
   sendText(args: SendTextArgs): Promise<SendResult>
@@ -74,4 +82,5 @@ export interface WhatsAppProvider {
   /** Meta: real approved template. Uazapi: falls back to plain text. */
   sendTemplate(args: SendTemplateArgs): Promise<SendResult>
   downloadMedia(args: DownloadMediaArgs): Promise<DownloadMediaResult>
+  reactToMessage(args: ReactArgs): Promise<void>
 }

--- a/src/lib/whatsapp/providers/types.ts
+++ b/src/lib/whatsapp/providers/types.ts
@@ -1,0 +1,77 @@
+/**
+ * Provider-agnostic WhatsApp sending interface.
+ *
+ * Both `meta.ts` and `uazapi.ts` implement this so every call site
+ * (send-message.ts, automations, flows, broadcasts) can send without
+ * knowing which provider is behind a given `whatsapp_config` row.
+ *
+ * Capability gaps between providers are absorbed HERE, not by the
+ * caller:
+ *   - Meta templates require Meta approval + only work inside the 24h
+ *     window. Uazapi has no such concept — `sendTemplate` on the
+ *     Uazapi implementation renders the template body as plain text.
+ *   - Meta's message id is a plain `wamid`; Uazapi's is a composite
+ *     `owner:messageid`. Callers must treat `externalMessageId` as an
+ *     opaque string and pass it back verbatim (e.g. for `replyTo`).
+ */
+
+export type MediaKind = 'image' | 'video' | 'document' | 'audio'
+
+export interface SendResult {
+  /** Provider's id for the sent message — Meta's `wamid`, or Uazapi's `owner:messageid`. */
+  externalMessageId: string
+}
+
+export interface SendTextArgs {
+  to: string
+  text: string
+  /** externalMessageId of the message being replied to (quote preview). */
+  replyToExternalId?: string
+}
+
+export interface SendMediaArgs {
+  to: string
+  kind: MediaKind
+  /** Public URL the provider fetches at send time. */
+  link: string
+  caption?: string
+  /** Document-only file name. */
+  filename?: string
+  replyToExternalId?: string
+}
+
+export interface SendTemplateArgs {
+  to: string
+  templateName: string
+  language?: string
+  /** Body variable values, positional. */
+  params?: string[]
+  replyToExternalId?: string
+  /**
+   * Meta-only: the local `message_templates` row (header/button
+   * components). Ignored by providers without a template concept
+   * (Uazapi falls back to plain text using `templateName` + `params`).
+   */
+  templateRow?: unknown
+  /** Meta-only: structured per-send values (header text/media, button params). */
+  messageParams?: unknown
+}
+
+export interface DownloadMediaArgs {
+  /** Provider-specific media reference — Meta media id, or Uazapi externalMessageId. */
+  mediaRef: string
+}
+
+export interface DownloadMediaResult {
+  buffer: Buffer
+  contentType: string
+}
+
+export interface WhatsAppProvider {
+  readonly name: 'meta' | 'uazapi'
+  sendText(args: SendTextArgs): Promise<SendResult>
+  sendMedia(args: SendMediaArgs): Promise<SendResult>
+  /** Meta: real approved template. Uazapi: falls back to plain text. */
+  sendTemplate(args: SendTemplateArgs): Promise<SendResult>
+  downloadMedia(args: DownloadMediaArgs): Promise<DownloadMediaResult>
+}

--- a/src/lib/whatsapp/providers/uazapi.test.ts
+++ b/src/lib/whatsapp/providers/uazapi.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { UazapiProvider } from './uazapi'
+
+const CONFIG = {
+  instanceToken: 'test-token',
+  baseUrl: 'https://api.uazapi.com',
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+describe('UazapiProvider.sendText', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts to /send/text with digits-only number and the instance token header', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ id: 'owner:ABC123' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new UazapiProvider(CONFIG)
+    const result = await provider.sendText({ to: '5511999999999', text: 'hi' })
+
+    expect(result.externalMessageId).toBe('owner:ABC123')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://api.uazapi.com/send/text')
+    expect((init.headers as Record<string, string>).token).toBe('test-token')
+    expect(JSON.parse(init.body as string)).toEqual({
+      number: '5511999999999',
+      text: 'hi',
+    })
+  })
+
+  it('throws with the Uazapi error message on a non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ error: 'invalid token' }, false, 401))
+    )
+    const provider = new UazapiProvider(CONFIG)
+    await expect(provider.sendText({ to: '5511999999999', text: 'hi' })).rejects.toThrow(
+      /invalid token/
+    )
+  })
+})
+
+describe('UazapiProvider.sendTemplate — fallback to plain text', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the template name + params as text via /send/text', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ id: 'owner:XYZ' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = new UazapiProvider(CONFIG)
+    await provider.sendTemplate({
+      to: '5511999999999',
+      templateName: 'welcome',
+      params: ['John'],
+    })
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://api.uazapi.com/send/text')
+    expect(JSON.parse(init.body as string).text).toBe('welcome\nJohn')
+  })
+})
+
+describe('UazapiProvider.downloadMedia', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('decodes the base64 payload returned by /message/download', async () => {
+    const base64 = Buffer.from('hello').toString('base64')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ base64, mimetype: 'text/plain' }))
+    )
+    const provider = new UazapiProvider(CONFIG)
+    const result = await provider.downloadMedia({ mediaRef: 'owner:ABC123' })
+
+    expect(result.buffer.toString('utf8')).toBe('hello')
+    expect(result.contentType).toBe('text/plain')
+  })
+
+  it('throws when the response has no base64 payload', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({})))
+    const provider = new UazapiProvider(CONFIG)
+    await expect(provider.downloadMedia({ mediaRef: 'owner:ABC123' })).rejects.toThrow(
+      /no base64/
+    )
+  })
+})

--- a/src/lib/whatsapp/providers/uazapi.ts
+++ b/src/lib/whatsapp/providers/uazapi.ts
@@ -18,6 +18,7 @@ import type {
   DownloadMediaArgs,
   DownloadMediaResult,
   SendResult,
+  ReactArgs,
 } from './types'
 
 export interface UazapiProviderConfig {
@@ -133,6 +134,26 @@ export class UazapiProvider implements WhatsAppProvider {
     return {
       buffer: Buffer.from(data.base64, 'base64'),
       contentType: data.mimetype || data.mimeType || 'application/octet-stream',
+    }
+  }
+
+  /**
+   * POST /message/react — `id` must be the full `owner:messageid`
+   * form (same value stored as `externalMessageId`/`messages.message_id`
+   * for Uazapi rows). Empty `emoji` removes an existing reaction.
+   */
+  async reactToMessage(args: ReactArgs): Promise<void> {
+    const response = await fetch(this.url('/message/react'), {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        number: args.to,
+        id: args.targetExternalId,
+        text: args.emoji,
+      }),
+    })
+    if (!response.ok) {
+      await throwUazapiError(response, `Uazapi reaction failed: ${response.status}`)
     }
   }
 

--- a/src/lib/whatsapp/providers/uazapi.ts
+++ b/src/lib/whatsapp/providers/uazapi.ts
@@ -1,0 +1,153 @@
+/**
+ * Uazapi provider — HTTP client for the Uazapi REST API implementing
+ * the provider-agnostic `WhatsAppProvider` interface.
+ *
+ * Capability gaps vs. Meta (see docs/uazapi-integration-plan.md):
+ *   - No approved templates / 24h window. `sendTemplate` renders the
+ *     template name + params as plain text and sends via /send/text.
+ *   - Message ids are `owner:messageid` (composite) — always persist
+ *     the full string returned by Uazapi; it's required for replies.
+ *   - Media download is an explicit POST (no CDN URL handed to us).
+ */
+
+import type {
+  WhatsAppProvider,
+  SendTextArgs,
+  SendMediaArgs,
+  SendTemplateArgs,
+  DownloadMediaArgs,
+  DownloadMediaResult,
+  SendResult,
+} from './types'
+
+export interface UazapiProviderConfig {
+  instanceToken: string
+  baseUrl: string
+}
+
+interface UazapiSendResponse {
+  id?: string
+  messageid?: string
+  response?: { status?: string; message?: string }
+}
+
+async function throwUazapiError(response: Response, fallback: string): Promise<never> {
+  let message = fallback
+  try {
+    const data = await response.json()
+    if (typeof data?.error === 'string') message = data.error
+    else if (typeof data?.message === 'string') message = data.message
+  } catch {
+    // not JSON — keep fallback
+  }
+  throw new Error(message)
+}
+
+export class UazapiProvider implements WhatsAppProvider {
+  readonly name = 'uazapi' as const
+
+  constructor(private readonly config: UazapiProviderConfig) {}
+
+  private headers(): Record<string, string> {
+    return {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      token: this.config.instanceToken,
+    }
+  }
+
+  private url(path: string): string {
+    return `${this.config.baseUrl.replace(/\/$/, '')}${path}`
+  }
+
+  async sendText(args: SendTextArgs): Promise<SendResult> {
+    const body: Record<string, unknown> = {
+      number: args.to,
+      text: args.text,
+    }
+    if (args.replyToExternalId) body.replyid = args.replyToExternalId
+
+    const response = await fetch(this.url('/send/text'), {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    })
+    if (!response.ok) {
+      await throwUazapiError(response, `Uazapi API error: ${response.status}`)
+    }
+    const data = (await response.json()) as UazapiSendResponse
+    return { externalMessageId: data.id || data.messageid || '' }
+  }
+
+  async sendMedia(args: SendMediaArgs): Promise<SendResult> {
+    const body: Record<string, unknown> = {
+      number: args.to,
+      type: args.kind,
+      file: args.link,
+    }
+    if (args.caption) body.text = args.caption
+    if (args.kind === 'document' && args.filename) body.docName = args.filename
+    if (args.replyToExternalId) body.replyid = args.replyToExternalId
+
+    const response = await fetch(this.url('/send/media'), {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    })
+    if (!response.ok) {
+      await throwUazapiError(response, `Uazapi API error: ${response.status}`)
+    }
+    const data = (await response.json()) as UazapiSendResponse
+    return { externalMessageId: data.id || data.messageid || '' }
+  }
+
+  /**
+   * Uazapi has no template/approval concept — render as plain text.
+   * `params` are appended positionally in place of {{1}}, {{2}}, ...
+   * style placeholders is out of scope for the MVP; callers pass an
+   * already-rendered body via `templateName` when they need Uazapi
+   * fallback text (see send-message.ts).
+   */
+  async sendTemplate(args: SendTemplateArgs): Promise<SendResult> {
+    const text = [args.templateName, ...(args.params || [])].filter(Boolean).join('\n')
+    return this.sendText({
+      to: args.to,
+      text,
+      replyToExternalId: args.replyToExternalId,
+    })
+  }
+
+  async downloadMedia(args: DownloadMediaArgs): Promise<DownloadMediaResult> {
+    const response = await fetch(this.url('/message/download'), {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({ id: args.mediaRef, return_base64: true }),
+    })
+    if (!response.ok) {
+      await throwUazapiError(response, `Uazapi media download failed: ${response.status}`)
+    }
+    const data = (await response.json()) as { base64?: string; mimetype?: string; mimeType?: string }
+    if (!data.base64) {
+      throw new Error('Uazapi media download returned no base64 payload')
+    }
+    return {
+      buffer: Buffer.from(data.base64, 'base64'),
+      contentType: data.mimetype || data.mimeType || 'application/octet-stream',
+    }
+  }
+
+  /** Validates the instance token by hitting /instance/status. */
+  async verifyConnection(): Promise<{ connected: boolean; loggedIn: boolean }> {
+    const response = await fetch(this.url('/instance/status'), {
+      headers: this.headers(),
+    })
+    if (!response.ok) {
+      await throwUazapiError(response, `Uazapi API error: ${response.status}`)
+    }
+    const data = (await response.json()) as { status?: { connected?: boolean; loggedIn?: boolean } }
+    return {
+      connected: Boolean(data.status?.connected),
+      loggedIn: Boolean(data.status?.loggedIn),
+    }
+  }
+}

--- a/src/lib/whatsapp/resolve-conversation.test.ts
+++ b/src/lib/whatsapp/resolve-conversation.test.ts
@@ -12,14 +12,18 @@ import { SendMessageError } from './send-message';
 type ContactRow = { id: string; phone: string; name?: string | null };
 
 interface Script {
-  config?: { user_id: string } | null; // whatsapp_config.maybeSingle
+  // whatsapp_config — resolveAuditUserId's `.limit(1)` and
+  // resolve-conversation's default-provider `.select('provider, is_default')`
+  // both resolve via the bare `then()` below (unterminated builder chain),
+  // so a single row list backs both.
+  config?: { user_id: string; provider?: string; is_default?: boolean } | null;
   contactCandidates?: ContactRow[]; // contacts .like (same every call)
   /** Per-call `.like` results — overrides contactCandidates. Lets a
    *  test simulate "miss, then hit" for the unique-race path. */
   contactCandidatesByCall?: ContactRow[][];
   insertedContactId?: string; // contacts insert -> single
   insertContactError?: { code?: string } | null;
-  existingConversation?: { id: string } | null; // conversations select.maybeSingle
+  existingConversation?: { id: string; provider?: string } | null; // conversations select.maybeSingle
   insertedConversationId?: string; // conversations insert -> single
 }
 
@@ -30,6 +34,7 @@ function makeDb(script: Script): SupabaseClient {
 
   const builder: Record<string, unknown> = {
     select: () => builder,
+    limit: () => builder,
     insert: () => {
       mode = 'insert';
       return builder;
@@ -75,9 +80,17 @@ function makeDb(script: Script): SupabaseClient {
         });
       return Promise.resolve({ data: null, error: null });
     },
-    // Thenable: `await db.from().update().eq()` lands here.
-    then: (resolve: (v: { data: null; error: null }) => void) =>
-      resolve({ data: null, error: null }),
+    // Thenable: `await db.from().update().eq()` lands here, as does
+    // `await db.from('whatsapp_config').select(...).eq(...)` (no
+    // terminal .single()/.maybeSingle()) — used by resolveAuditUserId's
+    // `.limit(1)` and resolve-conversation's default-provider lookup.
+    then: (resolve: (v: { data: unknown; error: null }) => void) => {
+      if (table === 'whatsapp_config' && mode === 'select') {
+        resolve({ data: script.config ? [script.config] : [], error: null });
+        return;
+      }
+      resolve({ data: null, error: null });
+    },
   };
 
   return {
@@ -116,9 +129,9 @@ describe('resolveConversationByPhone', () => {
 
   it('returns the existing contact + conversation without creating', async () => {
     const db = makeDb({
-      config: { user_id: 'owner-1' },
+      config: { user_id: 'owner-1', provider: 'meta' },
       contactCandidates: [{ id: 'c1', phone: '14155550123' }],
-      existingConversation: { id: 'cv1' },
+      existingConversation: { id: 'cv1', provider: 'meta' },
     });
     const res = await resolveConversationByPhone(
       db,
@@ -129,12 +142,13 @@ describe('resolveConversationByPhone', () => {
       conversationId: 'cv1',
       contactId: 'c1',
       contactCreated: false,
+      provider: 'meta',
     });
   });
 
   it('creates contact + conversation when none exist', async () => {
     const db = makeDb({
-      config: { user_id: 'owner-1' },
+      config: { user_id: 'owner-1', provider: 'meta' },
       contactCandidates: [],
       insertedContactId: 'c2',
       existingConversation: null,
@@ -149,6 +163,7 @@ describe('resolveConversationByPhone', () => {
     expect(res).toEqual({
       conversationId: 'cv2',
       contactId: 'c2',
+      provider: 'meta',
       contactCreated: true,
     });
   });

--- a/src/lib/whatsapp/resolve-conversation.ts
+++ b/src/lib/whatsapp/resolve-conversation.ts
@@ -30,6 +30,8 @@ export interface ResolvedConversation {
   contactId: string;
   /** True if this call created the contact (vs matched an existing one). */
   contactCreated: boolean;
+  /** Provider the conversation is (or was already) associated with. */
+  provider: string;
 }
 
 /**
@@ -37,12 +39,20 @@ export interface ResolvedConversation {
  * `accountId`. Throws `SendMessageError` (shared with the send core,
  * so the route maps one error family) on a bad phone, a missing
  * WhatsApp config, or a DB failure.
+ *
+ * `provider` selects which WhatsApp connection a brand-new conversation
+ * is stamped with (see migration 029 — an account can hold a Meta row,
+ * a Uazapi row, or both). Omit it to use the account's default
+ * provider (`whatsapp_config.is_default`). Ignored when the contact
+ * already has a conversation — that conversation keeps whichever
+ * provider opened it.
  */
 export async function resolveConversationByPhone(
   db: SupabaseClient,
   accountId: string,
   phone: string,
-  name?: string | null
+  name?: string | null,
+  provider?: 'meta' | 'uazapi'
 ): Promise<ResolvedConversation> {
   const sanitized = sanitizePhoneForMeta(phone);
   if (!isValidE164(sanitized)) {
@@ -53,19 +63,39 @@ export async function resolveConversationByPhone(
     );
   }
 
-  // Fail fast (and create nothing) when the account has no WhatsApp
-  // connected — the same error the send would raise anyway.
-  const { data: config } = await db
-    .from('whatsapp_config')
-    .select('id')
-    .eq('account_id', accountId)
-    .maybeSingle();
-  if (!config) {
-    throw new SendMessageError(
-      'whatsapp_not_configured',
-      'WhatsApp not configured. Please set up your WhatsApp integration first.',
-      400
-    );
+  // Resolve which config to use — an explicit `provider` must exist as
+  // a connected row; otherwise fall back to the account's default, and
+  // finally to whichever single row exists (pre-multi-provider accounts).
+  let resolvedProvider: string;
+  if (provider) {
+    const { data: config } = await db
+      .from('whatsapp_config')
+      .select('id')
+      .eq('account_id', accountId)
+      .eq('provider', provider)
+      .maybeSingle();
+    if (!config) {
+      throw new SendMessageError(
+        'whatsapp_not_configured',
+        `WhatsApp (${provider}) is not configured for this account.`,
+        400
+      );
+    }
+    resolvedProvider = provider;
+  } else {
+    const { data: configs } = await db
+      .from('whatsapp_config')
+      .select('provider, is_default')
+      .eq('account_id', accountId);
+    if (!configs || configs.length === 0) {
+      throw new SendMessageError(
+        'whatsapp_not_configured',
+        'WhatsApp not configured. Please set up your WhatsApp integration first.',
+        400
+      );
+    }
+    resolvedProvider =
+      configs.find((c) => c.is_default)?.provider ?? configs[0].provider;
   }
 
   // Audit user for created rows = the single account-wide default used
@@ -141,13 +171,20 @@ export async function resolveConversationByPhone(
   // webhook.
   const { data: conv } = await db
     .from('conversations')
-    .select('id')
+    .select('id, provider')
     .eq('account_id', accountId)
     .eq('contact_id', contactId)
     .maybeSingle();
 
   if (conv?.id) {
-    return { conversationId: conv.id, contactId, contactCreated };
+    // Keep whichever provider actually opened this conversation — the
+    // caller's requested `provider` only applies to brand-new threads.
+    return {
+      conversationId: conv.id,
+      contactId,
+      contactCreated,
+      provider: conv.provider || 'meta',
+    };
   }
 
   const { data: newConv, error: convErr } = await db
@@ -156,6 +193,7 @@ export async function resolveConversationByPhone(
       account_id: accountId,
       user_id: ownerUserId,
       contact_id: contactId,
+      provider: resolvedProvider,
     })
     .select('id')
     .single();
@@ -169,5 +207,10 @@ export async function resolveConversationByPhone(
     );
   }
 
-  return { conversationId: newConv.id, contactId, contactCreated };
+  return {
+    conversationId: newConv.id,
+    contactId,
+    contactCreated,
+    provider: resolvedProvider,
+  };
 }

--- a/src/lib/whatsapp/send-message.ts
+++ b/src/lib/whatsapp/send-message.ts
@@ -21,12 +21,6 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-import {
-  sendTextMessage,
-  sendTemplateMessage,
-  sendMediaMessage,
-  type MediaKind,
-} from '@/lib/whatsapp/meta-api';
 import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption';
 import { supabaseAdmin } from '@/lib/flows/admin-client';
 import {
@@ -37,6 +31,8 @@ import {
 } from '@/lib/whatsapp/phone-utils';
 import type { MessageTemplate } from '@/types';
 import { isMessageTemplate } from '@/lib/whatsapp/template-row-guard';
+import { getProviderFromConfig, type WhatsAppConfigRow } from '@/lib/whatsapp/providers/factory';
+import type { MediaKind } from '@/lib/whatsapp/providers/types';
 
 export const MEDIA_KINDS = ['image', 'video', 'document', 'audio'] as const;
 export const VALID_MESSAGE_TYPES = [
@@ -210,6 +206,9 @@ export async function sendMessageToConversation(
     );
   }
 
+  // Sanitization is digits-only for both providers — same format Uazapi
+  // expects for `number`. isValidE164 stays a Meta-shaped sanity check;
+  // Uazapi numbers happen to satisfy it too (same E.164-ish digit range).
   const sanitizedPhone = sanitizePhoneForMeta(contact.phone);
   if (!isValidE164(sanitizedPhone)) {
     throw new SendMessageError(
@@ -219,11 +218,16 @@ export async function sendMessageToConversation(
     );
   }
 
-  // WhatsApp config, account-scoped.
+  // WhatsApp config — scoped to the conversation's provider. A
+  // conversation created before migration 029 has provider='meta' by
+  // column default, which matches the only config row such an account
+  // could have had.
+  const conversationProvider = (conversation.provider as string | null) || 'meta';
   const { data: config, error: configError } = await db
     .from('whatsapp_config')
     .select('*')
     .eq('account_id', accountId)
+    .eq('provider', conversationProvider)
     .single();
 
   if (configError || !config) {
@@ -234,13 +238,12 @@ export async function sendMessageToConversation(
     );
   }
 
-  const accessToken = decrypt(config.access_token);
-
-  // Self-heal legacy CBC ciphertexts. Fire-and-forget; idempotent.
-  if (isLegacyFormat(config.access_token)) {
+  // Self-heal legacy CBC access_token ciphertexts (Meta only — Uazapi
+  // never had a CBC-era token). Fire-and-forget; idempotent.
+  if (config.provider === 'meta' && config.access_token && isLegacyFormat(config.access_token)) {
     void db
       .from('whatsapp_config')
-      .update({ access_token: encrypt(accessToken) })
+      .update({ access_token: encrypt(decrypt(config.access_token)) })
       .eq('id', config.id)
       .then(({ error }: { error: { message: string } | null }) => {
         if (error) {
@@ -251,6 +254,8 @@ export async function sendMessageToConversation(
         }
       });
   }
+
+  const provider = getProviderFromConfig(config as WhatsAppConfigRow);
 
   // Resolve the reply target to its Meta message_id. The parent must
   // belong to this same conversation — otherwise a caller could quote
@@ -303,49 +308,43 @@ export async function sendMessageToConversation(
 
   const attempt = async (phone: string): Promise<string> => {
     if (messageType === 'template') {
-      const result = await sendTemplateMessage({
-        phoneNumberId: config.phone_number_id,
-        accessToken,
+      const result = await provider.sendTemplate({
         to: phone,
         templateName: templateName!,
         language: templateLanguage || 'en_US',
-        template: templateRow ?? undefined,
+        templateRow: templateRow ?? undefined,
         messageParams: templateMessageParams ?? undefined,
         params: templateParams || [],
-        contextMessageId,
+        replyToExternalId: contextMessageId,
       });
-      return result.messageId;
+      return result.externalMessageId;
     }
     if (isMediaKind) {
-      const result = await sendMediaMessage({
-        phoneNumberId: config.phone_number_id,
-        accessToken,
+      const result = await provider.sendMedia({
         to: phone,
         kind: messageType as MediaKind,
         link: mediaUrl!,
         caption: contentText || undefined,
         filename: filename || undefined,
-        contextMessageId,
+        replyToExternalId: contextMessageId,
       });
-      return result.messageId;
+      return result.externalMessageId;
     }
-    const result = await sendTextMessage({
-      phoneNumberId: config.phone_number_id,
-      accessToken,
+    const result = await provider.sendText({
       to: phone,
       text: contentText!,
-      contextMessageId,
+      replyToExternalId: contextMessageId,
     });
-    return result.messageId;
+    return result.externalMessageId;
   };
 
-  // Send via Meta — retry across phone-number variants if Meta rejects
-  // with "recipient not in allowed list"; persist a working variant
-  // back to the contact so the next send goes straight through.
+  // Phone-variant retry is a Meta-specific workaround (sandbox numbers
+  // rejecting a trunk-prefix mismatch) — Uazapi has no such allowed-list
+  // concept, so it sends once with the sanitized number.
   let waMessageId = '';
   let workingPhone = sanitizedPhone;
   try {
-    const variants = phoneVariants(sanitizedPhone);
+    const variants = provider.name === 'meta' ? phoneVariants(sanitizedPhone) : [sanitizedPhone];
     let lastError: unknown = null;
 
     for (const variant of variants) {
@@ -369,9 +368,9 @@ export async function sendMessageToConversation(
     if (lastError) throw lastError;
   } catch (err) {
     const message =
-      err instanceof Error ? err.message : 'Unknown Meta API error';
-    console.error('[send-message] Meta send failed for all variants:', message);
-    throw new SendMessageError('meta_error', `Meta API error: ${message}`, 502);
+      err instanceof Error ? err.message : `Unknown ${provider.name} API error`;
+    console.error(`[send-message] ${provider.name} send failed for all variants:`, message);
+    throw new SendMessageError('provider_error', `${provider.name} API error: ${message}`, 502);
   }
 
   if (workingPhone !== sanitizedPhone) {
@@ -398,6 +397,7 @@ export async function sendMessageToConversation(
       message_id: waMessageId,
       status: 'sent',
       reply_to_message_id: replyToMessageId || null,
+      provider: provider.name,
     })
     .select()
     .single();

--- a/src/lib/whatsapp/uazapi-instance.ts
+++ b/src/lib/whatsapp/uazapi-instance.ts
@@ -1,0 +1,89 @@
+/**
+ * Uazapi instance attachment — verify a token's status and configure
+ * the inbound webhook. Distinct from `providers/uazapi.ts` (message
+ * send/receive), which handles day-to-day send/receive traffic.
+ *
+ * wacrm's role is deliberately narrow: it never creates an instance
+ * (no admin-token `/instance/create`) and never drives the WhatsApp
+ * session lifecycle (no `/instance/connect` QR flow, no
+ * `/instance/disconnect`). The instance is created AND logged in
+ * directly in the Uazapi panel by whoever manages it; wacrm only
+ * attaches to an already-authenticated instance token, receives
+ * inbound messages via webhook, and sends through the same token
+ * (see /api/uazapi/instance and /api/uazapi/webhook/[configId]).
+ */
+
+interface UazapiErrorBody {
+  error?: string
+  message?: string
+}
+
+async function throwUazapiError(response: Response, fallback: string): Promise<never> {
+  let message = fallback
+  try {
+    const data = (await response.json()) as UazapiErrorBody
+    message = data.error || data.message || fallback
+  } catch {
+    // not JSON — keep fallback
+  }
+  throw new Error(message)
+}
+
+function baseUrlOf(baseUrl: string): string {
+  return baseUrl.replace(/\/$/, '')
+}
+
+export interface InstanceStatusArgs {
+  baseUrl: string
+  instanceToken: string
+}
+
+export interface InstanceStatusResult {
+  connected: boolean
+  loggedIn: boolean
+}
+
+/**
+ * GET /instance/status — used purely to (a) validate a token when
+ * it's first attached and (b) show the WhatsApp session's live state
+ * in Settings. Never followed by a connect/pairing call.
+ */
+export async function getInstanceStatus(args: InstanceStatusArgs): Promise<InstanceStatusResult> {
+  const response = await fetch(`${baseUrlOf(args.baseUrl)}/instance/status`, {
+    headers: { token: args.instanceToken },
+  })
+  if (!response.ok) {
+    await throwUazapiError(response, `Uazapi instance status failed: ${response.status}`)
+  }
+  const data = (await response.json()) as { status?: { connected?: boolean; loggedIn?: boolean } }
+  return {
+    connected: Boolean(data.status?.connected),
+    loggedIn: Boolean(data.status?.loggedIn),
+  }
+}
+
+export interface ConfigureWebhookArgs {
+  baseUrl: string
+  instanceToken: string
+  url: string
+  events?: string[]
+}
+
+/** POST /webhook — points the instance's inbound events at our route. Idempotent. */
+export async function configureWebhook(args: ConfigureWebhookArgs): Promise<void> {
+  const response = await fetch(`${baseUrlOf(args.baseUrl)}/webhook`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      token: args.instanceToken,
+    },
+    body: JSON.stringify({
+      url: args.url,
+      events: args.events || ['messages', 'connection'],
+      enabled: true,
+    }),
+  })
+  if (!response.ok) {
+    await throwUazapiError(response, `Uazapi webhook configuration failed: ${response.status}`)
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -369,6 +369,52 @@ export interface Deal {
   assignee?: Profile;
 }
 
+// ---- Customer journey (sales-funnel Kanban, migration 030) --------
+//
+// Contact-centric counterpart to Pipeline/Deal above: every contact
+// enters `contact_journey` automatically on their first inbound
+// message (see src/lib/journey/enter-funnel.ts) and moves through
+// `funnel_stages` independently of whether a Deal has been opened.
+
+export interface FunnelStage {
+  id: string;
+  account_id: string;
+  key: string;
+  name: string;
+  position: number;
+  color: string;
+  created_at: string;
+}
+
+export interface ContactJourney {
+  id: string;
+  account_id: string;
+  contact_id: string;
+  stage_id: string;
+  entered_stage_at: string;
+  created_at: string;
+  updated_at: string;
+  contact?: Contact;
+  stage?: FunnelStage;
+  /**
+   * Attached client-side (not a DB join — `conversations.contact_id`
+   * has no unique constraint, so Supabase would embed it as an array).
+   * The Kanban page fetches conversations separately and indexes them
+   * by `contact_id` to populate this for the last-message preview.
+   */
+  conversation?: Pick<Conversation, "id" | "last_message_text" | "last_message_at">;
+}
+
+export interface ContactJourneyTransition {
+  id: string;
+  contact_journey_id: string;
+  account_id: string;
+  from_stage_id: string | null;
+  to_stage_id: string;
+  changed_by: string | null;
+  changed_at: string;
+}
+
 export type BroadcastStatus = 'draft' | 'scheduled' | 'sending' | 'sent' | 'failed';
 export type RecipientStatus = 'pending' | 'sent' | 'delivered' | 'read' | 'replied' | 'failed';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -159,6 +159,13 @@ export interface Conversation {
   created_at: string;
   updated_at: string;
   contact?: Contact;
+  /**
+   * Which WhatsApp provider owns this conversation (migration 029).
+   * Stamped once at creation by whichever webhook opened the thread;
+   * outbound sends read this to route to the right provider. Defaults
+   * to 'meta' for every conversation created before Uazapi support.
+   */
+  provider?: WhatsAppProviderName;
 }
 
 // ============================================================
@@ -216,6 +223,8 @@ export interface Message {
    * cue (renders with a "↩ button reply" affordance).
    */
   interactive_reply_id?: string;
+  /** Provider that sent/received this message. Null for rows inserted before migration 029. */
+  provider?: WhatsAppProviderName;
 }
 
 export type ReactionActor = 'customer' | 'agent';
@@ -230,12 +239,19 @@ export interface MessageReaction {
   created_at: string;
 }
 
+/** 'meta' = WhatsApp Cloud API (official). 'uazapi' = QR-based, unofficial. */
+export type WhatsAppProviderName = 'meta' | 'uazapi';
+
 export interface WhatsAppConfig {
   id: string;
   user_id: string;
-  phone_number_id: string;
+  /** Which provider this row configures. An account can hold one row per provider (migration 029). */
+  provider: WhatsAppProviderName;
+  /** Meta-only. Null on provider='uazapi' rows. */
+  phone_number_id?: string;
   waba_id?: string;
-  access_token: string;
+  /** Meta-only, encrypted. Null on provider='uazapi' rows. */
+  access_token?: string;
   verify_token?: string;
   status: 'connected' | 'disconnected';
   connected_at?: string;
@@ -249,6 +265,17 @@ export interface WhatsAppConfig {
   subscribed_apps_at?: string;
   /** Last error from /register; cleared on success. */
   last_registration_error?: string;
+  /** True when this is the provider used for brand-new outbound (broadcasts, cold automations). One per account. */
+  is_default: boolean;
+  /** Uazapi-only fields — null on provider='meta' rows. */
+  uazapi_instance_token?: string;
+  uazapi_base_url?: string;
+  uazapi_instance_name?: string;
+  uazapi_connection_status?: 'disconnected' | 'connecting' | 'connected';
+  uazapi_last_qr_at?: string;
+  uazapi_connected_at?: string;
+  /** Unused — the webhook now authenticates via the instance token Uazapi echoes back, not a URL secret. Column kept for backward compat with migration 029. */
+  uazapi_webhook_secret?: string;
 }
 
 // Raw Meta status enum. We persist this verbatim from Meta (sync + webhook)

--- a/supabase/migrations/029_uazapi_provider_support.sql
+++ b/supabase/migrations/029_uazapi_provider_support.sql
@@ -1,0 +1,91 @@
+-- ============================================================
+-- Multi-provider WhatsApp: add Uazapi as a second provider,
+-- coexisting with Meta on the same account.
+--
+-- Context (see docs/uazapi-integration-plan.md):
+--   whatsapp_config was UNIQUE(account_id) — one WhatsApp connection
+--   per account, implicitly Meta. This migration:
+--     1. Adds a `provider` column ('meta' | 'uazapi').
+--     2. Relaxes phone_number_id's UNIQUE constraint to apply only to
+--        Meta rows (Uazapi rows never populate it).
+--     3. Swaps the account-level UNIQUE to (account_id, provider) so
+--        an account can hold one Meta row AND one Uazapi row.
+--     4. Adds Uazapi-specific columns (nullable — irrelevant for
+--        provider='meta' rows) and an `is_default` flag used to pick
+--        the provider for brand-new outbound (broadcasts, automations
+--        reaching a contact with no existing conversation).
+--     5. Adds `provider` to conversations/messages so an existing
+--        conversation always knows which provider owns it — outbound
+--        sends read this column instead of guessing.
+--
+-- Idempotent — safe to re-run.
+-- ============================================================
+
+-- ---- 1. provider column -------------------------------------------
+ALTER TABLE whatsapp_config
+  ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'meta'
+    CHECK (provider IN ('meta', 'uazapi'));
+
+-- ---- 2. phone_number_id UNIQUE becomes Meta-only -------------------
+-- Uazapi rows never set phone_number_id, so a plain UNIQUE constraint
+-- would let at most one Uazapi row exist globally (NULL = NULL isn't
+-- true in Postgres uniqueness... except Postgres treats NULLs as
+-- distinct for UNIQUE constraints already, so this is actually safe
+-- as-is). We still scope it to Meta explicitly via a partial index so
+-- the intent is unambiguous and future NOT NULL work on the column
+-- doesn't silently break Uazapi rows.
+ALTER TABLE whatsapp_config DROP CONSTRAINT IF EXISTS whatsapp_config_phone_number_id_key;
+DROP INDEX IF EXISTS idx_whatsapp_config_phone_number_id_meta;
+CREATE UNIQUE INDEX idx_whatsapp_config_phone_number_id_meta
+  ON whatsapp_config (phone_number_id)
+  WHERE provider = 'meta' AND phone_number_id IS NOT NULL;
+
+ALTER TABLE whatsapp_config ALTER COLUMN phone_number_id DROP NOT NULL;
+ALTER TABLE whatsapp_config ALTER COLUMN access_token DROP NOT NULL;
+
+-- ---- 3. one row per (account, provider) instead of per account -----
+ALTER TABLE whatsapp_config DROP CONSTRAINT IF EXISTS whatsapp_config_account_id_key;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'whatsapp_config_account_provider_key'
+  ) THEN
+    ALTER TABLE whatsapp_config
+      ADD CONSTRAINT whatsapp_config_account_provider_key UNIQUE (account_id, provider);
+  END IF;
+END $$;
+
+-- ---- 4. Uazapi-specific columns + default-provider flag ------------
+ALTER TABLE whatsapp_config
+  ADD COLUMN IF NOT EXISTS uazapi_instance_token TEXT,       -- encrypted, AES-256-GCM (same scheme as access_token)
+  ADD COLUMN IF NOT EXISTS uazapi_base_url TEXT,             -- e.g. https://api.uazapi.com
+  ADD COLUMN IF NOT EXISTS uazapi_instance_name TEXT,
+  ADD COLUMN IF NOT EXISTS uazapi_connection_status TEXT
+    CHECK (uazapi_connection_status IN ('disconnected', 'connecting', 'connected')),
+  ADD COLUMN IF NOT EXISTS uazapi_last_qr_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS uazapi_connected_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS uazapi_webhook_secret TEXT,        -- random per-instance secret; validates inbound webhook requests (Uazapi has no HMAC signing)
+  ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT false;
+
+-- At most one default provider per account.
+DROP INDEX IF EXISTS idx_whatsapp_config_one_default_per_account;
+CREATE UNIQUE INDEX idx_whatsapp_config_one_default_per_account
+  ON whatsapp_config (account_id)
+  WHERE is_default = true;
+
+-- Every pre-existing row is Meta and was the only connection for its
+-- account — mark it default so outbound routing has an answer without
+-- requiring a manual step post-migration.
+UPDATE whatsapp_config SET is_default = true WHERE is_default = false;
+
+-- ---- 5. provider routing column on conversations/messages ----------
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'meta'
+    CHECK (provider IN ('meta', 'uazapi'));
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS provider TEXT
+    CHECK (provider IN ('meta', 'uazapi'));
+
+CREATE INDEX IF NOT EXISTS idx_whatsapp_config_provider ON whatsapp_config(provider);
+CREATE INDEX IF NOT EXISTS idx_conversations_provider ON conversations(provider);

--- a/supabase/migrations/029_uazapi_provider_support.sql
+++ b/supabase/migrations/029_uazapi_provider_support.sql
@@ -77,7 +77,19 @@ CREATE UNIQUE INDEX idx_whatsapp_config_one_default_per_account
 -- Every pre-existing row is Meta and was the only connection for its
 -- account — mark it default so outbound routing has an answer without
 -- requiring a manual step post-migration.
-UPDATE whatsapp_config SET is_default = true WHERE is_default = false;
+--
+-- Guarded by "account has no default yet" (not just "this row isn't
+-- default") so re-running the migration on a DB where an account has
+-- since added a second provider (with is_default correctly split
+-- between the two rows via the app) doesn't flip the non-default row
+-- to true too and trip the partial unique index above.
+UPDATE whatsapp_config wc
+SET is_default = true
+WHERE is_default = false
+  AND NOT EXISTS (
+    SELECT 1 FROM whatsapp_config wc2
+    WHERE wc2.account_id = wc.account_id AND wc2.is_default = true
+  );
 
 -- ---- 5. provider routing column on conversations/messages ----------
 ALTER TABLE conversations

--- a/supabase/migrations/030_customer_journey.sql
+++ b/supabase/migrations/030_customer_journey.sql
@@ -1,0 +1,103 @@
+-- ============================================================
+-- 030_customer_journey.sql — Sales-funnel Kanban (customer journey)
+--
+-- The Pipelines Kanban is deal-centric: a card only exists once
+-- someone opens an opportunity. This adds a second, contact-centric
+-- board — every contact enters automatically the moment they send
+-- their first inbound message, and moves through qualification
+-- stages before (optionally) becoming a Deal in a Pipeline.
+--
+-- Design notes
+--   - `funnel_stages` mirrors `pipeline_stages` (account-scoped,
+--     name/color/position) but has no settings UI yet — stages are
+--     seeded once per account from a fixed list in the app
+--     (SPEC_DEFAULT_FUNNEL_STAGES), the same client-side
+--     seed-if-empty pattern `pipelines/page.tsx` uses for
+--     `pipeline_stages`. `key` is a stable machine name (e.g.
+--     'new_lead') so app code can find "the first stage" or
+--     "the negotiation stage" without depending on display order.
+--   - `contact_journey` is the mutable current state: exactly one row
+--     per (account, contact). `entered_stage_at` resets on every
+--     stage change and drives the "stalled lead" aging badge in the
+--     UI.
+--   - `contact_journey_transitions` is an append-only log — the
+--     reason this is a dedicated table instead of a column on
+--     `contacts` is to measure time-in-stage and stage-to-stage
+--     conversion later. `from_stage_id` is NULL for the initial
+--     entry; `changed_by` is NULL when the automatic webhook hook
+--     created the row (no human in the loop), same convention as
+--     `contact_journey`'s own audit-less inserts.
+--
+-- RLS
+--   Same shape as `deals`: any account member may read; agent+ may
+--   write (create/move cards). The inbound webhooks use
+--   supabaseAdmin() and already bypass RLS, same as the rest of the
+--   inbound message path.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS funnel_stages (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  name TEXT NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  color TEXT NOT NULL DEFAULT '#3b82f6',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (account_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_funnel_stages_account ON funnel_stages(account_id);
+
+ALTER TABLE funnel_stages ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS funnel_stages_select ON funnel_stages;
+DROP POLICY IF EXISTS funnel_stages_insert ON funnel_stages;
+DROP POLICY IF EXISTS funnel_stages_update ON funnel_stages;
+DROP POLICY IF EXISTS funnel_stages_delete ON funnel_stages;
+CREATE POLICY funnel_stages_select ON funnel_stages FOR SELECT USING (is_account_member(account_id));
+CREATE POLICY funnel_stages_insert ON funnel_stages FOR INSERT WITH CHECK (is_account_member(account_id, 'agent'));
+CREATE POLICY funnel_stages_update ON funnel_stages FOR UPDATE USING (is_account_member(account_id, 'agent'));
+CREATE POLICY funnel_stages_delete ON funnel_stages FOR DELETE USING (is_account_member(account_id, 'agent'));
+
+CREATE TABLE IF NOT EXISTS contact_journey (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  stage_id UUID NOT NULL REFERENCES funnel_stages(id),
+  entered_stage_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (account_id, contact_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_journey_account ON contact_journey(account_id);
+CREATE INDEX IF NOT EXISTS idx_contact_journey_stage ON contact_journey(stage_id);
+
+ALTER TABLE contact_journey ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS contact_journey_select ON contact_journey;
+DROP POLICY IF EXISTS contact_journey_insert ON contact_journey;
+DROP POLICY IF EXISTS contact_journey_update ON contact_journey;
+DROP POLICY IF EXISTS contact_journey_delete ON contact_journey;
+CREATE POLICY contact_journey_select ON contact_journey FOR SELECT USING (is_account_member(account_id));
+CREATE POLICY contact_journey_insert ON contact_journey FOR INSERT WITH CHECK (is_account_member(account_id, 'agent'));
+CREATE POLICY contact_journey_update ON contact_journey FOR UPDATE USING (is_account_member(account_id, 'agent'));
+CREATE POLICY contact_journey_delete ON contact_journey FOR DELETE USING (is_account_member(account_id, 'agent'));
+
+CREATE TABLE IF NOT EXISTS contact_journey_transitions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  contact_journey_id UUID NOT NULL REFERENCES contact_journey(id) ON DELETE CASCADE,
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  from_stage_id UUID REFERENCES funnel_stages(id),
+  to_stage_id UUID NOT NULL REFERENCES funnel_stages(id),
+  changed_by UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  changed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_journey_transitions_journey ON contact_journey_transitions(contact_journey_id);
+CREATE INDEX IF NOT EXISTS idx_contact_journey_transitions_account ON contact_journey_transitions(account_id);
+
+ALTER TABLE contact_journey_transitions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS contact_journey_transitions_select ON contact_journey_transitions;
+DROP POLICY IF EXISTS contact_journey_transitions_insert ON contact_journey_transitions;
+CREATE POLICY contact_journey_transitions_select ON contact_journey_transitions FOR SELECT USING (is_account_member(account_id));
+CREATE POLICY contact_journey_transitions_insert ON contact_journey_transitions FOR INSERT WITH CHECK (is_account_member(account_id, 'agent'));
+-- Append-only: no UPDATE/DELETE policy, mirroring automation_logs.


### PR DESCRIPTION
## Summary

- Adds a new **contact-centric Kanban** at `/kanban`, alongside the existing deal-centric **Pipelines** board. Every contact enters the funnel automatically on their first inbound message (hooked into both the WhatsApp and Uazapi webhooks) and moves through 6 fixed stages: New Lead → Engaged → Qualified → Negotiating → Customer, with Cold/Lost reachable from any stage.
- New tables (migration `030_customer_journey.sql`): `funnel_stages` (seeded per account), `contact_journey` (current state, 1 row per contact), `contact_journey_transitions` (append-only history, enabling future stage-conversion analytics). RLS mirrors `deals` (any member reads, agent+ writes).
- Convenience bridge: moving a lead into "Negotiating" offers to create a linked opportunity in Pipelines (one-time action, not kept in sync afterwards).
- Adds 3 funnel metrics to the main dashboard: New Leads Today, Stalled Leads (3+ days in a non-terminal stage), and Lead → Customer conversion rate (30-day cohort).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean, `/kanban` route generated
- [x] `npx eslint` on all touched files — clean
- [x] `npx vitest run` — 546/548 passing (the 2 failures are a pre-existing timezone-dependent test in `date-utils.test.ts`, unrelated to this change; verified it fails identically on `main`)
- [ ] Apply `supabase/migrations/030_customer_journey.sql` to the target environment before merging/deploying (already applied and verified working against the author's own project)
- [ ] Manually confirm: an inbound message from a brand-new contact lands in "New Lead" on `/kanban` without manual action
- [ ] Manually confirm: dragging a card between stages persists and logs a transition row