### PR TITLE
feat(deploy): admin padrão no boot, SMTP no-reply e flag de signup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Criado em: 10/07/2026 01:30
+# Modificado em: 10/07/2026 01:30
+# Mantém o contexto de build enxuto e impede vazamento de segredos.
+node_modules
+.next
+.git
+.secrets
+.env*
+!.env.local.example
+deploy/.env
+logs
+tmp
+docs
+mcp-server/node_modules

--- a/.env.local.example
+++ b/.env.local.example
@@ -45,6 +45,14 @@ NEXT_PUBLIC_SITE_URL=https://crm.example.com
 # Default language locale (e.g. en)
 NEXT_PUBLIC_APP_LOCALE=en
 
+# Public self-service signup. "true" shows the /signup page and the
+# "create account" link on /login; anything else (default) hides them
+# and the middleware redirects /signup to /login (invite links with
+# ?invite=<token> keep working). On the self-hosted deploy, pair this
+# with DISABLE_SIGNUP (GoTrue) in deploy/env.example — the backend
+# block is the authoritative one; this flag only controls the UI.
+NEXT_PUBLIC_SIGNUP_ENABLED=false
+
 # ============================================================
 # OPTIONAL — only needed if you use the feature.
 # ============================================================

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,12 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Local (enterprise-evolui-crm)
+.secrets/
+logs/
+.claude/
+.vscode/
+*.code-workspace
+tmp/
+__pycache__/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,50 @@
+# Criado em: 10/07/2026 00:40
+# Modificado em: 10/07/2026 01:30
+#
+# Build multi-stage do enterprise-evolui-crm (Next.js 16, output standalone).
+# Contexto de build = raiz do repositório:
+#   docker build -f deploy/Dockerfile .
+#
+# A imagem é GENÉRICA: o build usa PLACEHOLDERS nas NEXT_PUBLIC_* e o
+# docker-entrypoint.sh os substitui em runtime pelos valores do .env do
+# compose. Nenhuma configuração fica embutida na imagem.
+
+# ---------- 1. Dependências ----------
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+# ---------- 2. Build (com placeholders) ----------
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+ENV NEXT_PUBLIC_SUPABASE_URL=https://supabase-placeholder.invalid \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY_PLACEHOLDER \
+    NEXT_PUBLIC_SITE_URL=https://site-placeholder.invalid \
+    NEXT_PUBLIC_APP_LOCALE=pt-BR \
+    NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# ---------- 3. Runtime ----------
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup -S nodejs -g 1001 && adduser -S nextjs -u 1001 -G nodejs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --chown=nextjs:nodejs deploy/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+USER nextjs
+EXPOSE 3000
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # Criado em: 10/07/2026 00:40
-# Modificado em: 10/07/2026 01:30
+# Modificado em: 13/07/2026 11:17
 #
 # Build multi-stage do enterprise-evolui-crm (Next.js 16, output standalone).
 # Contexto de build = raiz do repositório:
@@ -22,6 +22,7 @@ WORKDIR /app
 ENV NEXT_PUBLIC_SUPABASE_URL=https://supabase-placeholder.invalid \
     NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY_PLACEHOLDER \
     NEXT_PUBLIC_SITE_URL=https://site-placeholder.invalid \
+    NEXT_PUBLIC_SIGNUP_ENABLED=NEXT_PUBLIC_SIGNUP_ENABLED_PLACEHOLDER \
     NEXT_PUBLIC_APP_LOCALE=pt-BR \
     NEXT_TELEMETRY_DISABLED=1
 

