### PR TITLE
fix: use timing-safe compare for cron secret

### DIFF
--- a/src/app/api/automations/cron/route.ts
+++ b/src/app/api/automations/cron/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/automations/admin-client'
 import { resumePendingExecution } from '@/lib/automations/engine'
@@ -19,8 +20,13 @@ export async function GET(request: Request) {
   if (!expected) {
     return NextResponse.json({ error: 'cron not configured' }, { status: 503 })
   }
-  const supplied = request.headers.get('x-cron-secret')
-  if (supplied !== expected) {
+  const supplied = request.headers.get('x-cron-secret') ?? ''
+  const suppliedBuf = Buffer.from(supplied)
+  const expectedBuf = Buffer.from(expected)
+  if (
+    suppliedBuf.length !== expectedBuf.length ||
+    !timingSafeEqual(suppliedBuf, expectedBuf)
+  ) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 


### PR DESCRIPTION
## Summary

Use timing-safe string comparison for cron secret validation to prevent timing attacks.

## What changed

**File**: `src/app/api/automations/cron/route.ts`

- Import `timingSafeEqual` from `node:crypto`
- Replace simple string equality with constant-time comparison
- Match the pattern already used in flows cron endpoint

## Why

Simple string comparison leaks timing information — an attacker with network access could measure response latency and recover `AUTOMATION_CRON_SECRET` byte-by-byte.

## Test plan

- [x] typecheck + lint clean
- [x] Pattern matches flows cron implementation