### PR TITLE
Add optional Docker / Docker Compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.next
+node_modules
+docs
+mcp-server
+supabase
+*.md
+!README.md
+.env*
+!.env.local.example
+Dockerfile
+docker-compose*.yml
+.dockerignore
+.vscode
+.idea
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------
 # Stage 1 — install dependencies (cached until package*.json change)
 # ---------------------------------------------------------------
-FROM node:22-alpine AS deps
+FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -17,7 +17,7 @@ RUN npm ci
 # key, ENCRYPTION_KEY, META_APP_SECRET, ...) are read at runtime and
 # must NOT be baked into the image.
 # ---------------------------------------------------------------
-FROM node:22-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -37,7 +37,7 @@ RUN npm run build
 # ---------------------------------------------------------------
 # Stage 3 — minimal runtime (standalone output)
 # ---------------------------------------------------------------
-FROM node:22-alpine AS runner
+FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------
+# Stage 1 — install dependencies (cached until package*.json change)
+# ---------------------------------------------------------------
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ---------------------------------------------------------------
+# Stage 2 — build
+#
+# NEXT_PUBLIC_* values are inlined into the client bundle at build
+# time, so they must be provided as build args (docker-compose.yml
+# forwards them from .env.local). Server-only secrets (service role
+# key, ENCRYPTION_KEY, META_APP_SECRET, ...) are read at runtime and
+# must NOT be baked into the image.
+# ---------------------------------------------------------------
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_SITE_URL
+ARG NEXT_PUBLIC_APP_LOCALE=en
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY \
+    NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
+    NEXT_PUBLIC_APP_LOCALE=$NEXT_PUBLIC_APP_LOCALE \
+    NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# ---------------------------------------------------------------
+# Stage 3 — minimal runtime (standalone output)
+# ---------------------------------------------------------------
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup -S nextjs && adduser -S nextjs -G nextjs
+
+COPY --from=builder --chown=nextjs:nextjs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nextjs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nextjs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ npm run dev
 Open <http://localhost:3000>. You'll be redirected to `/login` (or
 `/dashboard` if already signed in).
 
+Prefer containers? See [docs/docker.md](./docs/docker.md) for the
+Dockerfile + Docker Compose setup.
+
 ## 🚀 Deploy on Hostinger (recommended)
 
 <p align="center">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+name: wacrm
+
+services:
+  app:
+    build:
+      context: .
+      # NEXT_PUBLIC_* vars are inlined at build time — forward them
+      # from .env.local as build args. Changing any of them requires
+      # a rebuild (docker compose up --build).
+      args:
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+        NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-}
+        NEXT_PUBLIC_APP_LOCALE: ${NEXT_PUBLIC_APP_LOCALE:-en}
+    # Runtime (server-only) secrets come from .env.local; they are
+    # never baked into the image.
+    env_file:
+      - .env.local
+    ports:
+      - "${PORT:-3000}:3000"
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:3000').then((r)=>process.exit(r.ok||r.status<500?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,15 +16,22 @@ services:
     # never baked into the image.
     env_file:
       - .env.local
+    # The server always listens on 3000 inside the container. Pinned
+    # here because `environment` wins over `env_file`, so a stray PORT
+    # in .env.local can't desync the app from the mapping and the
+    # healthcheck below.
+    environment:
+      PORT: 3000
+    # Host side only — HOST_PORT=8080 publishes the app on :8080.
     ports:
-      - "${PORT:-3000}:3000"
+      - '${HOST_PORT:-3000}:3000'
     restart: unless-stopped
     healthcheck:
       test:
         [
-          "CMD",
-          "node",
-          "-e",
+          'CMD',
+          'node',
+          '-e',
           "fetch('http://localhost:3000').then((r)=>process.exit(r.ok||r.status<500?0:1)).catch(()=>process.exit(1))",
         ]
       interval: 30s

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -23,7 +23,13 @@ is included.
    ```
 
 3. The app is served on [http://localhost:3000](http://localhost:3000)
-   (override the host port with `PORT=8080` in `.env.local`).
+   (publish it elsewhere with `HOST_PORT=8080` in `.env.local`).
+
+> Use `HOST_PORT`, not `PORT`, to move the published port. `PORT` is
+> what the server listens on _inside_ the container, and `env_file`
+> would inject it there — leaving the app on a port the mapping and
+> the healthcheck don't target. Compose pins it to 3000 for that
+> reason.
 
 ## Build-time vs runtime variables
 
@@ -44,7 +50,7 @@ docker build \
   --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key \
   -t wacrm .
 
-docker run -d --env-file .env.local -p 3000:3000 wacrm
+docker run -d --env-file .env.local -e PORT=3000 -p 3000:3000 wacrm
 ```
 
 ## Notes

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -58,6 +58,9 @@ docker run -d --env-file .env.local -e PORT=3000 -p 3000:3000 wacrm
 - Database migrations under `supabase/` are **not** run by the
   container — apply them with the Supabase CLI as described in the
   README.
