### PR TITLE
Fix MCP registry validation in server.json

### DIFF
--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.arnasdon/wacrm-mcp",
-  "description": "Drive a self-hosted wacrm WhatsApp CRM (contacts, conversations, messages, broadcasts) from MCP clients.",
+  "description": "Drive a self-hosted wacrm WhatsApp CRM from Claude, Cursor and other MCP clients.",
   "repository": {
     "url": "https://github.com/ArnasDon/wacrm",
     "source": "github",


### PR DESCRIPTION
Follow-up to #355. The `server.json` shipped there fails `mcp-publisher validate` against the live registry:

- `description` exceeded the registry's 100-character limit → shortened.
- `$schema` pointed at the deprecated `2025-10-17` schema → migrated to the current `2025-12-11`.

`mcp-publisher validate` now returns ✅. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)