### PR TITLE
fix(i18n): add missing contact tags tab label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -358,6 +358,7 @@
         "notes": "Notes",
         "custom": "Custom Fields",
         "deals": "Deals",
+        "tags": "Tags",
       "noTags": "No tags",
       "noDeals": "No deals",
       "addNotePlaceholder": "Add a note..."


### PR DESCRIPTION
## Summary
- add the missing `Contacts.detailView.tabs.tags` English translation
- prevent the contact detail tab from rendering the raw translation key

## Validation
- `jq empty messages/en.json`
- `git diff --check`