--- a/deploy/docker-compose.evolution.yml
+++ b/deploy/docker-compose.evolution.yml
@@ -1,0 +1,38 @@
+# Criado em: 10/07/2026 01:10
+# Modificado em: 10/07/2026 01:45
+#
+# FASE 2 — Evolution API (override opcional; fora do stack padrão).
+# A integração no código do CRM (camada de provider) ainda não existe:
+# o app hoje só fala com a Meta Cloud API.
+#
+# Ativar:
+#   docker compose -f docker-compose.yml -f docker-compose.evolution.yml up -d
+
+services:
+  evolution-api:
+    image: atendai/evolution-api:v2.2.3
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    environment:
+      SERVER_URL: https://evolution.evolui-crm.vya.digital
+      AUTHENTICATION_API_KEY: ${EVOLUTION_API_KEY}
+      DATABASE_ENABLED: "true"
+      DATABASE_PROVIDER: postgresql
+      # Schema próprio ("evolution") no mesmo Postgres — isolado do CRM.
+      DATABASE_CONNECTION_URI: postgresql://postgres:${POSTGRES_PASSWORD}@supabase-db:5432/postgres?schema=evolution
+      CACHE_LOCAL_ENABLED: "true"
+      LOG_LEVEL: ERROR
+    volumes:
+      - ${DATA_DIR:-/opt/docker_user/enterprise-evolui-crm}/evolution-instances:/evolution/instances
+    networks:
+      - app-network
+      - db-network
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=app-network
+      - traefik.http.routers.evolui-evolution.rule=Host(`evolution.evolui-crm.vya.digital`)
+      - traefik.http.routers.evolui-evolution.entrypoints=websecure
+      - traefik.http.routers.evolui-evolution.tls.certresolver=letsencrypt
+      - traefik.http.services.evolui-evolution.loadbalancer.server.port=8080

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,257 @@
+# Criado em: 10/07/2026 00:40
+# Modificado em: 10/07/2026 01:45
+#
+# Stack de produção do enterprise-evolui-crm:
+#   app (Next.js) + Supabase self-hosted + Evolution API.
+#
+# Redes:
+#   app-network — externa, já usada pelo Traefik do host. Só entram nela
+#                 os serviços roteados publicamente (app, kong, evolution).
+#   db-network  — interna (internal: true). Banco e serviços Supabase.
+#                 NENHUM serviço de banco publica portas no host.
+#
+# Uso:
+#   cp env.example .env    # preencher (nunca versionar)
+#   docker compose up -d --build
+
+name: evolui-crm
+
+networks:
+  app-network:
+    external: true
+  db-network:
+    internal: true
+
+# Dados persistidos em bind mounts sob DATA_DIR (padrão
+# /opt/docker_user/enterprise-evolui-crm). Criar as pastas antes do
+# primeiro up:
+#   sudo mkdir -p /opt/docker_user/enterprise-evolui-crm/{supabase-db-data,supabase-db-backups,supabase-storage-data}
+
+services:
+  # ------------------------------------------------------------------
+  # Aplicação (Next.js)
+  # ------------------------------------------------------------------
+  app:
+    # Imagem pré-buildada GENÉRICA — gere e publique com scripts/build-push.sh.
+    # Toda a configuração vem do .env em runtime (docker-entrypoint.sh
+    # injeta as NEXT_PUBLIC_* no bundle no start do container).
+    image: adminvyadigital/enterprise-evolui-crm:${APP_VERSION:-latest}
+    restart: unless-stopped
+    depends_on:
+      supabase-kong:
+        condition: service_started
+    environment:
+      NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      META_APP_SECRET: ${META_APP_SECRET}
+      META_APP_ID: ${META_APP_ID:-}
+      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-https://evolui-crm.vya.digital}
+      NEXT_PUBLIC_APP_LOCALE: ${NEXT_PUBLIC_APP_LOCALE:-pt-BR}
+      AUTOMATION_CRON_SECRET: ${AUTOMATION_CRON_SECRET:-}
+      ALLOWED_INVITE_HOSTS: ${ALLOWED_INVITE_HOSTS:-evolui-crm.vya.digital}
+    networks:
+      - app-network
+      - db-network
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=app-network
+      - traefik.http.routers.evolui-crm.rule=Host(`evolui-crm.vya.digital`)
+      - traefik.http.routers.evolui-crm.entrypoints=websecure
+      - traefik.http.routers.evolui-crm.tls.certresolver=lets-encrypt
+      - traefik.http.services.evolui-crm.loadbalancer.server.port=3000
+
+  # ------------------------------------------------------------------
+  # Supabase — banco de dados (sem portas expostas)
+  # ------------------------------------------------------------------
+  supabase-db:
+    image: supabase/postgres:15.8.1.049
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: postgres
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXP: 3600
+    volumes:
+      - ${DATA_DIR:-/opt/docker_user/enterprise-evolui-crm}/supabase-db-data:/var/lib/postgresql/data
+      - ${DATA_DIR:-/opt/docker_user/enterprise-evolui-crm}/supabase-db-backups:/backups
+      # Roda só no PRIMEIRO boot (data dir vazio): alinha as senhas dos
+      # roles internos (supabase_auth_admin etc.) com POSTGRES_PASSWORD.
+      - ./supabase/init/zz-align-role-passwords.sh:/docker-entrypoint-initdb.d/zz-align-role-passwords.sh:ro
+    networks:
+      - db-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # Backup diário via pg_dump para o volume supabase-db-backups.
+  # Retenção controlada por BACKUP_RETENTION_DAYS (padrão 7).
+  db-backup:
+    image: supabase/postgres:15.8.1.049
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-7}
+    volumes:
+      - ${DATA_DIR:-/opt/docker_user/enterprise-evolui-crm}/supabase-db-backups:/backups
+      - ./scripts/backup-db.sh:/usr/local/bin/backup-db.sh:ro
+    networks:
+      - db-network
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        while true; do
+          /usr/local/bin/backup-db.sh
+          sleep 86400
+        done
+
+  # ------------------------------------------------------------------
+  # Supabase — gateway (único serviço Supabase roteado pelo Traefik)
+  # ------------------------------------------------------------------
+  supabase-kong:
+    image: kong:2.8.1
+    restart: unless-stopped
+    depends_on:
+      supabase-auth:
+        condition: service_started
+      supabase-rest:
+        condition: service_started
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
+      KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_PLUGINS: request-transformer,cors,key-auth,acl
+      SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
+    volumes:
+      - ./supabase/kong.yml:/home/kong/temp.yml:ro
+    # Interpola SUPABASE_ANON_KEY/SUPABASE_SERVICE_KEY no template
+    # (mesmo mecanismo do compose oficial de self-hosting do Supabase).
+    entrypoint: bash -c 'eval "echo \"$$(cat /home/kong/temp.yml)\"" > /home/kong/kong.yml && /docker-entrypoint.sh kong docker-start'
+    networks:
+      - app-network
+      - db-network
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=app-network
+      - traefik.http.routers.evolui-supabase.rule=Host(`supabase.evolui-crm.vya.digital`)
+      - traefik.http.routers.evolui-supabase.entrypoints=websecure
+      - traefik.http.routers.evolui-supabase.tls.certresolver=lets-encrypt
+      - traefik.http.services.evolui-supabase.loadbalancer.server.port=8000
+
+  supabase-auth:
+    image: supabase/gotrue:v2.170.0
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD}@supabase-db:5432/postgres
+      GOTRUE_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-https://evolui-crm.vya.digital}
+      GOTRUE_URI_ALLOW_LIST: ${NEXT_PUBLIC_SITE_URL:-https://evolui-crm.vya.digital}/*
+      GOTRUE_JWT_SECRET: ${JWT_SECRET}
+      GOTRUE_JWT_EXP: 3600
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_DISABLE_SIGNUP: "true"
+      GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
+      # Sem SMTP configurado: confirma e-mails automaticamente.
+      # Configurar GOTRUE_SMTP_* e desligar isto quando houver SMTP.
+      GOTRUE_MAILER_AUTOCONFIRM: "true"
+    networks:
+      - db-network
+
+  supabase-rest:
+    image: postgrest/postgrest:v12.2.12
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@supabase-db:5432/postgres
+      PGRST_DB_SCHEMAS: public,storage
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${JWT_SECRET}
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+    networks:
+      - db-network
+
+  supabase-realtime:
+    image: supabase/realtime:v2.34.47
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    environment:
+      PORT: 4000
+      DB_HOST: supabase-db
+      DB_PORT: 5432
+      DB_USER: supabase_admin
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: postgres
+      DB_AFTER_CONNECT_QUERY: "SET search_path TO _realtime"
+      DB_ENC_KEY: supabaserealtime
+      API_JWT_SECRET: ${JWT_SECRET}
+      SECRET_KEY_BASE: ${REALTIME_SECRET_KEY_BASE}
+      ERL_AFLAGS: -proto_dist inet_tcp
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: "10000"
+      APP_NAME: realtime
+      SEED_SELF_HOST: "true"
+    networks:
+      - db-network
+
+  supabase-storage:
+    image: supabase/storage-api:v1.19.3
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+      supabase-rest:
+        condition: service_started
+    environment:
+      ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+      SERVICE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
+      POSTGREST_URL: http://supabase-rest:3000
+      PGRST_JWT_SECRET: ${JWT_SECRET}
+      DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@supabase-db:5432/postgres
+      FILE_SIZE_LIMIT: "52428800"
+      STORAGE_BACKEND: file
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: stub
+      REGION: stub
+      GLOBAL_S3_BUCKET: stub
+    volumes:
+      - ${DATA_DIR:-/opt/docker_user/enterprise-evolui-crm}/supabase-storage-data:/var/lib/storage
+    networks:
+      - db-network
+
+  supabase-meta:
+    image: supabase/postgres-meta:v0.89.3
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    environment:
+      PG_META_PORT: 8080
+      PG_META_DB_HOST: supabase-db
+      PG_META_DB_PORT: 5432
+      PG_META_DB_NAME: postgres
+      PG_META_DB_USER: supabase_admin
+      PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
+    networks:
+      - db-network
+
+  # Evolution API: movida para a Fase 2 — ver docker-compose.evolution.yml.
+  # Ativar com: docker compose -f docker-compose.yml -f docker-compose.evolution.yml up -d

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,5 @@
 # Criado em: 10/07/2026 00:40
-# Modificado em: 10/07/2026 01:45
+# Modificado em: 13/07/2026 11:17
 #
 # Stack de produção do enterprise-evolui-crm:
 #   app (Next.js) + Supabase self-hosted + Evolution API.
@@ -13,6 +13,14 @@
 # Uso:
 #   cp env.example .env    # preencher (nunca versionar)
 #   docker compose up -d --build
+#
+# Extras opcionais no .env:
+#   ADMIN_EMAIL/ADMIN_PASSWORD — cria o admin padrão no boot
+#     (serviço one-shot admin-bootstrap; idempotente).
+#   SMTP_* — envio de e-mail do GoTrue via conta no-reply
+#     (com SMTP ativo, setar GOTRUE_MAILER_AUTOCONFIRM=false).
+#   DISABLE_SIGNUP / NEXT_PUBLIC_SIGNUP_ENABLED — signup público
+#     (padrão: fechado).
 
 name: evolui-crm
 
@@ -49,6 +57,8 @@ services:
       META_APP_ID: ${META_APP_ID:-}
       NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-https://evolui-crm.vya.digital}
       NEXT_PUBLIC_APP_LOCALE: ${NEXT_PUBLIC_APP_LOCALE:-pt-BR}
+      # Espelha DISABLE_SIGNUP para o frontend (esconde /signup).
+      NEXT_PUBLIC_SIGNUP_ENABLED: ${NEXT_PUBLIC_SIGNUP_ENABLED:-false}
       AUTOMATION_CRON_SECRET: ${AUTOMATION_CRON_SECRET:-}
       ALLOWED_INVITE_HOSTS: ${ALLOWED_INVITE_HOSTS:-evolui-crm.vya.digital}
     networks:
@@ -164,11 +174,44 @@ services:
       GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
       GOTRUE_JWT_ADMIN_ROLES: service_role
       GOTRUE_JWT_AUD: authenticated
-      GOTRUE_DISABLE_SIGNUP: "true"
+      # Signup público controlado por DISABLE_SIGNUP no .env
+      # (padrão: desabilitado — entrada só por convite ou bootstrap).
+      GOTRUE_DISABLE_SIGNUP: ${DISABLE_SIGNUP:-true}
       GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
-      # Sem SMTP configurado: confirma e-mails automaticamente.
-      # Configurar GOTRUE_SMTP_* e desligar isto quando houver SMTP.
-      GOTRUE_MAILER_AUTOCONFIRM: "true"
+      # SMTP da conta no-reply (SMTP_* no .env). Enquanto o SMTP não
+      # estiver preenchido, manter GOTRUE_MAILER_AUTOCONFIRM=true;
+      # com SMTP ativo, setar false no .env para exigir confirmação.
+      GOTRUE_MAILER_AUTOCONFIRM: ${GOTRUE_MAILER_AUTOCONFIRM:-true}
+      GOTRUE_SMTP_HOST: ${SMTP_HOST:-}
+      GOTRUE_SMTP_PORT: ${SMTP_PORT:-587}
+      GOTRUE_SMTP_USER: ${SMTP_USER:-}
+      GOTRUE_SMTP_PASS: ${SMTP_PASS:-}
+      GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL:-}
+      GOTRUE_SMTP_SENDER_NAME: ${SMTP_SENDER_NAME:-Evolui CRM}
+    networks:
+      - db-network
+
+  # ------------------------------------------------------------------
+  # Bootstrap do usuário admin padrão (one-shot; roda a cada `up` e é
+  # idempotente — se ADMIN_EMAIL/ADMIN_PASSWORD não estiverem no .env,
+  # apenas loga que está desativado e sai).
+  # ------------------------------------------------------------------
+  admin-bootstrap:
+    image: curlimages/curl:8.12.1
+    restart: "no"
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+      supabase-auth:
+        condition: service_started
+    environment:
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
+      ADMIN_FULL_NAME: ${ADMIN_FULL_NAME:-Administrador}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
+    volumes:
+      - ./scripts/bootstrap-admin.sh:/usr/local/bin/bootstrap-admin.sh:ro
+    entrypoint: ["/bin/sh", "/usr/local/bin/bootstrap-admin.sh"]
     networks:
       - db-network
 

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Criado em: 10/07/2026 01:30
+# Modificado em: 10/07/2026 01:30
+#
+# Entrypoint do container do app. A imagem é buildada com PLACEHOLDERS
+# nas variáveis NEXT_PUBLIC_* (que o Next.js embute no bundle). Aqui,
+# no start, substituímos os placeholders pelos valores reais vindos do
+# ambiente (.env do compose) — a imagem fica genérica e o .env externo.
+
+set -eu
+
+: "${NEXT_PUBLIC_SUPABASE_URL:?defina NEXT_PUBLIC_SUPABASE_URL no ambiente}"
+: "${NEXT_PUBLIC_SUPABASE_ANON_KEY:?defina NEXT_PUBLIC_SUPABASE_ANON_KEY no ambiente}"
+: "${NEXT_PUBLIC_SITE_URL:?defina NEXT_PUBLIC_SITE_URL no ambiente}"
+
+PLACEHOLDER_URL="https://supabase-placeholder.invalid"
+PLACEHOLDER_WSS="wss://supabase-placeholder.invalid"
+PLACEHOLDER_ANON="NEXT_PUBLIC_SUPABASE_ANON_KEY_PLACEHOLDER"
+PLACEHOLDER_SITE="https://site-placeholder.invalid"
+
+RUNTIME_WSS="$(echo "${NEXT_PUBLIC_SUPABASE_URL}" | sed 's|^https:|wss:|; s|^http:|ws:|')"
+
+echo "[entrypoint] injetando configuração de runtime no bundle..."
+# Substitui em todos os arquivos de texto do build (JS, JSON, manifests).
+find /app/.next /app/server.js -type f \( -name '*.js' -o -name '*.json' -o -name '*.html' -o -name '*.rsc' \) 2>/dev/null \
+  | while read -r f; do
+      if grep -ql -e "${PLACEHOLDER_URL}" -e "${PLACEHOLDER_ANON}" -e "${PLACEHOLDER_SITE}" "$f" 2>/dev/null; then
+        sed -i \
+          -e "s|${PLACEHOLDER_WSS}|${RUNTIME_WSS}|g" \
+          -e "s|${PLACEHOLDER_URL}|${NEXT_PUBLIC_SUPABASE_URL}|g" \
+          -e "s|${PLACEHOLDER_ANON}|${NEXT_PUBLIC_SUPABASE_ANON_KEY}|g" \
+          -e "s|${PLACEHOLDER_SITE}|${NEXT_PUBLIC_SITE_URL}|g" \
+          "$f"
+      fi
+    done
+
+echo "[entrypoint] configuração aplicada; iniciando o servidor."
+exec node /app/server.js

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Criado em: 10/07/2026 01:30
-# Modificado em: 10/07/2026 01:30
+# Modificado em: 13/07/2026 11:17
 #
 # Entrypoint do container do app. A imagem é buildada com PLACEHOLDERS
 # nas variáveis NEXT_PUBLIC_* (que o Next.js embute no bundle). Aqui,
