### PR TITLE
feat: add Colombian Peso (COP) currency option

### DIFF
--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -42,6 +42,7 @@ export const CURRENCIES: CurrencyOption[] = [
   { code: "NGN", label: "Nigerian Naira", symbol: "₦" },
   { code: "SGD", label: "Singapore Dollar", symbol: "S$" },
   { code: "MXN", label: "Mexican Peso", symbol: "$" },
+  { code: "COP", label: "Colombian Peso", symbol: "$" },
 ];
 
 /**


### PR DESCRIPTION
## Summary

   Adds Colombian Peso (COP) to the supported currencies list in `src/lib/currency.ts`, so accounts targeting Latam markets can configure their default currency without overriding the picker.

   ## What changed

   - `src/lib/currency.ts` — appends `{ code: "COP", label: "Colombian Peso", symbol: "$" }` to `CURRENCIES`. No other files touched. `formatCurrency` already routes through `Intl.NumberFormat`, so the symbol
 and grouping are picked up automatically from the ISO-4217 code; the explicit `symbol` field is only used by `formatCurrencyShort` (donut/legend).

   ## Why this might belong upstream despite CONTRIBUTING.md

   `CONTRIBUTING.md` steers "new features" to forks, and a new currency arguably falls there — happy to move it to my fork if the maintainer prefers. The case for considering it upstream:

   - It's a one-line data addition, not a feature in the UX sense: no new component, no new screen, no new setting. Just a row in an existing picker.
   - `CURRENCIES` already carries several regional options (INR, JPY, BRL, MXN). COP is the same shape and the same gap to fill.
   - Latam is the obvious primary audience for a WhatsApp-first CRM and the upstream copy leans Spanish-first (`messages/es-CO.json` is shipped).

   If the answer is still "belongs in a fork," that's a clean close and I get it.

   ## Test plan

   - [ ] `npm run typecheck` clean.
   - [ ] `npm run lint` — no new errors.
   - [ ] `npm run build` succeeds.
   - [ ] Manual: open an account settings → currency picker → confirm COP appears and renders as `$1.234,56` (es-CO locale) or `COP 1,234.56` (en locale) for a sample deal.

   ## Related

   None — opening as a probe to test alignment before investing more in this direction.