### PR TITLE
fix(settings): wrap useSearchParams pages in Suspense so navigation works in prod

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1501,6 +1501,7 @@
       "appearance": "Appearance",
       "whatsapp": "WhatsApp",
       "templates": "Templates",
+      "quick-replies": "Quick replies",
       "fields": "Fields & tags",
       "deals": "Deals & currency",
       "members": "Team members",

--- a/src/app/(dashboard)/automations/new/page.tsx
+++ b/src/app/(dashboard)/automations/new/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo } from "react"
+import { Suspense, useMemo } from "react"
 import { useSearchParams } from "next/navigation"
 
 import {
@@ -11,7 +11,18 @@ import {
 import { AUTOMATION_TEMPLATES, type TemplateSlug } from "@/lib/automations/templates"
 import type { AutomationStepType, AutomationTriggerType } from "@/types"
 
+// `useSearchParams` requires a Suspense boundary or the production build
+// bails to CSR and errors out. Thin wrapper supplies it; the inner
+// component reads the `?template=` query string.
 export default function NewAutomationPage() {
+  return (
+    <Suspense fallback={null}>
+      <NewAutomationPageInner />
+    </Suspense>
+  )
+}
+
+function NewAutomationPageInner() {
   const params = useSearchParams()
   const template = params.get("template") as TemplateSlug | null
 

--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { Suspense, useState, useCallback, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { createClient } from "@/lib/supabase/client";
@@ -21,7 +21,18 @@ import { cn } from "@/lib/utils";
 // across reloads and sessions (device-scoped, like the theme prefs).
 const CONTACT_PANEL_STORAGE_KEY = "wacrm:inbox:contact-panel-open";
 
+// `useSearchParams` (the `?c=<id>` deep link below) requires a Suspense
+// boundary or the production build bails to CSR and errors out. Thin
+// wrapper supplies it; the inner component holds all the inbox state.
 export default function InboxPage() {
+  return (
+    <Suspense fallback={null}>
+      <InboxPageInner />
+    </Suspense>
+  );
+}
+
+function InboxPageInner() {
   const t = useTranslations("Inbox.page");
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, type ReactNode } from 'react';
+import { Suspense, useMemo, type ReactNode } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
@@ -23,7 +23,23 @@ import {
   type SettingsSection,
 } from '@/components/settings/settings-sections';
 
+// `useSearchParams` opts this page out of static prerendering unless it
+// sits under a Suspense boundary. Without one, the production build hits
+// the "missing Suspense with CSR bailout" error and the whole page bails
+// to client-side rendering — shipping a settings screen whose rail never
+// wires up its click handlers. You land on the section the URL carried
+// (the account-menu Settings link points at `?tab=whatsapp`) and can't
+// navigate away. Mirror the login/signup split: a thin wrapper supplies
+// the boundary; the inner component reads the query string.
 export default function SettingsPage() {
+  return (
+    <Suspense fallback={null}>
+      <SettingsPageInner />
+    </Suspense>
+  );
+}
+
+function SettingsPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { defaultCurrency } = useAuth();


### PR DESCRIPTION
## What & why

Opening **Settings → WhatsApp** (e.g. via the account menu, which links to `/settings?tab=whatsapp`) left the page **locked on the WhatsApp panel** — clicking any other rail section did nothing.

### Root cause
The settings page derives its active panel from `useSearchParams()` but wasn't wrapped in a `<Suspense>` boundary. In Next 16 that:

- **fails the production build** with `useSearchParams() should be wrapped in a suspense boundary … missing-suspense-with-csr-bailout`, and
- forces the page to **bail to full client-side rendering**, shipping a settings screen whose rail click handlers never wire up.

Since the entry link targets `?tab=whatsapp`, you land on WhatsApp and can't leave. `next dev` renders on-demand and papers over this, so it only shows up in a production build/deploy.

`login`/`signup` already wrap `useSearchParams` in `<Suspense>`; `settings`, `inbox`, and `automations/new` did not — so all three broke the build.

## Changes
- Wrap the `useSearchParams` consumer in `<Suspense>` on **settings**, **inbox**, and **automations/new** (thin wrapper + `*Inner` component, matching login/signup).
- Add the missing `Settings.sections.quick-replies` translation key (the rail was rendering the raw key `Settings.sections.quick-replies`).

## Verification
- **Before:** `next build` errors out during static generation on these pages.
- **After:** `next build` succeeds (`✓ Generating static pages 51/51`); ran the production server and confirmed every settings rail section navigates to its correct panel, and the rail shows "Quick replies".

## Follow-up (not in this PR)
The WhatsApp panel's setup-instruction strings (`Settings.whatsapp.step3_2` … `step4_4`) embed `<strong class="…">` inside `dangerouslySetInnerHTML={{ __html: t(...) }}`, which next-intl can't parse (`INVALID_TAG`) — cosmetic, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)