### PR TITLE
fix: full-page navigation after login so the session is applied (#365)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -65,6 +65,34 @@ const SECURITY_HEADERS = [
 
 const nextConfig: NextConfig = {
   /**
+   * Cross-origin dev access (Next.js 16).
+   *
+   * Next 16 blocks requests to dev-only resources (`/_next/*` internals,
+   * the HMR websocket, the dev overlay) unless the browser's Origin is
+   * the host the dev server booted on — `localhost` by default. Tunnels
+   * like ngrok serve the app from a public HTTPS host, so without
+   * allow-listing that host those dev requests come back 403: HMR stops
+   * working and the dev session degrades over the tunnel (issue #365).
+   *
+   * Wildcards match subdomains only (Next's CSRF matcher), so the
+   * randomised tunnel subdomain is covered. Add any other host via
+   * `ALLOWED_DEV_ORIGINS` (comma-separated). This key is dev-only and
+   * has no effect on a production build.
+   */
+  allowedDevOrigins: [
+    "*.ngrok-free.app",
+    "*.ngrok.app",
+    "*.ngrok.io",
+    "*.trycloudflare.com",
+    "*.loca.lt",
+    ...(process.env.ALLOWED_DEV_ORIGINS
+      ? process.env.ALLOWED_DEV_ORIGINS.split(",")
+          .map((origin) => origin.trim())
+          .filter(Boolean)
+      : []),
+  ],
+
+  /**
    * Cache-Control policy.
    *
    * Why this exists:

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { createClient } from "@/lib/supabase/client";
@@ -42,7 +42,6 @@ function LoginPageInner() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
   const supabase = createClient();
 
   const handleLogin = async (e: React.FormEvent) => {
@@ -61,11 +60,18 @@ function LoginPageInner() {
       return;
     }
 
-    if (inviteToken) {
-      router.push(`/join/${encodeURIComponent(inviteToken)}`);
-    } else {
-      router.push("/dashboard");
-    }
+    // Full-page navigation (not router.push) so the browser issues a
+    // fresh top-level request that carries the just-written Supabase
+    // auth cookies to the middleware gating /dashboard. A soft
+    // client-side navigation can reach the protected route before the
+    // server observes the new session, so the middleware bounces it
+    // back to /login — which looks like the page "just refreshing"
+    // instead of signing in (issue #365). Mirrors the deliberate full
+    // reload the invite-accept flow already uses in join/[token].
+    const destination = inviteToken
+      ? `/join/${encodeURIComponent(inviteToken)}`
+      : "/dashboard";
+    window.location.href = destination;
   };
 
   return (


### PR DESCRIPTION
## Summary

Over an ngrok tunnel, clicking **Sign in** just refreshed the login page instead of logging in — it worked fine on localhost.

## Root cause

The login page signs in client-side, then does a **soft** navigation into a middleware-gated route:

```tsx
await supabase.auth.signInWithPassword({ email, password });
router.push("/dashboard");
```

`/dashboard` is protected by `src/middleware.ts`, which redirects to `/login` unless `supabase.auth.getUser()` sees the session. A soft `router.push` can reach the protected route before the server-side layer reliably observes the just-written auth cookies, so the middleware bounces `/dashboard → /login` — and the page appears to "just refresh."

The repo already knows this pattern: the invite-accept flow in `src/app/join/[token]/page.tsx` deliberately uses a full reload (*"not router.push, so AuthProvider re-fetches"*). Login was the lone outlier still using the fragile soft navigation.

**Why ngrok and not localhost:** environmental. HTTPS + proxy latency widen the timing window, and on **Next.js 16** cross-origin dev resources (HMR, the dev overlay) are blocked by default unless the tunnel host is allow-listed.

## Changes

- **`src/app/(auth)/login/page.tsx`** — navigate with `window.location.href` after `signInWithPassword`, mirroring the join flow so the next top-level request carries the fresh cookies to the middleware (removes the now-unused `useRouter`).
- **`next.config.ts`** — add `allowedDevOrigins` for common dev tunnels (ngrok / cloudflared / localtunnel), extendable via `ALLOWED_DEV_ORIGINS`, so Next 16 stops returning 403 for dev-only resources over the tunnel.

## Testing

- `tsc --noEmit` ✅
- `eslint` (changed files) ✅
- `vitest run src/middleware.test.ts` ✅ (4/4)

A full login-over-ngrok reproduction needs a live Supabase project + an active tunnel, which isn't available in the dev sandbox; the fix rests on the middleware logic, the passing checks, and consistency with the repo's existing full-reload convention.

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
