### PR TITLE
fix(ai): grant EXECUTE on claim_ai_reply_slot so auto-reply works (#345)

### DIFF
--- a/src/lib/ai/auto-reply.ts
+++ b/src/lib/ai/auto-reply.ts
@@ -122,7 +122,15 @@ export async function dispatchInboundToAiReply(
         max_replies: config.autoReplyMaxPerConversation,
       },
     )
-    if (claimErr || claimed !== true) return
+    if (claimErr) {
+      // A real error here (vs. losing the cap race) is almost always a
+      // deploy issue — e.g. `claim_ai_reply_slot` not EXECUTE-able by the
+      // service role, or the migration not applied. Log it loudly: a
+      // silent return makes "auto-reply never fires" undiagnosable.
+      console.error('[ai auto-reply] claim_ai_reply_slot failed:', claimErr)
+      return
+    }
+    if (claimed !== true) return // lost the per-conversation cap race
 
     await engineSendText({
       accountId,

--- a/supabase/migrations/029_ai_reply.sql
+++ b/supabase/migrations/029_ai_reply.sql
@@ -129,3 +129,13 @@ RETURNS boolean AS $$
   )
   SELECT EXISTS (SELECT 1 FROM claimed);
 $$ LANGUAGE sql SECURITY DEFINER SET search_path = public;
+
+-- The auto-reply bot claims slots under the service-role client (the
+-- inbound webhook has no auth.uid()), so it needs EXECUTE. SECURITY
+-- DEFINER alone is not enough — it sets the privileges the function runs
+-- *with*, not who may call it. Without this grant the RPC fails with
+-- permission-denied on instances where the default PUBLIC execute
+-- privilege has been revoked (hardened / self-hosted Supabase), and the
+-- bot silently never replies. Only the service role claims slots, so we
+-- grant to it alone (mirrors 007 / 012). See migration 031 / issue #345.
+GRANT EXECUTE ON FUNCTION public.claim_ai_reply_slot(uuid, integer) TO service_role;

--- a/supabase/migrations/031_ai_reply_slot_grant.sql
+++ b/supabase/migrations/031_ai_reply_slot_grant.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- 031_ai_reply_slot_grant.sql — fix: AI auto-reply never fires
+--
+-- Migration 029 created `claim_ai_reply_slot(uuid, integer)` as a
+-- SECURITY DEFINER function but never GRANTed EXECUTE on it — the only
+-- function in the schema missing its grant (cf. 007, 012, 018, 019,
+-- 025, 030, which all grant EXECUTE explicitly).
+--
+-- SECURITY DEFINER changes the privileges a function runs *with*, not
+-- who may *call* it: the caller still needs EXECUTE. On Postgres
+-- instances where the default PUBLIC execute privilege on public-schema
+-- functions has been revoked (standard on hardened / self-hosted
+-- Supabase), `service_role` therefore cannot invoke it. The AI
+-- auto-reply path runs entirely under the service-role client (the
+-- inbound webhook has no auth.uid()), so `db.rpc('claim_ai_reply_slot')`
+-- fails with permission-denied, the caller bails before sending, and the
+-- bot silently never answers ANY inbound message — while the Playground
+-- (which never claims a slot) keeps working. See issue #345.
+--
+-- Only the service role ever claims a slot, so we grant to it alone —
+-- matching the increment-counter precedent in 007 / 012, and never
+-- exposing a counter-mutating function to end users.
+--
+-- Idempotent — GRANT is a no-op when the privilege already exists.
+-- ============================================================
+
+GRANT EXECUTE ON FUNCTION public.claim_ai_reply_slot(uuid, integer) TO service_role;


### PR DESCRIPTION
Fixes #345.

## Problem
When AI auto-reply is enabled, the bot never replies to any inbound message — while the Playground works fine.

## Root cause
Migration `029_ai_reply.sql` defines `claim_ai_reply_slot(uuid, integer)` as `SECURITY DEFINER` but **never grants `EXECUTE`** on it. It's the only function in the schema missing its grant (007, 012, 017, 018, 019, 025, and 030 all grant theirs — 030, the very next migration, grants to `authenticated, service_role`).

`SECURITY DEFINER` sets the privileges a function runs *with*, not who may *call* it — the caller still needs `EXECUTE`. On instances where the default `PUBLIC` execute privilege on `public`-schema functions has been revoked (hardened / self-hosted Supabase — the reporter is on a Hostinger VPS), the `service_role` that PostgREST uses cannot invoke it.

The auto-reply path runs entirely under the service-role client (the inbound webhook has no `auth.uid()`), so `db.rpc('claim_ai_reply_slot', …)` fails permission-denied → `claimErr` is truthy → the dispatch bails **before sending** → the bot silently never answers. The **Playground works** because it's a pure generate call that never claims a slot — exactly the reported split.

The rest of the path checked out: `.rpc()` on a scalar boolean genuinely returns a bare `true`, and the gates, wiring, config, and both providers are correct. The missing grant is the sole defect.

## Fix
- **`031_ai_reply_slot_grant.sql`** (new) — grants `EXECUTE` on `claim_ai_reply_slot` to `service_role`. A new migration is required because 029 is already applied on existing installs. Granted to `service_role` only (the sole caller), matching the 007/012 increment-counter precedent — never exposing a counter-mutating function to end users.
- **`029_ai_reply.sql`** — added the same grant next to the definition so fresh installs are correct.
- **`src/lib/ai/auto-reply.ts`** — the claim step now logs a real RPC error instead of returning silently, so this class of deploy failure is diagnosable.

## Recovery on affected installs
Apply migration 031 (`supabase db push` / your migration runner). No app redeploy is needed for the DB grant; the logging improvement ships with the next build.

## Testing
Auto-reply unit tests pass (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)