@@ -17,19 +17,31 @@ PLACEHOLDER_URL="https://supabase-placeholder.invalid"
 PLACEHOLDER_WSS="wss://supabase-placeholder.invalid"
 PLACEHOLDER_ANON="NEXT_PUBLIC_SUPABASE_ANON_KEY_PLACEHOLDER"
 PLACEHOLDER_SITE="https://site-placeholder.invalid"
+PLACEHOLDER_SIGNUP="NEXT_PUBLIC_SIGNUP_ENABLED_PLACEHOLDER"
 
 RUNTIME_WSS="$(echo "${NEXT_PUBLIC_SUPABASE_URL}" | sed 's|^https:|wss:|; s|^http:|ws:|')"
+
+# Flag de signup público: normaliza para "true"/"false" (padrão false —
+# signup fechado; ver DISABLE_SIGNUP/GOTRUE_DISABLE_SIGNUP no compose).
+if [ "${NEXT_PUBLIC_SIGNUP_ENABLED:-false}" = "true" ]; then
+  RUNTIME_SIGNUP="true"
+else
+  RUNTIME_SIGNUP="false"
+fi
+# O middleware lê a variável em runtime — garante o valor normalizado.
+export NEXT_PUBLIC_SIGNUP_ENABLED="${RUNTIME_SIGNUP}"
 
 echo "[entrypoint] injetando configuração de runtime no bundle..."
 # Substitui em todos os arquivos de texto do build (JS, JSON, manifests).
 find /app/.next /app/server.js -type f \( -name '*.js' -o -name '*.json' -o -name '*.html' -o -name '*.rsc' \) 2>/dev/null \
   | while read -r f; do
-      if grep -ql -e "${PLACEHOLDER_URL}" -e "${PLACEHOLDER_ANON}" -e "${PLACEHOLDER_SITE}" "$f" 2>/dev/null; then
+      if grep -ql -e "${PLACEHOLDER_URL}" -e "${PLACEHOLDER_ANON}" -e "${PLACEHOLDER_SITE}" -e "${PLACEHOLDER_SIGNUP}" "$f" 2>/dev/null; then
         sed -i \
           -e "s|${PLACEHOLDER_WSS}|${RUNTIME_WSS}|g" \
           -e "s|${PLACEHOLDER_URL}|${NEXT_PUBLIC_SUPABASE_URL}|g" \
           -e "s|${PLACEHOLDER_ANON}|${NEXT_PUBLIC_SUPABASE_ANON_KEY}|g" \
           -e "s|${PLACEHOLDER_SITE}|${NEXT_PUBLIC_SITE_URL}|g" \
+          -e "s|${PLACEHOLDER_SIGNUP}|${RUNTIME_SIGNUP}|g" \
           "$f"
       fi
     done

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -1,0 +1,48 @@
+# Criado em: 10/07/2026 00:40
+# Modificado em: 10/07/2026 01:10
+#
+# Template do .env do deploy (docker compose). Copie para .env e
+# preencha — NUNCA versionar o .env real. Guarde uma cópia dos valores
+# em .secrets/ (fora do git).
+#
+# Geração das chaves Supabase self-hosted (anon/service_role a partir
+# do JWT_SECRET): https://supabase.com/docs/guides/self-hosting#api-keys
+
+# ---------- Supabase ----------
+# URL pública do gateway (Kong) roteada pelo Traefik
+NEXT_PUBLIC_SUPABASE_URL=https://supabase.evolui-crm.vya.digital
+# JWTs derivados do JWT_SECRET (role: anon / service_role)
+NEXT_PUBLIC_SUPABASE_ANON_KEY=coloque-o-jwt-anon-aqui
+SUPABASE_SERVICE_ROLE_KEY=coloque-o-jwt-service-role-aqui
+# Segredo JWT (>= 32 chars): openssl rand -hex 32
+JWT_SECRET=coloque-um-segredo-de-32-bytes-aqui
+# Senha do Postgres: openssl rand -hex 24
+POSTGRES_PASSWORD=coloque-a-senha-do-postgres-aqui
+# Secret do Realtime (Phoenix): openssl rand -hex 32
+REALTIME_SECRET_KEY_BASE=coloque-um-segredo-de-64-chars-aqui
+
+# ---------- Aplicação ----------
+# Tag da imagem publicada (adminvyadigital/enterprise-evolution-crm)
+APP_VERSION=0.0.1
+NEXT_PUBLIC_SITE_URL=https://evolui-crm.vya.digital
+NEXT_PUBLIC_APP_LOCALE=pt-BR
+# 64 hex chars (AES-256-GCM): node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ENCRYPTION_KEY=coloque-64-hex-chars-aqui
+# Cron das automações: openssl rand -hex 32
+AUTOMATION_CRON_SECRET=coloque-um-segredo-aqui
+ALLOWED_INVITE_HOSTS=evolui-crm.vya.digital
+
+# ---------- WhatsApp (Meta Cloud API) ----------
+META_APP_SECRET=coloque-o-app-secret-da-meta-aqui
+META_APP_ID=
+
+# ---------- Evolution API (FASE 2 — docker-compose.evolution.yml) ----------
+# Chave de autenticação da API: openssl rand -hex 32
+EVOLUTION_API_KEY=coloque-a-chave-da-evolution-aqui
+
+# ---------- Backup ----------
+BACKUP_RETENTION_DAYS=0
+
+# ---------- Persistência ----------
+# Base dos bind mounts de dados (criar as subpastas antes do 1º up)
+DATA_DIR=/opt/docker_user/enterprise-evolui-crm

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -1,5 +1,5 @@
 # Criado em: 10/07/2026 00:40
-# Modificado em: 10/07/2026 01:10
+# Modificado em: 13/07/2026 11:17
 #
 # Template do .env do deploy (docker compose). Copie para .env e
 # preencha — NUNCA versionar o .env real. Guarde uma cópia dos valores
@@ -31,6 +31,35 @@ ENCRYPTION_KEY=coloque-64-hex-chars-aqui
 # Cron das automações: openssl rand -hex 32
 AUTOMATION_CRON_SECRET=coloque-um-segredo-aqui
 ALLOWED_INVITE_HOSTS=evolui-crm.vya.digital
+
+# ---------- Admin padrão (bootstrap one-shot no boot do stack) ----------
+# Se vazios, o serviço admin-bootstrap não faz nada. Guardar os valores
+# reais em .secrets/ (fora do git). O usuário criado vira owner da
+# própria conta via trigger handle_new_user.
+ADMIN_EMAIL=
+ADMIN_PASSWORD=
+ADMIN_FULL_NAME=Administrador
+
+# ---------- Signup público ----------
+# true (padrão) = ninguém se registra sozinho; entrada só por convite
+# ou pelo admin-bootstrap. false = signup aberto.
+DISABLE_SIGNUP=true
+# Espelho para o frontend: true mostra a página /signup e o link
+# "criar conta". Manter coerente com DISABLE_SIGNUP (invertido).
+NEXT_PUBLIC_SIGNUP_ENABLED=false
+
+# ---------- SMTP (conta no-reply, somente envio) ----------
+# Usado pelo GoTrue (confirmação de e-mail, reset de senha etc.).
+# Enquanto vazio, manter GOTRUE_MAILER_AUTOCONFIRM=true (e-mails são
+# confirmados automaticamente). Com SMTP preenchido, setar false.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=no-reply@vya.digital
+SMTP_PASS=
+# Remetente exibido nos e-mails
+SMTP_ADMIN_EMAIL=no-reply@vya.digital
+SMTP_SENDER_NAME=Evolui CRM
+GOTRUE_MAILER_AUTOCONFIRM=true
 
 # ---------- WhatsApp (Meta Cloud API) ----------
 META_APP_SECRET=coloque-o-app-secret-da-meta-aqui