-- If you use automation Wait steps, remember to point your cron pinger
-  at `GET /api/automations/cron` on this deployment (see
-  `docs/automations-and-cron.md`).
+- Nothing inside the container is scheduled. If you use automation
+  Wait steps or flows, point an external scheduler at
+  `GET /api/automations/cron` and `GET /api/flows/cron` on this
+  deployment, sending the shared secret in the `x-cron-secret` header
+  (`AUTOMATION_CRON_SECRET`, see `.env.local.example`). Both return
+  503 until that variable is set.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,57 @@
+# Running with Docker
+
+The repo ships a multi-stage `Dockerfile` (Next.js standalone output,
+runs as a non-root user) and a `docker-compose.yml` with a single
+`app` service. Supabase is external — point the app at your hosted
+(or self-hosted) Supabase project via env vars; no database container
+is included.
+
+## Quick start
+
+1. Copy the env template and fill it in:
+
+   ```bash
+   cp .env.local.example .env.local
+   ```
+
+2. Build and start (the `--env-file` flag is required — Compose only
+   reads `.env` by default for `${VAR}` substitution, and this project
+   keeps its config in `.env.local`):
+
+   ```bash
+   docker compose --env-file .env.local up --build -d
+   ```
+
+3. The app is served on [http://localhost:3000](http://localhost:3000)
+   (override the host port with `PORT=8080` in `.env.local`).
+
+## Build-time vs runtime variables
+
+- `NEXT_PUBLIC_*` variables are **inlined into the client bundle at
+  build time**. They are passed as Docker build args by
+  `docker-compose.yml`. If you change any of them, rebuild:
+  `docker compose --env-file .env.local up --build -d`.
+- Everything else (`SUPABASE_SERVICE_ROLE_KEY`, `ENCRYPTION_KEY`,
+  `META_APP_SECRET`, …) is read at **runtime** from `.env.local` via
+  `env_file` and is never baked into the image — safe to change with
+  just a container restart.
+
+## Plain Docker (no Compose)
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co \
+  --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key \
+  -t wacrm .
+
+docker run -d --env-file .env.local -p 3000:3000 wacrm
+```
+
+## Notes
+
+- Database migrations under `supabase/` are **not** run by the
+  container — apply them with the Supabase CLI as described in the
+  README.
+- If you use automation Wait steps, remember to point your cron pinger
+  at `GET /api/automations/cron` on this deployment (see
+  `docs/automations-and-cron.md`).

--- a/next.config.ts
+++ b/next.config.ts
@@ -64,6 +64,11 @@ const SECURITY_HEADERS = [
 ] as const;
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained server bundle (.next/standalone) so the
+  // Docker image can run without node_modules or the Next CLI.
+  // Harmless outside Docker: `next start` keeps working as before.
+  output: "standalone",
+
   /**
    * Cross-origin dev access (Next.js 16).
    *


### PR DESCRIPTION
## Summary

Add an optional, self-contained container setup (Dockerfile + Docker Compose) for forkers who self-host on their own infra. Purely additive — `next start` and the Hostinger path are unchanged.

## What changed

- **`Dockerfile`** — multi-stage (deps → build → runtime) using Next.js `output: "standalone"`; runs as a non-root user; only `.next/standalone`, `.next/static`, and `public` land in the final image.
- **`docker-compose.yml`** — single `app` service. Supabase stays external (no DB container). `NEXT_PUBLIC_*` are forwarded as build args; server secrets come from `.env.local` via `env_file` at runtime. Includes a healthcheck and `restart: unless-stopped`.
- **`.dockerignore`** — excludes `.git`, `node_modules`, `.next`, `docs`, `supabase`, all `.env*`, etc.
- **`docs/docker.md`** — usage guide, including the build-time (`NEXT_PUBLIC_*`, inlined into the client bundle) vs runtime (secrets) distinction and the `--env-file .env.local` note.
- **`next.config.ts`** — `output: "standalone"`. No-op for `next start` / Hostinger; only the Docker build consumes it.
- **`README.md`** — one line pointing to `docs/docker.md` after the quick start.

Database migrations remain out of scope for the container (applied via the Supabase CLI, matching the existing external-Supabase model).

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` succeeds (runs inside the Docker build).
- [x] `docker compose --env-file .env.local up --build -d` builds and starts; container reports healthy; `/` → 307 `/dashboard`, `/login` → 200.
- [x] Verified end-to-end on a real deploy (Coolify + external self-hosted Supabase): app boots, auth and DB reachable.

Note: the 5 local test failures in `currency`/`date-utils` are timezone/ICU-locale artifacts of a non-UTC dev machine and are unrelated to this change (the only source edit is `output: "standalone"`); they pass in CI (Linux/UTC).

## Related

Closes #371.
