### PR TITLE
Correct MCP registry namespace casing (ArnasDon), bump to 0.1.1

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wacrm-mcp",
-  "version": "0.1.0",
-  "mcpName": "io.github.arnasdon/wacrm-mcp",
+  "version": "0.1.1",
+  "mcpName": "io.github.ArnasDon/wacrm-mcp",
   "description": "Model Context Protocol (MCP) server for wacrm — drive your self-hosted WhatsApp CRM from Claude, Cursor, and other MCP clients.",
   "license": "MIT",
   "author": "Arnas Donauskas",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.arnasdon/wacrm-mcp",
+  "name": "io.github.ArnasDon/wacrm-mcp",
   "description": "Drive a self-hosted wacrm WhatsApp CRM from Claude, Cursor and other MCP clients.",
   "repository": {
     "url": "https://github.com/ArnasDon/wacrm",
     "source": "github",
     "subfolder": "mcp-server"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "wacrm-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
This commit landed on the branch just after #356 was merged, so it missed that PR. Opening it on its own.

The MCP registry namespace is **case-sensitive** and keyed to the GitHub login — the owner is `ArnasDon`, not `arnasdon`. Publishing as `io.github.arnasdon/wacrm-mcp` is rejected with 403. This fixes:

- `server.json` `name` and `package.json` `mcpName` → `io.github.ArnasDon/wacrm-mcp`.
- Version bump `0.1.0` → `0.1.1`: the published `0.1.0` baked in the lowercase `mcpName`, and the registry validates the published package's `mcpName` against `server.json`, so a fresh npm version is required.

`mcp-publisher validate` passes; name and version are aligned across both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)