--- a/deploy/scripts/apply-migrations.sh
+++ b/deploy/scripts/apply-migrations.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Criado em: 10/07/2026 12:40
+# Modificado em: 10/07/2026 12:50
+#
+# Aplica as migrations do CRM (supabase/migrations/*.sql) no Postgres
+# self-hosted, em ordem alfabética (001_, 002_, ...), via psql dentro
+# do container supabase-db (usuário supabase_admin = superuser).
+#
+# Idempotência: registra cada migration aplicada na tabela
+# public._migrations e pula as já executadas — rodar de novo é seguro.
+#
+# Uso (na pasta deploy/):
+#   ./scripts/apply-migrations.sh [caminho/para/migrations]
+# Sem argumento, procura em: <repo>/supabase/migrations,
+# deploy/migrations e deploy/supabase/migrations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(dirname "${SCRIPT_DIR}")"
+REPO_ROOT="$(dirname "${DEPLOY_DIR}")"
+
+# Localiza as migrations: 1º argumento > variável MIGRATIONS_DIR >
+# locais conhecidos (repo completo ou cópia junto ao deploy/).
+MIGRATIONS_DIR="${1:-${MIGRATIONS_DIR:-}}"
+if [[ -z "${MIGRATIONS_DIR}" ]]; then
+  for candidato in \
+    "${REPO_ROOT}/supabase/migrations" \
+    "${DEPLOY_DIR}/migrations" \
+    "${DEPLOY_DIR}/supabase/migrations"; do
+    if [[ -d "${candidato}" ]]; then
+      MIGRATIONS_DIR="${candidato}"
+      break
+    fi
+  done
+fi
+if [[ -z "${MIGRATIONS_DIR}" || ! -d "${MIGRATIONS_DIR}" ]]; then
+  echo "ERRO: pasta de migrations não encontrada." >&2
+  echo "No servidor sem o repositório completo, copie a pasta antes:" >&2
+  echo "  scp -r supabase/migrations usuario@servidor:<caminho>/deploy/migrations" >&2
+  echo "Ou informe o caminho: ./scripts/apply-migrations.sh /caminho/para/migrations" >&2
+  exit 1
+fi
+echo "==> Usando migrations de: ${MIGRATIONS_DIR}"
+
+PSQL=(docker compose -f "${DEPLOY_DIR}/docker-compose.yml" exec -T supabase-db \
+  psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1 --quiet)
+
+echo "==> Criando tabela de controle (se não existir)"
+"${PSQL[@]}" -c "CREATE TABLE IF NOT EXISTS public._migrations (
+  name text PRIMARY KEY,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);"
+
+aplicadas=0
+puladas=0
+for arquivo in "${MIGRATIONS_DIR}"/*.sql; do
+  nome="$(basename "${arquivo}")"
+  ja_existe="$("${PSQL[@]}" -tAc \
+    "SELECT 1 FROM public._migrations WHERE name = '${nome}'")"
+  if [[ "${ja_existe}" == "1" ]]; then
+    puladas=$((puladas + 1))
+    continue
+  fi
+  echo "==> Aplicando ${nome}"
+  "${PSQL[@]}" -f - < "${arquivo}"
+  "${PSQL[@]}" -c "INSERT INTO public._migrations (name) VALUES ('${nome}');"
+  aplicadas=$((aplicadas + 1))
+done
+
+echo "==> Concluído: ${aplicadas} aplicadas, ${puladas} já existentes"
+echo "==> Verificação rápida:"
+"${PSQL[@]}" -c "SELECT count(*) AS tabelas FROM information_schema.tables
+  WHERE table_schema = 'public';"

--- a/deploy/scripts/backup-db.sh
+++ b/deploy/scripts/backup-db.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Criado em: 10/07/2026 00:40
+# Modificado em: 10/07/2026 00:40
+#
+# Backup do Postgres (Supabase self-hosted) para o volume /backups.
+# Executado pelo serviço db-backup (loop diário) ou manualmente:
+#   docker compose exec db-backup /usr/local/bin/backup-db.sh
+#
+# Variáveis:
+#   PGPASSWORD              — senha do postgres (vem do compose)
+#   BACKUP_RETENTION_DAYS   — dias de retenção (padrão 7)
+
+set -euo pipefail
+
+BACKUP_DIR="/backups"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
+STAMP="$(date +%Y-%m-%d_%H%M%S)"
+FILE="${BACKUP_DIR}/evolui-crm_${STAMP}.dump"
+
+echo "[backup-db] iniciando pg_dump -> ${FILE}"
+pg_dump \
+  --host=supabase-db \
+  --port=5432 \
+  --username=postgres \
+  --dbname=postgres \
+  --format=custom \
+  --file="${FILE}"
+
+echo "[backup-db] concluído: $(du -h "${FILE}" | cut -f1)"
+
+# Rotação: remove dumps mais antigos que a retenção.
+find "${BACKUP_DIR}" -name 'evolui-crm_*.dump' -mtime "+${RETENTION_DAYS}" -delete
+echo "[backup-db] rotação aplicada (retenção: ${RETENTION_DAYS} dias)"

--- a/deploy/scripts/bootstrap-admin.sh
+++ b/deploy/scripts/bootstrap-admin.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Criado em: 13/07/2026 11:07
+# Modificado em: 13/07/2026 11:07
+#
+# Bootstrap do usuário admin padrão — roda como serviço one-shot do
+# docker compose (admin-bootstrap) no boot do stack.
+#
+# Cria o usuário via Admin API do GoTrue (POST /admin/users), direto no
+# serviço supabase-auth pela rede interna (sem passar pelo Kong). A
+# Admin API ignora GOTRUE_DISABLE_SIGNUP, e o trigger handle_new_user
+# cria profile + conta pessoal + role 'owner' automaticamente.
+#
+# Idempotente: se o e-mail já existir, o GoTrue responde 422 e o script
+# apenas loga e sai 0. Sem ADMIN_EMAIL/ADMIN_PASSWORD definidos, o
+# bootstrap é considerado desativado (sai 0 sem erro).
+#
+# Credenciais SOMENTE via variáveis de ambiente (nunca em argv) e
+# nunca ecoadas nos logs.
+
+set -eu
+
+AUTH_URL="${GOTRUE_INTERNAL_URL:-http://supabase-auth:9999}"
+
+log() {
+  echo "[bootstrap-admin] $1"
+}
+
+if [ -z "${ADMIN_EMAIL:-}" ] || [ -z "${ADMIN_PASSWORD:-}" ]; then
+  log "ADMIN_EMAIL/ADMIN_PASSWORD não definidos — bootstrap desativado."
+  exit 0
+fi
+
+if [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+  log "ERRO: SUPABASE_SERVICE_ROLE_KEY não definido no ambiente."
+  exit 1
+fi
+
+# Espera o GoTrue ficar saudável (até ~60s).
+tentativa=0
+until curl -fsS -o /dev/null "${AUTH_URL}/health"; do
+  tentativa=$((tentativa + 1))
+  if [ "${tentativa}" -ge 30 ]; then
+    log "ERRO: GoTrue não respondeu em ${AUTH_URL}/health após 60s."
+    exit 1
+  fi
+  log "aguardando GoTrue (${tentativa}/30)..."
+  sleep 2
+done
+
+log "GoTrue disponível; criando usuário admin (e-mail mascarado: ${ADMIN_EMAIL%%@*}@***)..."
+
+# Payload e header de autorização em arquivos temporários — nada de
+# senha/token em argv (visível em /proc e em logs de processo).
+PAYLOAD_FILE="$(mktemp)"
+HEADER_FILE="$(mktemp)"
+trap 'rm -f "${PAYLOAD_FILE}" "${HEADER_FILE}"' EXIT
+cat > "${PAYLOAD_FILE}" <<EOF
+{
+  "email": "${ADMIN_EMAIL}",
+  "password": "${ADMIN_PASSWORD}",
+  "email_confirm": true,
+  "user_metadata": { "full_name": "${ADMIN_FULL_NAME:-Administrador}" }
+}
+EOF
+printf 'Authorization: Bearer %s\n' "${SUPABASE_SERVICE_ROLE_KEY}" > "${HEADER_FILE}"
+
+HTTP_CODE="$(
+  curl -sS -o /tmp/bootstrap-admin-response.json -w '%{http_code}' \
+    -X POST "${AUTH_URL}/admin/users" \
+    -H @"${HEADER_FILE}" \
+    -H "Content-Type: application/json" \
+    --data @"${PAYLOAD_FILE}"
+)"
+
+case "${HTTP_CODE}" in
+  200|201)
+    log "usuário admin criado com sucesso (HTTP ${HTTP_CODE})."
+    ;;
+  422)
+    # E-mail já registrado — execução repetida do stack; nada a fazer.
+    log "usuário já existe (HTTP 422) — nada a fazer."
+    ;;
+  *)
+    log "ERRO: GoTrue respondeu HTTP ${HTTP_CODE}."
+    # Resposta pode conter detalhes úteis e não contém a senha.
+    cat /tmp/bootstrap-admin-response.json || true
+    echo ""
+    exit 1
+    ;;
+esac
+
+log "bootstrap concluído."
+exit 0

--- a/deploy/scripts/build-push.sh
+++ b/deploy/scripts/build-push.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Criado em: 10/07/2026 01:10
+# Modificado em: 10/07/2026 01:30
+#
+# Builda e publica a imagem do app no Docker Hub.
+#   Imagem: adminvyadigital/enterprise-evolution-crm
+#   Tags..: <versão> e latest
+#
+# A imagem é GENÉRICA — nenhum valor do .env entra no build. Toda a
+# configuração (NEXT_PUBLIC_* inclusive) é injetada em runtime pelo
+# docker-entrypoint.sh a partir do .env do compose.
+#
+# Uso:
+#   docker login -u adminvyadigital        # uma vez, interativo
+#   cd deploy && ./scripts/build-push.sh [versão]   # padrão: 0.0.1
+
+set -euo pipefail
+
+REGISTRY_USER="adminvyadigital"
+IMAGE_NAME="enterprise-evoli-crm"
+VERSION="${1:-0.0.2}"
+IMAGE="${REGISTRY_USER}/${IMAGE_NAME}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(dirname "${SCRIPT_DIR}")"
+REPO_ROOT="$(dirname "${DEPLOY_DIR}")"
+
+echo "==> Buildando ${IMAGE}:${VERSION} (e latest)"
+docker build \
+  -f "${DEPLOY_DIR}/Dockerfile" \
+  -t "${IMAGE}:${VERSION}" \
+  -t "${IMAGE}:latest" \
+  "${REPO_ROOT}" --no-cache
+
+echo "==> Publicando no Docker Hub"
+docker push "${IMAGE}:${VERSION}"
+docker push "${IMAGE}:latest"
+
+echo "==> Concluído: ${IMAGE}:${VERSION} e ${IMAGE}:latest publicadas"

--- a/deploy/supabase/init/zz-align-role-passwords.sh
+++ b/deploy/supabase/init/zz-align-role-passwords.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Criado em: 10/07/2026 16:30
+# Modificado em: 10/07/2026 16:30
+#
+# Executado pelo entrypoint do Postgres no PRIMEIRO boot (data dir
+# vazio), via /docker-entrypoint-initdb.d/. Alinha as senhas dos roles
+# internos do Supabase com POSTGRES_PASSWORD — sem isso, GoTrue,
+# PostgREST e Storage não conectam (Bug 2 do report de 10/07/2026).
+#
+# Prefixo "zz-" garante execução DEPOIS dos init scripts da própria
+# imagem supabase/postgres (que criam esses roles).
+
+set -euo pipefail
+
+echo "[init] alinhando senhas dos roles internos do Supabase..."
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<-SQL
+	ALTER USER supabase_auth_admin WITH PASSWORD '${POSTGRES_PASSWORD}';
+	ALTER USER authenticator WITH PASSWORD '${POSTGRES_PASSWORD}';
+	ALTER USER supabase_storage_admin WITH PASSWORD '${POSTGRES_PASSWORD}';
+SQL
+echo "[init] senhas alinhadas."

--- a/deploy/supabase/kong.yml
+++ b/deploy/supabase/kong.yml
@@ -1,0 +1,127 @@
+# Criado em: 10/07/2026 00:40
+# Modificado em: 10/07/2026 12:15
+#
+# Configuração declarativa do Kong (gateway do Supabase self-hosted).
+# Roteia /auth/v1, /rest/v1, /realtime/v1 e /storage/v1 para os
+# serviços internos. Autenticação por apikey (anon / service_role),
+# como no template oficial de self-hosting do Supabase.
+
+# Aspas SIMPLES obrigatórias: o entrypoint interpola o arquivo com
+# eval/echo, que removeria aspas duplas (Kong exige string aqui).
+_format_version: '2.1'
+_transform: true
+
+# As chaves são interpoladas pelo entrypoint do serviço supabase-kong
+# (eval/echo do template) a partir de SUPABASE_ANON_KEY / SUPABASE_SERVICE_KEY.
+consumers:
+  - username: anon
+    keyauth_credentials:
+      - key: $SUPABASE_ANON_KEY
+  - username: service_role
+    keyauth_credentials:
+      - key: $SUPABASE_SERVICE_KEY
+
+acls:
+  - consumer: anon
+    group: anon
+  - consumer: service_role
+    group: admin
+
+services:
+  - name: auth-v1-open
+    url: http://supabase-auth:9999/verify
+    routes:
+      - name: auth-v1-open
+        strip_path: true
+        paths:
+          - /auth/v1/verify
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-callback
+    url: http://supabase-auth:9999/callback
+    routes:
+      - name: auth-v1-open-callback
+        strip_path: true
+        paths:
+          - /auth/v1/callback
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-authorize
+    url: http://supabase-auth:9999/authorize
+    routes:
+      - name: auth-v1-open-authorize
+        strip_path: true
+        paths:
+          - /auth/v1/authorize
+    plugins:
+      - name: cors
+
+  - name: auth-v1
+    url: http://supabase-auth:9999/
+    routes:
+      - name: auth-v1-all
+        strip_path: true
+        paths:
+          - /auth/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: rest-v1
+    url: http://supabase-rest:3000/
+    routes:
+      - name: rest-v1-all
+        strip_path: true
+        paths:
+          - /rest/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: true
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: realtime-v1-ws
+    url: http://supabase-realtime:4000/socket
+    protocol: ws
+    routes:
+      - name: realtime-v1-ws
+        strip_path: true
+        paths:
+          - /realtime/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: storage-v1
+    url: http://supabase-storage:5000/
+    routes:
+      - name: storage-v1-all
+        strip_path: true
+        paths:
+          - /storage/v1/
+    plugins:
+      - name: cors

--- a/docs/DEPLOY_V2_PLAN.md
+++ b/docs/DEPLOY_V2_PLAN.md
@@ -1,0 +1,73 @@
+<!--
+Criado em: 10/07/2026 13:00
+Modificado em: 10/07/2026 13:00
+-->
+
+# Plano — Deploy v2 (correção dos bugs do primeiro deploy)
+
+**Objetivo**: novo deploy reproduzível do zero, sem intervenção manual,
+corrigindo os bugs documentados em
+[bugs/2026-07-10-deploy-docker-bugs.md](bugs/2026-07-10-deploy-docker-bugs.md)
+e incluindo a criação do usuário admin como etapa do fluxo.
+
+## Mudanças a implementar
+
+### 1. Init do banco — senhas dos roles internos (Bug 2)
+Criar `deploy/supabase/init/00-align-role-passwords.sh`, montado em
+`/docker-entrypoint-initdb.d/` no serviço `supabase-db`:
+- No primeiro boot (data dir vazio), executa
+  `ALTER USER supabase_auth_admin / authenticator /
+  supabase_storage_admin WITH PASSWORD '${POSTGRES_PASSWORD}'`.
+- Para bases já existentes o script não roda (comportamento padrão do
+  entrypoint Postgres) — documentar o comando manual no README do deploy.
+
+### 2. Migrations empacotadas e automáticas (Bugs 3 e 6)
+- Copiar `supabase/migrations/` para `deploy/migrations/` no pacote de
+  deploy (o servidor não tem o repo completo). Adicionar ao
+  `build-push.sh` um aviso/cópia, ou sincronizar via `scp` documentado.
+- Manter `apply-migrations.sh` (idempotente) como executor, chamado
+  pelo bootstrap — nunca manualmente no caminho feliz.
+
+### 3. Bootstrap único — ordem correta (Bugs 3 e 5)
+Criar `deploy/scripts/bootstrap.sh` que orquestra:
+1. `docker compose up -d supabase-db` e espera healthcheck;
+2. (primeiro boot) senhas via init script — automático;
+3. `docker compose up -d` (demais serviços);
+4. Espera `supabase-auth` responder (`/auth/v1/health` via Kong);
+5. `./scripts/apply-migrations.sh`;
+6. **Criação do usuário admin**: `python3 scripts/create_admin_user.py`
+   (lê `.secrets/create_account.json` + `.secrets/.env`) — agora
+   DEPOIS das migrations, para o trigger `handle_new_user` criar o
+   profile automaticamente (sem backfill);
+7. Smoke test: `GET https://evolui-crm.vya.digital/login` → 200 e
+   `POST /auth/v1/token` com as credenciais do admin → 200.
+
+### 4. Higiene
+- `kong.yml`: já corrigido (aspas simples) — sem ação, manter comentário.
+- Versionar a imagem: publicar `0.0.2` com `build-push.sh` e fixar
+  `APP_VERSION=0.0.2` no `.env` do servidor.
+- Registrar o deploy em `docs/SESSIONS/2026-07-10/`.
+
+## Sequência de execução no servidor
+
+```bash
+# 1. Atualizar pacote de deploy (deploy/ + migrations) no servidor
+# 2. Conferir .env (APP_VERSION=0.0.2) e .secrets/ (create_account.json)
+cd deploy
+./scripts/bootstrap.sh
+```
+
+## Verificação (fim a fim)
+1. `docker compose ps` — todos "Up", nenhum "Restarting".
+2. Login no app com o admin criado; troca de senha funciona (Bug 3 era
+   o bloqueio).
+3. `docker compose exec supabase-db psql -U supabase_admin -d postgres
+   -c "SELECT count(*) FROM public._migrations;"` → 35.
+4. Certificados Let's Encrypt válidos nos 2 hosts (`openssl s_client`).
+5. Backup: rodar `backup-db.sh` e conferir dump em
+   `${DATA_DIR}/supabase-db-backups`.
+
+## Fora deste deploy
+- Evolution API (Fase 2 — `docker-compose.evolution.yml`).
+- SMTP do GoTrue (hoje `GOTRUE_MAILER_AUTOCONFIRM=true`).
+- Desativar página `/signup` na UI (cosmético; API já bloqueia).

--- a/docs/SESSIONS/2026-07-13/DAILY_ACTIVITIES_2026-07-13.md
+++ b/docs/SESSIONS/2026-07-13/DAILY_ACTIVITIES_2026-07-13.md
@@ -1,0 +1,18 @@
+<!-- Criado em: 13/07/2026 11:17 -->
+<!-- Modificado em: 13/07/2026 11:17 -->
+
+# Atividades — 13/07/2026
+
+## Admin padrão no boot, SMTP no-reply e flag de signup
+
+- **Horário/Status**: 11:00–11:20 — concluído (aguardando PR).
+- **Objetivo**: (1) criar usuário admin padrão no início do stack; (2) configurar envio de e-mail via SMTP com conta no-reply; (3) variável de ambiente para desativar a auto-criação de usuários (signup público).
+- **Contexto**: auth é Supabase/GoTrue self-hosted (`deploy/docker-compose.yml`). O admin era criado manualmente por `scripts/create_admin_user.py`; `GOTRUE_DISABLE_SIGNUP` e `GOTRUE_MAILER_AUTOCONFIRM` estavam hard-coded; nenhum SMTP configurado; a página `/signup` continuava visível mesmo com signup bloqueado no backend.
+- **Passos/Resultado**:
+  - Novo serviço one-shot `admin-bootstrap` no compose (imagem `curlimages/curl`, rede interna) executando `deploy/scripts/bootstrap-admin.sh`: espera o `/health` do GoTrue, cria o usuário via Admin API (`POST /admin/users`, ignora o bloqueio de signup); idempotente (HTTP 422 = já existe); desativado se `ADMIN_EMAIL`/`ADMIN_PASSWORD` vazios; token e senha nunca em argv (arquivos temporários).
+  - SMTP no GoTrue: `GOTRUE_SMTP_HOST/PORT/USER/PASS/ADMIN_EMAIL/SENDER_NAME` vindos de `SMTP_*` do `.env`; `GOTRUE_MAILER_AUTOCONFIRM` agora configurável (padrão `true` enquanto não houver SMTP). Somente envio — sem IMAP (decisão do usuário).
+  - Signup público: `GOTRUE_DISABLE_SIGNUP: ${DISABLE_SIGNUP:-true}` (backend) + `NEXT_PUBLIC_SIGNUP_ENABLED` (frontend, padrão `false`): middleware redireciona `/signup` → `/login` (exceto com `?invite=`), link "criar conta" oculto no `/login`; placeholder novo no `Dockerfile` + substituição no `docker-entrypoint.sh`.
+- **Decisões**: bootstrap como serviço one-shot no compose (escolha do usuário) em vez de etapa no entrypoint do app; signup desabilitado por padrão; e-mail apenas via GoTrue (nenhum mailer no app Next.js).
+- **Arquivos modificados**: `deploy/docker-compose.yml`, `deploy/env.example`, `deploy/Dockerfile`, `deploy/docker-entrypoint.sh`, `deploy/scripts/bootstrap-admin.sh` (novo), `src/middleware.ts`, `src/app/(auth)/login/page.tsx`, `src/lib/auth/signup-flag.ts` (novo), `.env.local.example`.
+- **Verificação**: `docker compose --env-file env.example config` OK; `sh -n` nos scripts OK; `npm run lint` sem erros novos (26 pré-existentes na main); `tsc --noEmit` limpo.
+- **Commits**: branch `359-admin-bootstrap-smtp-signup-flag` (PR a abrir).

--- a/docs/bugs/2026-07-10-deploy-docker-bugs.md
+++ b/docs/bugs/2026-07-10-deploy-docker-bugs.md
@@ -1,0 +1,116 @@
+<!--
+Criado em: 10/07/2026 13:00
+Modificado em: 10/07/2026 13:00
+-->
+
+# Bug Report — Primeiro deploy Docker (10/07/2026)
+
+Bugs encontrados durante o primeiro deploy do stack (app + Supabase
+self-hosted + Traefik) em `evolui-crm.vya.digital`, com causa raiz,
+correção aplicada e prevenção para o próximo deploy.
+
+| # | Severidade | Componente | Status |
+|---|------------|------------|--------|
+| 1 | 🔴 Alta | supabase-kong | ✅ Corrigido |
+| 2 | 🔴 Alta | supabase-auth / rest / storage | ✅ Contornado manualmente — precisa correção definitiva |
+| 3 | 🔴 Alta | banco (schema do CRM) | ✅ Contornado — precisa automação |
+| 4 | 🟠 Média | Traefik (TLS) | ✅ Resolvido (consequência do #1) |
+| 5 | 🟠 Média | usuário admin | ✅ Contornado — precisa reordenação no fluxo |
+| 6 | 🟡 Baixa | scripts/apply-migrations.sh | ✅ Corrigido |
+| 7 | 🟡 Baixa | .secrets/create_account.json | ✅ Corrigido pelo usuário |
+
+---
+
+## Bug 1 — Kong em crash-loop: `_format_version: expected a string`
+
+- **Sintoma**: container `supabase-kong` reiniciando em loop;
+  `init_by_lua error: error parsing declarative config ... in
+  '_format_version': expected a string`.
+- **Causa raiz**: o entrypoint interpola o template com
+  `eval "echo \"$(cat temp.yml)\""`, que **remove aspas duplas** do
+  arquivo. `_format_version: "2.1"` virava o número YAML `2.1`.
+- **Correção**: aspas simples (`'2.1'`) em `deploy/supabase/kong.yml`
+  (sobrevivem ao eval) + comentário explicando a restrição.
+- **Prevenção**: nunca usar aspas duplas em valores do kong.yml;
+  validado por simulação do eval no repositório.
+
+## Bug 2 — GoTrue/PostgREST/Storage: `password authentication failed`
+
+- **Sintoma**: `supabase-auth` em crash-loop com
+  `FATAL: password authentication failed for user "supabase_auth_admin"`;
+  Kong devolvia `503 name resolution failed` (o container caía e o DNS
+  interno do Docker deixava de resolver o nome).
+- **Causa raiz**: a imagem `supabase/postgres` cria os roles internos
+  (`supabase_auth_admin`, `authenticator`, `supabase_storage_admin`)
+  **sem alinhar as senhas** com `POSTGRES_PASSWORD`, que é o que as
+  connection strings do compose usam.
+- **Correção aplicada (manual)**: `ALTER USER ... WITH PASSWORD` para
+  os três roles, executado como `supabase_admin` (o `postgres` da
+  imagem NÃO é superuser — tentar com ele dá
+  `"supabase_auth_admin" is a reserved role`).
+- **Prevenção (deploy v2)**: script SQL de inicialização montado em
+  `/docker-entrypoint-initdb.d/` que alinha as senhas no primeiro boot.
+
+## Bug 3 — Tabelas do CRM inexistentes: `relation "public.profiles" does not exist`
+
+- **Sintoma**: app logava `[getCurrentAccount] profile fetch error
+  42P01`; nenhuma operação funcionava (inclusive troca de senha).
+- **Causa raiz**: as 35 migrations de `supabase/migrations/*.sql`
+  nunca foram aplicadas no Postgres self-hosted — era passo manual do
+  plano e não havia automação.
+- **Correção**: criado `deploy/scripts/apply-migrations.sh`
+  (idempotente, registra em `public._migrations`, roda como
+  `supabase_admin`).
+- **Prevenção (deploy v2)**: migrations incluídas no fluxo de
+  bootstrap, executadas antes de qualquer criação de usuário.
+
+## Bug 4 — TLS servindo `TRAEFIK DEFAULT CERT`
+
+- **Sintoma**: `create_admin_user.py` falhava com
+  `CERTIFICATE_VERIFY_FAILED: self-signed certificate`.
+- **Causa raiz**: consequência do Bug 1 — com o Kong em crash-loop o
+  Traefik não tinha backend saudável, e o certificado Let's Encrypt
+  não era servido para os hosts.
+- **Correção**: resolvido com o Bug 1; HTTPS validado na sequência
+  (a chamada seguinte à Admin API completou o TLS normalmente).
+
+## Bug 5 — Usuário admin criado sem profile
+
+- **Sintoma**: usuário existia em `auth.users`, mas sem linha em
+  `public.profiles` (e portanto sem conta no CRM).
+- **Causa raiz**: ordem invertida — o usuário foi criado **antes** de
+  as migrations existirem; o trigger `handle_new_user` (que cria o
+  profile) ainda não estava instalado.
+- **Correção**: backfill manual
+  (`INSERT INTO public.profiles ... SELECT ... FROM auth.users ON
+  CONFLICT DO NOTHING`).
+- **Prevenção (deploy v2)**: criação do admin passa a ser etapa
+  **posterior** às migrations no bootstrap.
+
+## Bug 6 — apply-migrations.sh não encontrava a pasta no servidor
+
+- **Sintoma**: `pasta de migrations não encontrada` — no servidor só
+  existe `deploy/`, sem o repositório completo.
+- **Correção**: o script agora procura em múltiplos locais
+  (`<repo>/supabase/migrations`, `deploy/migrations`,
+  `deploy/supabase/migrations`) e aceita o caminho como argumento.
+
+## Bug 7 — `create_account.json` com e-mail inválido
+
+- **Sintoma**: `create_admin_user.py` rejeitava o JSON (`Campo 'email'
+  ausente ou inválido`) — o valor não continha `@`.
+- **Correção**: valor corrigido pelo usuário no `.secrets/`
+  (validação do script funcionou como esperado).
+
+---
+
+## Lições para o deploy v2
+
+1. **Ordem importa**: banco saudável → senhas dos roles → migrations →
+   admin → app. Automatizar como sequência única (bootstrap).
+2. **Nada manual no caminho crítico**: senhas de roles e migrations
+   precisam ser automáticas (init script + runner idempotente).
+3. **Superuser correto**: toda manutenção no Postgres da imagem
+   Supabase usa `supabase_admin`, não `postgres`.
+4. **Template do Kong é sensível a aspas** — documentado no próprio
+   arquivo.

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,20 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
  *     deny them. A supply-chain compromise or a forgotten plugin
  *     can't silently opt back in.
  */
+/**
+ * Self-hosted Supabase lives on its own hostname (not *.supabase.co),
+ * so the CSP must also allow the origin from NEXT_PUBLIC_SUPABASE_URL.
+ * Inlined at build time — rebuild the image when the URL changes.
+ */
+const SUPABASE_ORIGIN = (() => {
+  try {
+    return new URL(process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").origin;
+  } catch {
+    return "";
+  }
+})();
+const SUPABASE_WSS = SUPABASE_ORIGIN.replace(/^https:/, "wss:");
+
 const SECURITY_HEADERS = [
   {
     key: "Strict-Transport-Security",
@@ -51,11 +65,11 @@ const SECURITY_HEADERS = [
       "img-src 'self' data: blob: https:",
       // Outbound media previews (blob: from MediaRecorder + file picker)
       // and Supabase public-bucket audio/video the inbox renders.
-      "media-src 'self' blob: https://*.supabase.co",
+      `media-src 'self' blob: https://*.supabase.co ${SUPABASE_ORIGIN}`.trim(),
       "font-src 'self' data:",
       // Supabase REST + realtime (WSS). All Meta API calls happen
       // server-side, so graph.facebook.com does not belong here.
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      `connect-src 'self' https://*.supabase.co wss://*.supabase.co ${SUPABASE_ORIGIN} ${SUPABASE_WSS}`.trim(),
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",
@@ -64,6 +78,11 @@ const SECURITY_HEADERS = [
 ] as const;
 
 const nextConfig: NextConfig = {
+  // Standalone server bundle for the Docker image (deploy/Dockerfile):
+  // .next/standalone carries its own node_modules subset, so the final
+  // image ships without the full dependency tree.
+  output: "standalone",
+
   /**
    * Cache-Control policy.
    *

--- a/scripts/create_admin_user.py
+++ b/scripts/create_admin_user.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+"""
+-------------------------------------------------------------------------
+NOME..: create_admin_user.py
+LANG..: Python3
+TITULO: Cria usuário pré-definido via Admin API do GoTrue (Supabase)
+DATA..: 10/07/2026 12:00
+MODIFICADO: 10/07/2026 12:00
+VERSÃO: 0.1.0
+HOST..: local / diversos
+LOCAL.: scripts/
+OBS...: Lê credenciais do usuário de .secrets/create_account.json
+        (email, password, username ou full_name) e as chaves de API de
+        .secrets/.env (NEXT_PUBLIC_SUPABASE_URL e
+        SUPABASE_SERVICE_ROLE_KEY). Nada é hardcoded. Funciona mesmo
+        com GOTRUE_DISABLE_SIGNUP=true (a Admin API ignora o bloqueio
+        de signup público). O trigger handle_new_user do banco cria o
+        profile/conta automaticamente.
+
+DEPEND: requests
+
+-------------------------------------------------------------------------
+Modifications.....:
+ Date          Rev    Author           Description
+ 10/07/2026    1      Claude/yves      Elaboração
+
+-------------------------------------------------------------------------
+STATUS: DEV
+"""
+
+import logging
+import sys
+from json import loads
+from pathlib import Path
+
+import requests
+
+RAIZ = Path(__file__).resolve().parent.parent
+SECRETS_DIR = RAIZ / ".secrets"
+
+
+def config_logging() -> bool:
+    """
+    Configura o logging padrão do programa.
+
+    :return: True se configurado (ou já configurado).
+    :rtype: bool
+
+    :Example:
+
+    >>> config_logging()
+    True
+    """
+    logger = logging.getLogger()
+    if logger.hasHandlers():
+        return True
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(funcName)s:%(lineno)d - %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+    logging.info("=== Programa: %s ===", Path(sys.argv[0]).name)
+    return True
+
+
+def _mask(valor: str) -> str:
+    """
+    Mascara um valor sensível para log (mostra só o tamanho).
+
+    :param valor: Valor a mascarar.
+    :type valor: str
+    :return: Máscara no formato ``********(N)``.
+    :rtype: str
+
+    :Example:
+
+    >>> _mask("segredo")
+    '********(7)'
+    """
+    return f"********({len(valor)})" if isinstance(valor, str) else "********"
+
+
+def carregar_env(caminho: Path) -> dict | bool:
+    """
+    Carrega variáveis de um arquivo dotenv simples (chave=valor).
+
+    :param caminho: Caminho do arquivo .env.
+    :type caminho: Path
+    :return: Dicionário de variáveis ou False em caso de erro.
+    :rtype: dict | bool
+    """
+    logging.info("=== Função: %s ===", sys._getframe().f_code.co_name)
+    if not caminho or not isinstance(caminho, Path):
+        logging.error("Parâmetro 'caminho' inválido")
+        return False
+    try:
+        if not caminho.exists():
+            logging.error("Arquivo não encontrado: %s", caminho)
+            return False
+        variaveis: dict[str, str] = {}
+        for linha in caminho.read_text(encoding="utf-8").splitlines():
+            linha = linha.strip()
+            if not linha or linha.startswith("#") or "=" not in linha:
+                continue
+            nome, valor = linha.split("=", 1)
+            variaveis[nome.strip()] = valor.strip().strip('"').strip("'")
+        logging.info("Variáveis carregadas: %d", len(variaveis))
+        logging.info("=== Termino Função: %s ===", sys._getframe().f_code.co_name)
+        return variaveis
+    except BaseException as errorMsg:
+        logging.error("Erro ao carregar o arquivo .env")
+        logging.error("Exception occurred", exc_info=True)
+        logging.error(errorMsg)
+        return False
+
+
+def carregar_conta(caminho: Path) -> dict | bool:
+    """
+    Carrega e valida as credenciais do usuário a criar.
+
+    Aceita ``full_name`` ou, na falta dele, mapeia ``username`` para o
+    nome de exibição (usado pelo trigger handle_new_user do banco).
+
+    :param caminho: Caminho do JSON (ex.: .secrets/create_account.json).
+    :type caminho: Path
+    :return: Dict com email, password e full_name, ou False em erro.
+    :rtype: dict | bool
+    """
+    logging.info("=== Função: %s ===", sys._getframe().f_code.co_name)
+    if not caminho or not isinstance(caminho, Path):
+        logging.error("Parâmetro 'caminho' inválido")
+        return False
+    try:
+        if not caminho.exists():
+            logging.error("Arquivo não encontrado: %s", caminho)
+            return False
+        dados = loads(caminho.read_text(encoding="utf-8"))
+        email = dados.get("email", "")
+        password = dados.get("password", "")
+        full_name = dados.get("full_name") or dados.get("username") or ""
+        if not email or "@" not in email:
+            logging.error("Campo 'email' ausente ou inválido no JSON")
+            return False
+        if not password or len(password) < 8:
+            logging.error("Campo 'password' ausente ou menor que 8 caracteres")
+            return False
+        if not full_name:
+            logging.warning("Sem 'full_name'/'username' — perfil ficará sem nome")
+        logging.info(
+            "Conta carregada: email=%s, password=%s, full_name=%s",
+            email, _mask(password), full_name,
+        )
+        logging.info("=== Termino Função: %s ===", sys._getframe().f_code.co_name)
+        return {"email": email, "password": password, "full_name": full_name}
+    except BaseException as errorMsg:
+        logging.error("Erro ao carregar o JSON de conta")
+        logging.error("Exception occurred", exc_info=True)
+        logging.error(errorMsg)
+        return False
+
+
+def criar_usuario(send_data: dict) -> dict | bool:
+    """
+    Cria o usuário via Admin API do GoTrue (POST /auth/v1/admin/users).
+
+    :param send_data: Dict com supabase_url, service_role_key, email,
+        password e full_name.
+    :type send_data: dict
+    :return: JSON do usuário criado ou False em caso de erro.
+    :rtype: dict | bool
+    """
+    logging.info("=== Função: %s ===", sys._getframe().f_code.co_name)
+    if not send_data or not isinstance(send_data, dict):
+        logging.error("Parâmetro 'send_data' inválido")
+        return False
+    for campo in ("supabase_url", "service_role_key", "email", "password"):
+        if not send_data.get(campo):
+            logging.error("Campo obrigatório ausente em send_data: %s", campo)
+            return False
+    try:
+        endpoint = f"{send_data['supabase_url'].rstrip('/')}/auth/v1/admin/users"
+        headers = {
+            "Authorization": f"Bearer {send_data['service_role_key']}",
+            "apikey": send_data["service_role_key"],
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "email": send_data["email"],
+            "password": send_data["password"],
+            "email_confirm": True,
+            "user_metadata": {"full_name": send_data.get("full_name", "")},
+        }
+        resposta = requests.post(endpoint, headers=headers, json=payload, timeout=30)
+        if resposta.status_code in (200, 201):
+            corpo = resposta.json()
+            logging.info("Usuário criado: id=%s, email=%s", corpo.get("id"), send_data["email"])
+            logging.info("=== Termino Função: %s ===", sys._getframe().f_code.co_name)
+            return corpo
+        if resposta.status_code == 422 and "already" in resposta.text.lower():
+            logging.warning("Usuário já existe: %s — nada a fazer", send_data["email"])
+            return {"status": "exists", "email": send_data["email"]}
+        logging.error("Falha na criação: HTTP %d", resposta.status_code)
+        logging.error("Resposta: %s", resposta.text[:500])
+        return False
+    except BaseException as errorMsg:
+        logging.error("Erro na chamada à Admin API do GoTrue")
+        logging.error("Exception occurred", exc_info=True)
+        logging.error(errorMsg)
+        return False
+
+
+def main() -> int:
+    """
+    Ponto de entrada: carrega segredos e cria o usuário.
+
+    :return: 0 em sucesso, 1 em erro.
+    :rtype: int
+    """
+    config_logging()
+    env = carregar_env(SECRETS_DIR / ".env")
+    if not env:
+        return 1
+    conta = carregar_conta(SECRETS_DIR / "create_account.json")
+    if not conta:
+        return 1
+    supabase_url = env.get("NEXT_PUBLIC_SUPABASE_URL", "")
+    service_role_key = env.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    if not supabase_url or not supabase_url.startswith("http"):
+        logging.error("NEXT_PUBLIC_SUPABASE_URL ausente/inválida no .secrets/.env")
+        return 1
+    if not service_role_key:
+        logging.error("SUPABASE_SERVICE_ROLE_KEY ausente no .secrets/.env")
+        return 1
+    logging.info(
+        "==> VAR: supabase_url TYPE: %s, CONTENT: %s", type(supabase_url), supabase_url
+    )
+    logging.info(
+        "==> VAR: service_role_key TYPE: %s, CONTENT: %s",
+        type(service_role_key), _mask(service_role_key),
+    )
+    send_data = {
+        "supabase_url": supabase_url,
+        "service_role_key": service_role_key,
+        "email": conta["email"],
+        "password": conta["password"],
+        "full_name": conta["full_name"],
+    }
+    resultado = criar_usuario(send_data)
+    if not resultado:
+        return 1
+    logging.info("Concluído com sucesso.")
+    logging.info("=== Termino programa: %s ===", Path(sys.argv[0]).name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_keys.py
+++ b/scripts/generate_keys.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+"""
+-------------------------------------------------------------------------
+NOME..: generate_keys.py
+LANG..: Python3
+TITULO: Gera todas as chaves/segredos do deploy em .secrets/.env
+DATA..: 10/07/2026 02:00
+MODIFICADO: 10/07/2026 11:35
+VERSÃO: 0.2.0
+HOST..: local
+LOCAL.: scripts/
+OBS...: Gera JWT_SECRET, POSTGRES_PASSWORD, ENCRYPTION_KEY,
+        REALTIME_SECRET_KEY_BASE, AUTOMATION_CRON_SECRET,
+        EVOLUTION_API_KEY e os JWTs anon/service_role do Supabase
+        self-hosted (HS256, derivados do JWT_SECRET). MESCLA com o
+        .secrets/.env existente: preserva todas as linhas/variáveis
+        atuais e só acrescenta as chaves que faltam. Use --rotate para
+        regerar também as já existentes. Sempre cria backup antes.
+
+DEPEND: somente stdlib (secrets, hmac, hashlib, base64, json)
+
+-------------------------------------------------------------------------
+Modifications.....:
+ Date          Rev    Author           Description
+ 10/07/2026    1      Claude/yves      Elaboração
+
+-------------------------------------------------------------------------
+STATUS: DEV
+"""
+
+import logging
+import sys
+from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from hmac import new as hmac_new
+from json import dumps
+from pathlib import Path
+from secrets import token_hex
+
+
+def config_logging() -> bool:
+    """
+    Configura o logging padrão do programa.
+
+    :return: True se configurado (ou já configurado).
+    :rtype: bool
+
+    :Example:
+
+    >>> config_logging()
+    True
+    """
+    logger = logging.getLogger()
+    if logger.hasHandlers():
+        return True
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(funcName)s:%(lineno)d - %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+    logging.info("=== Programa: %s ===", Path(sys.argv[0]).name)
+    return True
+
+
+def _b64url(data: bytes) -> str:
+    """
+    Codifica bytes em base64url sem padding (formato JWT).
+
+    :param data: Bytes a codificar.
+    :type data: bytes
+    :return: String base64url sem '='.
+    :rtype: str
+
+    :Example:
+
+    >>> _b64url(b"abc")
+    'YWJj'
+    """
+    return urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def gerar_jwt_supabase(role: str, jwt_secret: str) -> str | bool:
+    """
+    Gera um JWT HS256 no formato esperado pelo Supabase self-hosted.
+
+    :param role: Papel do token ("anon" ou "service_role").
+    :type role: str
+    :param jwt_secret: Segredo HMAC compartilhado (JWT_SECRET).
+    :type jwt_secret: str
+    :return: JWT assinado ou False em caso de erro.
+    :rtype: str | bool
+
+    :Example:
+
+    >>> token = gerar_jwt_supabase("anon", "x" * 40)
+    >>> token.count(".")
+    2
+    """
+    logging.info("=== Função: %s ===", sys._getframe().f_code.co_name)
+    if not role or not isinstance(role, str):
+        logging.error("Parâmetro 'role' inválido")
+        return False
+    if not jwt_secret or not isinstance(jwt_secret, str) or len(jwt_secret) < 32:
+        logging.error("Parâmetro 'jwt_secret' inválido (mínimo 32 chars)")
+        return False
+    try:
+        agora = datetime.now(timezone.utc)
+        header = {"alg": "HS256", "typ": "JWT"}
+        payload = {
+            "role": role,
+            "iss": "supabase",
+            "iat": int(agora.timestamp()),
+            "exp": int((agora + timedelta(days=3650)).timestamp()),
+        }
+        parte_header = _b64url(dumps(header, separators=(",", ":")).encode())
+        parte_payload = _b64url(dumps(payload, separators=(",", ":")).encode())
+        mensagem = f"{parte_header}.{parte_payload}".encode()
+        assinatura = hmac_new(jwt_secret.encode(), mensagem, sha256).digest()
+        logging.info("=== Termino Função: %s ===", sys._getframe().f_code.co_name)
+        return f"{parte_header}.{parte_payload}.{_b64url(assinatura)}"
+    except BaseException as errorMsg:
+        logging.error("Erro ao gerar JWT")
+        logging.error("Exception occurred", exc_info=True)
+        logging.error(errorMsg)
+        return False
+
+
+def gerar_chaves() -> dict | bool:
+    """
+    Gera o conjunto completo de segredos do deploy.
+
+    :return: Dicionário chave->valor ou False em caso de erro.
+    :rtype: dict | bool
+    """
+    logging.info("=== Função: %s ===", sys._getframe().f_code.co_name)
+    try:
+        jwt_secret = token_hex(32)
+        anon = gerar_jwt_supabase("anon", jwt_secret)
+        service = gerar_jwt_supabase("service_role", jwt_secret)
+        if not anon or not service:
+            logging.error("Falha ao derivar JWTs do Supabase")
+            return False
+        chaves = {
+            "JWT_SECRET": jwt_secret,
+            "NEXT_PUBLIC_SUPABASE_ANON_KEY": anon,
+            "SUPABASE_SERVICE_ROLE_KEY": service,
+            "POSTGRES_PASSWORD": token_hex(24),
+            "REALTIME_SECRET_KEY_BASE": token_hex(32),
+            "ENCRYPTION_KEY": token_hex(32),
+            "AUTOMATION_CRON_SECRET": token_hex(32),
+            "EVOLUTION_API_KEY": token_hex(32),
+        }
+        logging.info("=== Termino Função: %s ===", sys._getframe().f_code.co_name)
+        return chaves
+    except BaseException as errorMsg:
+        logging.error("Erro ao gerar chaves")
+        logging.error("Exception occurred", exc_info=True)
+        logging.error(errorMsg)
+        return False
+
+
+def gravar_env(chaves: dict, destino: Path, rotate: bool = False) -> bool:
+    """
+    MESCLA as chaves no arquivo dotenv existente, com backup prévio.
+
+    Preserva todas as linhas atuais (comentários, outras variáveis,
+    ordem). Variáveis já presentes são mantidas — só são substituídas
+    quando ``rotate=True``. Chaves novas são acrescentadas ao final.
+
+    :param chaves: Dicionário chave->valor a mesclar.
+    :type chaves: dict
+    :param destino: Caminho do arquivo .env de saída.
+    :type destino: Path
+    :param rotate: Se True, sobrescreve valores de chaves existentes.
+    :type rotate: bool
+    :return: True em sucesso, False em erro.
+    :rtype: bool
+    """
+    logging.info("=== Função: %s ===", sys._getframe().f_code.co_name)
+    if not chaves or not isinstance(chaves, dict):
+        logging.error("Parâmetro 'chaves' inválido")
+        return False
+    if not destino or not isinstance(destino, Path):
+        logging.error("Parâmetro 'destino' inválido")
+        return False
+    try:
+        destino.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        agora = datetime.now().strftime("%d/%m/%Y %H:%M")
+        linhas: list[str] = []
+        existentes: dict[str, int] = {}
+        if destino.exists():
+            stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            backup = destino.with_name(f".env.bak_{stamp}")
+            backup.write_text(destino.read_text(encoding="utf-8"), encoding="utf-8")
+            backup.chmod(0o600)
+            logging.info("Backup criado: %s", backup)
+            linhas = destino.read_text(encoding="utf-8").splitlines()
+            for indice, linha in enumerate(linhas):
+                if "=" in linha and not linha.lstrip().startswith("#"):
+                    existentes[linha.split("=", 1)[0].strip()] = indice
+        else:
+            linhas = [
+                f"# Criado em: {agora}",
+                "# Gerado por scripts/generate_keys.py — NUNCA versionar.",
+            ]
+        adicionadas, rotacionadas, preservadas = [], [], []
+        for nome, valor in chaves.items():
+            if nome in existentes:
+                if rotate:
+                    linhas[existentes[nome]] = f"{nome}={valor}"
+                    rotacionadas.append(nome)
+                else:
+                    preservadas.append(nome)
+            else:
+                adicionadas.append(f"{nome}={valor}")
+        if adicionadas:
+            linhas += ["", f"# Chaves geradas em {agora} (generate_keys.py)"]
+            linhas += adicionadas
+        # Atualiza (ou insere) o carimbo de modificação no cabeçalho.
+        for indice, linha in enumerate(linhas[:5]):
+            if linha.startswith("# Modificado em:"):
+                linhas[indice] = f"# Modificado em: {agora}"
+                break
+        else:
+            linhas.insert(1, f"# Modificado em: {agora}")
+        destino.write_text("\n".join(linhas) + "\n", encoding="utf-8")
+        destino.chmod(0o600)
+        logging.info(
+            "Arquivo gravado: %s (novas: %d, preservadas: %d, rotacionadas: %d)",
+            destino, len(adicionadas), len(preservadas), len(rotacionadas),
+        )
+        logging.info("=== Termino Função: %s ===", sys._getframe().f_code.co_name)
+        return True
+    except BaseException as errorMsg:
+        logging.error("Erro ao gravar o arquivo .env")
+        logging.error("Exception occurred", exc_info=True)
+        logging.error(errorMsg)
+        return False
+
+
+def main() -> int:
+    """
+    Ponto de entrada: gera as chaves e mescla em .secrets/.env.
+
+    Uso: python3 scripts/generate_keys.py [--rotate]
+    (--rotate regenera também as chaves já existentes no arquivo)
+
+    :return: 0 em sucesso, 1 em erro.
+    :rtype: int
+    """
+    config_logging()
+    rotate = "--rotate" in sys.argv[1:]
+    raiz = Path(__file__).resolve().parent.parent
+    destino = raiz / ".secrets" / ".env"
+    chaves = gerar_chaves()
+    if not chaves:
+        return 1
+    if not gravar_env(chaves, destino, rotate):
+        return 1
+    logging.info("Segredos gerados. Copie/mescle com deploy/.env conforme necessário.")
+    logging.info("=== Termino programa: %s ===", Path(sys.argv[0]).name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { createClient } from "@/lib/supabase/client";
+import { isSignupEnabled } from "@/lib/auth/signup-flag";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -143,19 +144,23 @@ function LoginPageInner() {
             </Button>
           </form>
 
-          <p className="mt-6 text-center text-sm text-muted-foreground">
-            {t('noAccount')}{" "}
-            <Link
-              href={
-                inviteToken
-                  ? `/signup?invite=${encodeURIComponent(inviteToken)}`
-                  : "/signup"
-              }
-              className="text-primary hover:text-primary/80"
-            >
-              {t('createAccount')}
-            </Link>
-          </p>
+          {/* Link de cadastro só com signup público habilitado; com
+              token de convite o fluxo /join continua disponível. */}
+          {(isSignupEnabled() || inviteToken) && (
+            <p className="mt-6 text-center text-sm text-muted-foreground">
+              {t('noAccount')}{" "}
+              <Link
+                href={
+                  inviteToken
+                    ? `/signup?invite=${encodeURIComponent(inviteToken)}`
+                    : "/signup"
+                }
+                className="text-primary hover:text-primary/80"
+              >
+                {t('createAccount')}
+              </Link>
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/lib/auth/signup-flag.ts
+++ b/src/lib/auth/signup-flag.ts
@@ -1,0 +1,21 @@
+// ============================================================
+// Flag de signup público — NEXT_PUBLIC_SIGNUP_ENABLED.
+//
+// Padrão: desabilitado. O deploy self-hosted também bloqueia no
+// backend via GOTRUE_DISABLE_SIGNUP (deploy/docker-compose.yml);
+// esta flag apenas controla a UI (página /signup e link "criar
+// conta" no /login). Mantenha as duas coerentes no .env.
+//
+// Em bundles client o valor é inlinado no build; no deploy Docker
+// a imagem é buildada com placeholder e o docker-entrypoint.sh o
+// substitui por "true"/"false" no start do container.
+// ============================================================
+
+/**
+ * Indica se o cadastro público (signup aberto) está habilitado.
+ *
+ * @returns `true` somente quando NEXT_PUBLIC_SIGNUP_ENABLED === "true".
+ */
+export function isSignupEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_SIGNUP_ENABLED === "true";
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -69,6 +69,21 @@ export async function middleware(request: NextRequest) {
     return withRefreshedCookies(NextResponse.redirect(url))
   }
 
+  // Signup público desabilitado (NEXT_PUBLIC_SIGNUP_ENABLED !== 'true'):
+  // /signup redireciona para /login. Exceção: com token de convite na
+  // query o fluxo /join continua usando a página de signup.
+  if (
+    !user &&
+    request.nextUrl.pathname === '/signup' &&
+    process.env.NEXT_PUBLIC_SIGNUP_ENABLED !== 'true' &&
+    !request.nextUrl.searchParams.get('invite')
+  ) {
+    const url = request.nextUrl.clone()
+    url.pathname = '/login'
+    url.search = ''
+    return withRefreshedCookies(NextResponse.redirect(url))
+  }
+
   // Protected pages - redirect to login if not authenticated
   const protectedPaths = ['/dashboard', '/inbox', '/contacts', '/pipelines', '/broadcasts', '/automations', '/settings']
   if (!user && protectedPaths.some(path => request.nextUrl.pathname.startsWith(path))) {


### PR DESCRIPTION
## O quê

- **Admin padrão no boot**: serviço one-shot `admin-bootstrap` no compose executa `deploy/scripts/bootstrap-admin.sh`, que cria o usuário via Admin API do GoTrue (rede interna, ignora bloqueio de signup). Idempotente (422 = já existe); desativado se `ADMIN_EMAIL`/`ADMIN_PASSWORD` vazios. O trigger `handle_new_user` cria profile + conta + role `owner`.
- **SMTP no-reply (somente envio)**: `GOTRUE_SMTP_*` alimentado por `SMTP_*` do `.env`; `GOTRUE_MAILER_AUTOCONFIRM` configurável (padrão `true` enquanto não houver SMTP).
- **Flag de signup público**: `DISABLE_SIGNUP` (GoTrue, padrão `true`) + `NEXT_PUBLIC_SIGNUP_ENABLED` (UI, padrão `false`) — middleware redireciona `/signup` → `/login` (exceto `?invite=`), link "criar conta" oculto; placeholder novo no Dockerfile/entrypoint.

## Por quê

Provisionamento automatizado do stack self-hosted: admin criado no primeiro `up`, e-mails transacionais reais via conta no-reply e controle explícito (por env) da auto-criação de usuários.

## Atenção

- A imagem do app precisa ser regerada (`deploy/scripts/build-push.sh`) para o novo placeholder `NEXT_PUBLIC_SIGNUP_ENABLED`.

## Verificação

- `docker compose --env-file env.example config` OK; `sh -n` nos scripts OK.
- `tsc --noEmit` limpo; lint sem erros novos (26 pré-existentes na main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)