### PR TITLE
feat: reconcile AI inbox agent with current main

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -63,6 +63,22 @@ const SECURITY_HEADERS = [
   },
 ] as const;
 
+export const PRIVATE_PAGE_CACHE_CONTROL =
+  "private, no-cache, no-store, max-age=0, must-revalidate";
+
+const PROTECTED_PAGE_PREFIXES = [
+  "/agents",
+  "/dashboard",
+  "/inbox",
+  "/contacts",
+  "/pipelines",
+  "/broadcasts",
+  "/automations",
+  "/flows",
+  "/notifications",
+  "/settings",
+] as const;
+
 const nextConfig: NextConfig = {
   /**
    * Cross-origin dev access (Next.js 16).
@@ -135,8 +151,23 @@ const nextConfig: NextConfig = {
         source: "/api/:path*",
         headers: [{ key: "Cache-Control", value: "no-store" }],
       },
+      ...PROTECTED_PAGE_PREFIXES.flatMap((prefix) => [
+        {
+          source: prefix,
+          headers: [
+            { key: "Cache-Control", value: PRIVATE_PAGE_CACHE_CONTROL },
+          ],
+        },
+        {
+          source: `${prefix}/:path*`,
+          headers: [
+            { key: "Cache-Control", value: PRIVATE_PAGE_CACHE_CONTROL },
+          ],
+        },
+      ]),
       {
-        source: "/:path((?!_next/static|_next/image|api).*)",
+        source:
+          "/:path((?!_next/static|_next/image|api|agents|dashboard|inbox|contacts|pipelines|broadcasts|automations|flows|notifications|settings).*)",
         headers: [
           {
             key: "Cache-Control",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "zapi:check": "node scripts/zapi-readiness-check.mjs",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",

--- a/scripts/zapi-readiness-check.mjs
+++ b/scripts/zapi-readiness-check.mjs
@@ -1,0 +1,504 @@
+/**
+ * Z-API connection and readiness check for wacrm.
+ *
+ * Checks:
+ * - Required environment variables + value quality
+ * - NEXT_PUBLIC_SITE_URL is suitable for provider webhooks
+ * - Optional Z-API /me reachability when smoke-check credentials are set
+ * - Optional remote migration presence via supabase migration list
+ *
+ * Usage:
+ *   node scripts/zapi-readiness-check.mjs
+ * Optional:
+ *   SUPABASE_DB_URL=<postgres://...> node scripts/zapi-readiness-check.mjs
+ */
+
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { createClient } from '@supabase/supabase-js';
+
+const REQUIRED = {
+  NEXT_PUBLIC_SUPABASE_URL: {
+    label: 'NEXT_PUBLIC_SUPABASE_URL',
+    validate: (value) => value.startsWith('https://') && value.includes('.supabase.co'),
+  },
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: {
+    label: 'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    validate: (value) => value.includes('.') && value.split('.').length >= 3,
+  },
+  SUPABASE_SERVICE_ROLE_KEY: {
+    label: 'SUPABASE_SERVICE_ROLE_KEY',
+    validate: (value) => {
+      const forbidden = ['COLE_SUA_SERVICE_ROLE_KEY_AQUI', 'your-service-role-key'];
+      if (!value.length || forbidden.includes(value)) return false;
+      const parts = value.split('.');
+      return parts.length >= 3 && parts.every((part) => part.length > 0);
+    },
+  },
+  ENCRYPTION_KEY: {
+    label: 'ENCRYPTION_KEY',
+    validate: (value) => /^[0-9a-fA-F]{64}$/.test(value),
+  },
+};
+
+function loadEnvFile(path) {
+  if (!fs.existsSync(path)) return {};
+  const text = fs.readFileSync(path, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const env = {};
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    env[key] = value;
+  }
+  return env;
+}
+
+function normalize(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function maskValue(value) {
+  if (!value) return '';
+  if (value.length <= 12) return '***';
+  return `${value.slice(0, 3)}...${value.slice(-3)}`;
+}
+
+function decryptSecret(encryptedText, keyHex) {
+  const parts = encryptedText.split(':');
+  const key = Buffer.from(keyHex, 'hex');
+
+  if (parts.length === 3) {
+    const [ivHex, ctHex, tagHex] = parts;
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(tagHex, 'hex');
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    let decrypted = decipher.update(ctHex, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+  }
+
+  if (parts.length === 2) {
+    const [ivHex, ctHex] = parts;
+    const iv = Buffer.from(ivHex, 'hex');
+    const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+    let decrypted = decipher.update(ctHex, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+  }
+
+  throw new Error(`unrecognised encrypted secret format (${parts.length - 1} colons)`);
+}
+
+function checkSiteUrl(value) {
+  if (!value) {
+    return {
+      ok: false,
+      status: 'fail',
+      message: 'missing; Z-API requires a public HTTPS webhook URL in production',
+      value: '',
+    };
+  }
+  try {
+    const url = new URL(value);
+    const localhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+    const ok = url.protocol === 'https:' || localhost;
+    return {
+      ok,
+      status: ok ? (localhost ? 'warn' : 'ok') : 'fail',
+      message: ok
+        ? localhost
+          ? 'local URL is valid only for local testing'
+          : 'valid HTTPS origin'
+        : 'must be HTTPS unless using localhost',
+      value: `${url.protocol}//${url.host}`,
+    };
+  } catch {
+    return {
+      ok: false,
+      status: 'fail',
+      message: 'invalid URL',
+      value,
+    };
+  }
+}
+
+async function checkZapiMe({ instanceId, instanceToken, clientToken }) {
+  const url = `https://api.z-api.io/instances/${encodeURIComponent(instanceId)}/token/${encodeURIComponent(instanceToken)}/me`;
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Client-Token': clientToken,
+        'Content-Type': 'application/json',
+      },
+    });
+    const text = await response.text().catch(() => '');
+    let data = null;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = null;
+    }
+    const connected = data?.connected === true;
+    return {
+      checked: true,
+      ok: response.ok,
+      connected,
+      status: response.ok ? 'ok' : 'fail',
+      value: `${response.status}`,
+      message: response.ok
+        ? connected
+          ? 'Z-API /me reachable and instance is connected'
+          : 'Z-API /me reachable, but the instance is not connected yet'
+        : `Z-API /me returned ${response.status}: ${text.slice(0, 120)}`,
+    };
+  } catch (error) {
+    return {
+      checked: true,
+      ok: false,
+      connected: false,
+      status: 'fail',
+      value: '0',
+      message: `Z-API request failed: ${error instanceof Error ? error.message : 'unknown error'}`,
+    };
+  }
+}
+
+async function checkZapiReachability(env) {
+  const instanceId = normalize(env.ZAPI_INSTANCE_ID);
+  const instanceToken = normalize(env.ZAPI_INSTANCE_TOKEN);
+  const clientToken = normalize(env.ZAPI_CLIENT_TOKEN);
+  if (!instanceId || !instanceToken || !clientToken) {
+    return {
+      checked: false,
+      ok: true,
+      connected: false,
+      status: 'warn',
+      value: '',
+      message:
+        'smoke credentials not set; normal credentials are stored per account in the database',
+    };
+  }
+
+  return checkZapiMe({ instanceId, instanceToken, clientToken });
+}
+
+function runSupabaseMigrationCheck(dbUrl) {
+  const run = dbUrl
+    ? spawnSync('npx', ['supabase', 'migration', 'list', '--db-url', dbUrl], {
+        encoding: 'utf8',
+        timeout: 120000,
+      })
+    : spawnSync('npx', ['supabase', 'migration', 'list', '--linked'], {
+        encoding: 'utf8',
+        timeout: 120000,
+      });
+
+  if (run.status !== 0) {
+    return {
+      checked: false,
+      ok: false,
+      message:
+        'Migration proof is unavailable. Set SUPABASE_DB_URL and rerun `zapi:check`, or `supabase link` first.',
+    };
+  }
+
+  const stdout = `${run.stdout || ''}`;
+  const has030 = /030_whatsapp_webhook_replay_guard\.sql/.test(stdout);
+  const has031 = /031_zapi_migration\.sql/.test(stdout);
+  const has037 = /037_ai_inbox_agent\.sql/.test(stdout);
+  const has038 = /038_ai_agent_run_idempotency\.sql/.test(stdout);
+  const has039 = /039_ai_agent_user_owner_fallback\.sql/.test(stdout);
+  const ok = has030 && has031 && has037 && has038 && has039;
+
+  return {
+    checked: true,
+    ok,
+    versionsFound: stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean),
+    message:
+      ok
+        ? 'Found migration versions 030, 031, 037, 038, and 039 in remote migration history.'
+        : 'Missing one or more required migration versions 030, 031, 037, 038, or 039 in output.',
+  };
+}
+
+function checkLocalAiMigrations() {
+  const required = [
+    'supabase/migrations/037_ai_inbox_agent.sql',
+    'supabase/migrations/038_ai_agent_run_idempotency.sql',
+    'supabase/migrations/039_ai_agent_user_owner_fallback.sql',
+  ];
+  const missing = required.filter((path) => !fs.existsSync(path));
+  return {
+    ok: missing.length === 0,
+    missing,
+    message: missing.length === 0
+      ? 'AI migration files 037, 038, and 039 are present locally.'
+      : `missing local AI migration file(s): ${missing.join(', ')}`,
+  };
+}
+
+function checkOpenAiProvider(value) {
+  const normalized = normalize(value);
+  const ok = normalized.startsWith('sk-') && normalized.length > 20;
+  return {
+    ok,
+    status: ok ? 'ok' : 'fail',
+    value: ok ? 'openai' : '',
+    message: ok
+      ? 'OpenAI Responses API provider key is present'
+      : 'missing or invalid OPENAI_API_KEY; AI inbox agent cannot run in production',
+  };
+}
+
+async function checkSavedZapiConfig(env, targetAccountId) {
+  const checks = [];
+
+  const supabaseUrl = normalize(env.NEXT_PUBLIC_SUPABASE_URL);
+  const serviceRoleKey = normalize(env.SUPABASE_SERVICE_ROLE_KEY);
+  const encryptionKey = normalize(env.ENCRYPTION_KEY);
+  if (!supabaseUrl || !serviceRoleKey || !/^[0-9a-fA-F]{64}$/.test(encryptionKey)) {
+    return {
+      ok: false,
+      checks: [
+        {
+          item: 'db.whatsapp_config',
+          status: 'fail',
+          value: '',
+          message: 'cannot inspect saved Z-API config until Supabase env and ENCRYPTION_KEY are valid',
+        },
+      ],
+    };
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  let query = supabase
+    .from('whatsapp_config')
+    .select(
+      'id, account_id, zapi_instance_id, zapi_instance_token, zapi_client_token, zapi_webhook_secret, zapi_connected_phone, connection_status, status'
+    )
+    .order('updated_at', { ascending: false });
+  if (targetAccountId) query = query.eq('account_id', targetAccountId);
+
+  const { data, error } = await query;
+
+  if (error) {
+    return {
+      ok: false,
+      checks: [
+        {
+          item: 'db.whatsapp_config_schema',
+          status: 'fail',
+          value: error.code || '',
+          message: `cannot select Z-API columns from whatsapp_config: ${error.message}`,
+        },
+      ],
+    };
+  }
+
+  checks.push({
+    item: 'db.whatsapp_config_schema',
+    status: 'ok',
+    value: `${data.length} row(s)`,
+    message: targetAccountId
+      ? 'Z-API columns are present on whatsapp_config for the target account'
+      : 'Z-API columns are present on whatsapp_config',
+  });
+
+  const completeRows = data.filter(
+    (row) =>
+      row.zapi_instance_id &&
+      row.zapi_instance_token &&
+      row.zapi_client_token &&
+      row.zapi_webhook_secret
+  );
+
+  if (!completeRows.length) {
+    checks.push({
+      item: 'db.whatsapp_config_rows',
+      status: 'fail',
+      value: `${data.length} row(s)`,
+      message: targetAccountId
+        ? 'target account has no zapi_instance_id, encrypted instance token, Client-Token, and webhook secret'
+        : 'no account has zapi_instance_id, encrypted instance token, Client-Token, and webhook secret',
+    });
+    return { ok: false, checks };
+  }
+
+  checks.push({
+    item: 'db.whatsapp_config_rows',
+    status: 'ok',
+    value: `${completeRows.length} configured`,
+    message: targetAccountId
+      ? 'target account has encrypted Z-API credentials and webhook secret'
+      : 'at least one account has encrypted Z-API credentials and webhook secret',
+  });
+
+  let lastMessage = 'no configured row could be validated against Z-API /me';
+  for (const row of completeRows) {
+    try {
+      const zapiCheck = await checkZapiMe({
+        instanceId: row.zapi_instance_id,
+        instanceToken: decryptSecret(row.zapi_instance_token, encryptionKey),
+        clientToken: decryptSecret(row.zapi_client_token, encryptionKey),
+      });
+      lastMessage = zapiCheck.message;
+      if (zapiCheck.ok && zapiCheck.connected) {
+        checks.push({
+          item: 'db.zapi.me',
+          status: 'ok',
+          value: maskValue(row.zapi_instance_id),
+          message: 'saved Z-API credentials validate and the instance is connected',
+        });
+        return { ok: true, checks };
+      }
+    } catch (error) {
+      lastMessage =
+        error instanceof Error ? `failed to decrypt or validate saved Z-API credentials: ${error.message}` : lastMessage;
+    }
+  }
+
+  checks.push({
+    item: 'db.zapi.me',
+    status: 'fail',
+    value: '',
+    message: lastMessage,
+  });
+  return { ok: false, checks };
+}
+
+(async function main() {
+  const envFromFile = loadEnvFile('.env.local');
+  const env = { ...envFromFile, ...process.env };
+  const checks = [];
+  let allOk = true;
+
+  console.log('wacrm + Z-API readiness check');
+  console.log('-----------------------------');
+
+  for (const [key, cfg] of Object.entries(REQUIRED)) {
+    const value = normalize(env[key]);
+    const valid = value && cfg.validate(value);
+    checks.push({
+      item: `env.${key}`,
+      status: valid ? 'ok' : 'fail',
+      value: maskValue(value),
+      message: valid ? 'valid' : `invalid or missing (${cfg.label})`,
+    });
+    if (!valid) allOk = false;
+  }
+
+  const siteUrl = checkSiteUrl(normalize(env.NEXT_PUBLIC_SITE_URL));
+  checks.push({
+    item: 'env.NEXT_PUBLIC_SITE_URL',
+    status: siteUrl.status,
+    value: siteUrl.value,
+    message: siteUrl.message,
+  });
+  if (!siteUrl.ok) allOk = false;
+
+  const cronSecret = normalize(env.AUTOMATION_CRON_SECRET);
+  checks.push({
+    item: 'env.AUTOMATION_CRON_SECRET',
+    status: cronSecret ? 'ok' : 'fail',
+    value: cronSecret ? maskValue(cronSecret) : '',
+    message: cronSecret ? 'present' : 'missing; cron smoke tests will fail',
+  });
+  if (!cronSecret) allOk = false;
+
+  const openAiProvider = checkOpenAiProvider(env.OPENAI_API_KEY);
+  checks.push({
+    item: 'ai.provider',
+    status: openAiProvider.status,
+    value: openAiProvider.value,
+    message: openAiProvider.message,
+  });
+  if (!openAiProvider.ok) allOk = false;
+
+  const targetAccountId = normalize(env.WACRM_TARGET_ACCOUNT_ID);
+  checks.push({
+    item: 'env.WACRM_TARGET_ACCOUNT_ID',
+    status: targetAccountId ? 'ok' : 'fail',
+    value: targetAccountId ? maskValue(targetAccountId) : '',
+    message: targetAccountId
+      ? 'target account selected for saved Z-API readiness checks'
+      : 'missing; readiness must validate the target production account, not any account',
+  });
+  if (!targetAccountId) allOk = false;
+
+  const zapiCheck = await checkZapiReachability(env);
+  checks.push({
+    item: 'zapi.me',
+    status: zapiCheck.status,
+    value: zapiCheck.value,
+    message: zapiCheck.message,
+  });
+  if (!zapiCheck.ok) allOk = false;
+
+  const migrationCheck = runSupabaseMigrationCheck(normalize(env.SUPABASE_DB_URL));
+  checks.push({
+    item: 'db.migrations',
+    status: migrationCheck.ok ? 'ok' : migrationCheck.checked ? 'fail' : 'warn',
+    value: migrationCheck.versionsFound ? `${migrationCheck.versionsFound.length} entries` : '',
+    message: migrationCheck.message,
+  });
+  if (!migrationCheck.ok) allOk = false;
+
+  const localAiMigrations = checkLocalAiMigrations();
+  checks.push({
+    item: 'local.ai_migrations',
+    status: localAiMigrations.ok ? 'ok' : 'fail',
+    value: localAiMigrations.ok ? '032,033,034' : '',
+    message: localAiMigrations.message,
+  });
+  if (!localAiMigrations.ok) allOk = false;
+
+  const savedConfigCheck = await checkSavedZapiConfig(env, targetAccountId);
+  checks.push(...savedConfigCheck.checks);
+  if (!savedConfigCheck.ok) allOk = false;
+
+  console.log('');
+  for (const check of checks) {
+    const line = [
+      check.item.padEnd(30),
+      check.status.padEnd(5).toUpperCase(),
+      check.value ? `[${check.value}]` : '[ ]',
+      `- ${check.message}`,
+    ].join(' ');
+    console.log(line);
+  }
+
+  if (migrationCheck.checked) {
+    console.log('');
+    console.log('Migration versions returned by Supabase CLI:');
+    if (migrationCheck.versionsFound?.length) {
+      for (const item of migrationCheck.versionsFound) {
+        console.log(`- ${item}`);
+      }
+    } else {
+      console.log('- (none found)');
+    }
+  }
+
+  console.log('');
+  if (allOk) {
+    console.log('Result: READY');
+    process.exitCode = 0;
+  } else {
+    console.log('Result: BLOCKED');
+    process.exitCode = 1;
+  }
+})();

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -12,6 +12,7 @@ import { ProfileForm } from '@/components/settings/profile-form';
 import { SecurityPanel } from '@/components/settings/security-panel';
 import { AppearancePanel } from '@/components/settings/appearance-panel';
 import { WhatsAppConfig } from '@/components/settings/whatsapp-config';
+import { AiAgentSettings } from '@/components/settings/ai-agent-settings';
 import { TemplateManager } from '@/components/settings/template-manager';
 import { QuickRepliesManager } from '@/components/settings/quick-replies-manager';
 import { FieldsAndTagsPanel } from '@/components/settings/fields-and-tags-panel';
@@ -75,6 +76,7 @@ function SettingsPageInner() {
     security: <SecurityPanel />,
     appearance: <AppearancePanel />,
     whatsapp: <WhatsAppConfig />,
+    'ai-agent': <AiAgentSettings />,
     templates: <TemplateManager />,
     'quick-replies': <QuickRepliesManager />,
     fields: <FieldsAndTagsPanel />,

--- a/src/app/api/ai-agent/config/route.test.ts
+++ b/src/app/api/ai-agent/config/route.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  config: null as Record<string, unknown> | null,
+  selectError: null as { message: string } | null,
+  upsertError: null as { message: string } | null,
+  upsertPayload: null as Record<string, unknown> | null,
+  filters: [] as Array<[string, unknown]>,
+}));
+
+const getCurrentAccount = vi.hoisted(() => vi.fn());
+const requireRole = vi.hoisted(() => vi.fn());
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json(payload: unknown, init?: ResponseInit) {
+      return new Response(JSON.stringify(payload), {
+        status: init?.status ?? 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  },
+}));
+
+vi.mock('@/lib/auth/account', () => ({
+  getCurrentAccount,
+  requireRole,
+  toErrorResponse(error: unknown) {
+    const status =
+      error instanceof Error && error.message === 'Forbidden' ? 403 : 500;
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Internal server error',
+      }),
+      {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  },
+}));
+
+import { GET, PATCH } from './route';
+
+const accountId = 'account-1';
+const userId = 'user-1';
+
+beforeEach(() => {
+  requireRole.mockClear();
+  h.config = null;
+  h.selectError = null;
+  h.upsertError = null;
+  h.upsertPayload = null;
+  h.filters = [];
+
+  const supabase = {
+    from: vi.fn(() => {
+      const query = {
+        select: vi.fn(() => query),
+        eq: vi.fn((column: string, value: unknown) => {
+          h.filters.push([column, value]);
+          return query;
+        }),
+        maybeSingle: vi.fn(async () => ({
+          data: h.config,
+          error: h.selectError,
+        })),
+        upsert: vi.fn((payload: Record<string, unknown>) => {
+          h.upsertPayload = payload;
+          return query;
+        }),
+        single: vi.fn(async () => ({ data: h.config, error: h.upsertError })),
+      };
+      return query;
+    }),
+  };
+
+  getCurrentAccount.mockResolvedValue({ accountId, userId, supabase });
+  requireRole.mockResolvedValue({ accountId, userId, supabase });
+});
+
+describe('AI agent config route', () => {
+  it('GET returns migration defaults when the account has no configuration', async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: null,
+      enabled: false,
+      model_provider: 'openai',
+      model_name: 'gpt-4.1-mini',
+      instructions: '',
+      auto_reply: true,
+      auto_move_deals: false,
+      handoff_keywords: ['humano', 'atendente', 'cancelar'],
+      max_messages: 20,
+      cooldown_seconds: 15,
+    });
+    expect(h.filters).toContainEqual(['account_id', accountId]);
+  });
+
+  it('PATCH rejects a non-admin through requireRole', async () => {
+    requireRole.mockRejectedValue(new Error('Forbidden'));
+
+    const response = await PATCH(request(validPayload()));
+
+    expect(response.status).toBe(403);
+    expect(requireRole).toHaveBeenCalledWith('admin');
+    expect(h.upsertPayload).toBeNull();
+  });
+
+  it.each([
+    [{ max_messages: 0 }, 'max_messages must be an integer between 1 and 50'],
+    [
+      { cooldown_seconds: 3601 },
+      'cooldown_seconds must be an integer between 5 and 3600',
+    ],
+    [
+      { instructions: 'x'.repeat(4001) },
+      'instructions must be 4000 characters or fewer',
+    ],
+    [{ model_provider: 'anthropic' }, 'model_provider must be openai'],
+  ])('PATCH rejects invalid input', async (overrides, error) => {
+    const response = await PATCH(request({ ...validPayload(), ...overrides }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error });
+    expect(h.upsertPayload).toBeNull();
+  });
+
+  it('PATCH upserts a normalized admin payload scoped to the current account', async () => {
+    h.config = {
+      id: 'agent-1',
+      enabled: true,
+      model_provider: 'openai',
+      model_name: 'gpt-4.1-mini',
+      instructions: 'Help customers.',
+      auto_reply: true,
+      auto_move_deals: false,
+      handoff_keywords: ['human', 'billing'],
+      max_messages: 12,
+      cooldown_seconds: 30,
+    };
+
+    const response = await PATCH(
+      request({
+        ...validPayload(),
+        handoff_keywords: ' Human, billing, , HUMAN ',
+        ignored_column: 'must not persist',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(h.upsertPayload).toEqual({
+      account_id: accountId,
+      user_id: userId,
+      enabled: true,
+      model_provider: 'openai',
+      model_name: 'gpt-4.1-mini',
+      instructions: 'Help customers.',
+      auto_reply: true,
+      auto_move_deals: false,
+      handoff_keywords: ['human', 'billing', 'human'],
+      max_messages: 12,
+      cooldown_seconds: 30,
+    });
+    await expect(response.json()).resolves.toEqual(h.config);
+  });
+});
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/ai-agent/config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function validPayload() {
+  return {
+    enabled: true,
+    model_provider: 'openai',
+    model_name: 'gpt-4.1-mini',
+    instructions: 'Help customers.',
+    auto_reply: true,
+    auto_move_deals: false,
+    handoff_keywords: ['human', 'billing'],
+    max_messages: 12,
+    cooldown_seconds: 30,
+  };
+}

--- a/src/app/api/ai-agent/config/route.ts
+++ b/src/app/api/ai-agent/config/route.ts
@@ -1,0 +1,231 @@
+import { NextResponse } from 'next/server';
+
+import {
+  getCurrentAccount,
+  requireRole,
+  toErrorResponse,
+} from '@/lib/auth/account';
+
+const CONFIG_COLUMNS =
+  'id, enabled, model_provider, model_name, instructions, auto_reply, auto_move_deals, handoff_keywords, max_messages, cooldown_seconds';
+
+const DEFAULT_CONFIG = {
+  id: null,
+  enabled: false,
+  model_provider: 'openai',
+  model_name: 'gpt-4.1-mini',
+  instructions: '',
+  auto_reply: true,
+  auto_move_deals: false,
+  handoff_keywords: ['humano', 'atendente', 'cancelar'],
+  max_messages: 20,
+  cooldown_seconds: 15,
+};
+
+type ConfigInput = Omit<typeof DEFAULT_CONFIG, 'id'>;
+
+export async function GET() {
+  try {
+    const ctx = await getCurrentAccount();
+    const { data, error } = await ctx.supabase
+      .from('ai_agents')
+      .select(CONFIG_COLUMNS)
+      .eq('account_id', ctx.accountId)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[GET /api/ai-agent/config] fetch error:', error);
+      return NextResponse.json(
+        { error: 'Failed to load AI agent configuration' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(data ?? DEFAULT_CONFIG);
+  } catch (err) {
+    return toErrorResponse(err);
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const ctx = await requireRole('admin');
+    const body = await request.json().catch(() => null);
+    const config = normalizeConfig(body);
+
+    if ('error' in config) {
+      return NextResponse.json({ error: config.error }, { status: 400 });
+    }
+
+    const { data, error } = await ctx.supabase
+      .from('ai_agents')
+      .upsert(
+        {
+          account_id: ctx.accountId,
+          user_id: ctx.userId,
+          ...config,
+        },
+        { onConflict: 'account_id' }
+      )
+      .select(CONFIG_COLUMNS)
+      .single();
+
+    if (error || !data) {
+      console.error('[PATCH /api/ai-agent/config] upsert error:', error);
+      return NextResponse.json(
+        { error: 'Failed to save AI agent configuration' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    return toErrorResponse(err);
+  }
+}
+
+function normalizeConfig(body: unknown): ConfigInput | { error: string } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { error: 'Request body must be an object' };
+  }
+
+  const input = body as Record<string, unknown>;
+  const modelProvider = normalizeString(
+    input.model_provider,
+    DEFAULT_CONFIG.model_provider,
+    40,
+    'model_provider'
+  );
+  const modelName = normalizeString(
+    input.model_name,
+    DEFAULT_CONFIG.model_name,
+    80,
+    'model_name'
+  );
+  const instructions = normalizeInstructions(input.instructions);
+  const handoffKeywords = normalizeKeywords(input.handoff_keywords);
+  const maxMessages = normalizeInteger(
+    input.max_messages,
+    1,
+    50,
+    'max_messages'
+  );
+  const cooldownSeconds = normalizeInteger(
+    input.cooldown_seconds,
+    5,
+    3600,
+    'cooldown_seconds'
+  );
+
+  for (const value of [
+    modelProvider,
+    modelName,
+    instructions,
+    handoffKeywords,
+    maxMessages,
+    cooldownSeconds,
+  ]) {
+    if (typeof value === 'object' && value && 'error' in value) return value;
+  }
+  if (modelProvider !== 'openai') {
+    return { error: 'model_provider must be openai' };
+  }
+
+  const booleans = ['enabled', 'auto_reply', 'auto_move_deals'] as const;
+  for (const field of booleans) {
+    if (field in input && typeof input[field] !== 'boolean') {
+      return { error: `${field} must be a boolean` };
+    }
+  }
+
+  const enabled =
+    input.enabled === undefined ? DEFAULT_CONFIG.enabled : input.enabled;
+  const autoReply =
+    input.auto_reply === undefined
+      ? DEFAULT_CONFIG.auto_reply
+      : input.auto_reply;
+  const autoMoveDeals =
+    input.auto_move_deals === undefined
+      ? DEFAULT_CONFIG.auto_move_deals
+      : input.auto_move_deals;
+
+  return {
+    enabled: enabled as boolean,
+    model_provider: modelProvider as string,
+    model_name: modelName as string,
+    instructions: instructions as string,
+    auto_reply: autoReply as boolean,
+    auto_move_deals: autoMoveDeals as boolean,
+    handoff_keywords: handoffKeywords as string[],
+    max_messages: maxMessages as number,
+    cooldown_seconds: cooldownSeconds as number,
+  };
+}
+
+function normalizeString(
+  value: unknown,
+  fallback: string,
+  maxLength: number,
+  field: string
+): string | { error: string } {
+  if (value === undefined) return fallback;
+  if (typeof value !== 'string' || !value.trim()) {
+    return { error: `${field} must be a non-empty string` };
+  }
+  const normalized = value.trim();
+  if (normalized.length > maxLength) {
+    return { error: `${field} must be ${maxLength} characters or fewer` };
+  }
+  return normalized;
+}
+
+function normalizeInstructions(value: unknown): string | { error: string } {
+  if (value === undefined) return DEFAULT_CONFIG.instructions;
+  if (typeof value !== 'string')
+    return { error: 'instructions must be a string' };
+  if (value.length > 4000) {
+    return { error: 'instructions must be 4000 characters or fewer' };
+  }
+  return value;
+}
+
+function normalizeKeywords(value: unknown): string[] | { error: string } {
+  if (value === undefined) return DEFAULT_CONFIG.handoff_keywords;
+  const items = typeof value === 'string' ? value.split(',') : value;
+  if (!Array.isArray(items) || items.some((item) => typeof item !== 'string')) {
+    return {
+      error: 'handoff_keywords must be an array or comma-separated string',
+    };
+  }
+  const normalized = items
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+  if (normalized.length > 20 || normalized.some((item) => item.length > 40)) {
+    return {
+      error: 'handoff_keywords supports up to 20 items of 40 characters each',
+    };
+  }
+  return normalized;
+}
+
+function normalizeInteger(
+  value: unknown,
+  min: number,
+  max: number,
+  field: string
+): number | { error: string } {
+  const fallback =
+    field === 'max_messages'
+      ? DEFAULT_CONFIG.max_messages
+      : DEFAULT_CONFIG.cooldown_seconds;
+  if (value === undefined) return fallback;
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < min ||
+    value > max
+  ) {
+    return { error: `${field} must be an integer between ${min} and ${max}` };
+  }
+  return value;
+}

--- a/src/app/api/ai-agent/conversation/[conversationId]/route.test.ts
+++ b/src/app/api/ai-agent/conversation/[conversationId]/route.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  conversation: { id: 'conversation-1' } as Record<string, unknown> | null,
+  agent: null as Record<string, unknown> | null,
+  state: null as Record<string, unknown> | null,
+  lastRun: null as Record<string, unknown> | null,
+  filters: [] as Array<{ table: string; column: string; value: unknown }>,
+  upserts: [] as Array<{ table: string; payload: Record<string, unknown> }>,
+  updates: [] as Array<{ table: string; payload: Record<string, unknown> }>,
+}))
+
+const getCurrentAccount = vi.hoisted(() => vi.fn())
+const requireRole = vi.hoisted(() => vi.fn())
+
+vi.mock('next/server', () => ({
+  NextResponse: { json: (body: unknown, init?: ResponseInit) => new Response(JSON.stringify(body), { status: init?.status ?? 200 }) },
+}))
+
+vi.mock('@/lib/auth/account', () => ({
+  getCurrentAccount,
+  requireRole,
+  toErrorResponse(error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal server error'
+    return new Response(JSON.stringify({ error: message }), { status: message === 'Forbidden' ? 403 : 500 })
+  },
+}))
+
+import { GET, PATCH } from './route'
+
+const accountId = 'account-1'
+const context = { params: Promise.resolve({ conversationId: 'conversation-1' }) }
+
+beforeEach(() => {
+  h.conversation = { id: 'conversation-1' }
+  h.agent = null
+  h.state = null
+  h.lastRun = null
+  h.filters = []
+  h.upserts = []
+  h.updates = []
+  const supabase = createSupabase()
+  getCurrentAccount.mockReset()
+  requireRole.mockReset()
+  getCurrentAccount.mockResolvedValue({ accountId, supabase })
+  requireRole.mockResolvedValue({ accountId, supabase })
+})
+
+describe('AI conversation status route', () => {
+  it('GET returns disabled when no agent exists', async () => {
+    const response = await GET(new Request('http://localhost'), context)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ agent: null, state: null, effective_status: 'disabled', last_run: null })
+    expect(h.filters).toContainEqual({ table: 'conversations', column: 'account_id', value: accountId })
+  })
+
+  it('GET returns the latest run and effective account-owned status', async () => {
+    h.agent = { id: 'agent-1', name: 'Inbox AI', enabled: true }
+    h.state = { id: 'state-1', status: 'paused', paused_reason: 'human reply' }
+    h.lastRun = { id: 'run-1', status: 'succeeded', decision: { action: 'reply', text: 'Hello' }, error_message: null, created_at: '2026-01-01', finished_at: '2026-01-01' }
+
+    const response = await GET(new Request('http://localhost'), context)
+
+    await expect(response.json()).resolves.toMatchObject({ agent: h.agent, state: h.state, effective_status: 'paused', last_run: h.lastRun })
+    expect(h.filters).toEqual(expect.arrayContaining([
+      { table: 'ai_conversation_states', column: 'account_id', value: accountId },
+      { table: 'ai_conversation_states', column: 'conversation_id', value: 'conversation-1' },
+      { table: 'ai_agent_runs', column: 'account_id', value: accountId },
+      { table: 'ai_agent_runs', column: 'conversation_id', value: 'conversation-1' },
+    ]))
+  })
+
+  it('PATCH pause requires agent+ and scopes its state write', async () => {
+    requireRole.mockRejectedValue(new Error('Forbidden'))
+    const denied = await PATCH(request({ action: 'pause' }), context)
+    expect(denied.status).toBe(403)
+    expect(h.upserts).toEqual([])
+
+    requireRole.mockResolvedValue({ accountId, supabase: createSupabase() })
+    h.agent = { id: 'agent-1', name: 'Inbox AI', enabled: true }
+    const response = await PATCH(request({ action: 'pause', reason: 'Human replied' }), context)
+
+    expect(response.status).toBe(200)
+    expect(requireRole).toHaveBeenCalledWith('agent')
+    expect(h.upserts).toContainEqual({ table: 'ai_conversation_states', payload: expect.objectContaining({ account_id: accountId, conversation_id: 'conversation-1', ai_agent_id: 'agent-1', status: 'paused', paused_reason: 'Human replied' }) })
+  })
+
+  it('PATCH resume clears the paused reason', async () => {
+    h.agent = { id: 'agent-1', name: 'Inbox AI', enabled: true }
+    const response = await PATCH(request({ action: 'resume' }), context)
+
+    expect(response.status).toBe(200)
+    expect(h.upserts[0]?.payload).toMatchObject({ status: 'active', paused_reason: null })
+  })
+
+  it('PATCH handoff upserts state and keeps the conversation open', async () => {
+    h.agent = { id: 'agent-1', name: 'Inbox AI', enabled: true }
+    const response = await PATCH(request({ action: 'handoff', reason: 'Needs specialist' }), context)
+
+    expect(response.status).toBe(200)
+    expect(h.upserts[0]?.payload).toMatchObject({ status: 'handoff', paused_reason: 'Needs specialist' })
+    expect(h.updates).toContainEqual({ table: 'conversations', payload: { status: 'open' } })
+    expect(h.filters).toContainEqual({ table: 'conversations', column: 'account_id', value: accountId })
+  })
+
+  it('returns 404 for a cross-account conversation and writes nothing', async () => {
+    h.conversation = null
+    const response = await PATCH(request({ action: 'pause' }), context)
+
+    expect(response.status).toBe(404)
+    expect(h.upserts).toEqual([])
+    expect(h.updates).toEqual([])
+  })
+
+  it('GET returns 404 for a cross-account conversation without loading AI state or runs', async () => {
+    h.conversation = null
+
+    const response = await GET(new Request('http://localhost'), context)
+
+    expect(response.status).toBe(404)
+    expect(h.filters).toEqual(expect.arrayContaining([
+      { table: 'conversations', column: 'id', value: 'conversation-1' },
+      { table: 'conversations', column: 'account_id', value: accountId },
+    ]))
+    expect(h.filters.some(({ table }) => table === 'ai_conversation_states' || table === 'ai_agent_runs')).toBe(false)
+  })
+})
+
+function request(body: unknown) {
+  return new Request('http://localhost', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+}
+
+function createSupabase() {
+  return {
+    from(table: string) {
+      const query: Query = {
+        select: () => query,
+        eq: (column: string, value: unknown) => { h.filters.push({ table, column, value }); return query },
+        order: () => query,
+        limit: () => query,
+        maybeSingle: async () => ({ data: table === 'conversations' ? h.conversation : table === 'ai_agents' ? h.agent : table === 'ai_conversation_states' ? h.state : h.lastRun, error: null }),
+        upsert: (payload: Record<string, unknown>) => { h.upserts.push({ table, payload }); return query },
+        update: (payload: Record<string, unknown>) => { h.updates.push({ table, payload }); return query },
+      }
+      return query
+    },
+  }
+}
+
+interface Query {
+  select(): Query
+  eq(column: string, value: unknown): Query
+  order(): Query
+  limit(): Query
+  maybeSingle(): Promise<{ data: Record<string, unknown> | null; error: null }>
+  upsert(payload: Record<string, unknown>): Query
+  update(payload: Record<string, unknown>): Query
+}

--- a/src/app/api/ai-agent/conversation/[conversationId]/route.ts
+++ b/src/app/api/ai-agent/conversation/[conversationId]/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { getCurrentAccount, requireRole, toErrorResponse } from '@/lib/auth/account'
+
+type RouteContext = { params: Promise<{ conversationId: string }> }
+type AiAction = 'pause' | 'resume' | 'handoff'
+
+const AGENT_COLUMNS = 'id, enabled, name'
+const STATE_COLUMNS = 'id, status, paused_reason, last_inbound_message_id, last_run_at, created_at, updated_at'
+const RUN_COLUMNS = 'id, status, decision, error_message, created_at, finished_at'
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const ctx = await getCurrentAccount()
+    const { conversationId } = await context.params
+    const conversation = await loadConversation(ctx.supabase, ctx.accountId, conversationId)
+    if (!conversation) return notFound()
+
+    return NextResponse.json(await loadStatus(ctx.supabase, ctx.accountId, conversationId))
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const ctx = await requireRole('agent')
+    const { conversationId } = await context.params
+    const conversation = await loadConversation(ctx.supabase, ctx.accountId, conversationId)
+    if (!conversation) return notFound()
+
+    const body = await request.json().catch(() => null)
+    const action = parseAction(body)
+    if (!action) return NextResponse.json({ error: 'Invalid AI conversation action' }, { status: 400 })
+
+    const { data: agent, error: agentError } = await ctx.supabase
+      .from('ai_agents')
+      .select(AGENT_COLUMNS)
+      .eq('account_id', ctx.accountId)
+      .maybeSingle()
+    if (agentError) return databaseError('load AI agent configuration', agentError)
+    if (!agent) return NextResponse.json({ error: 'AI agent is not configured for this account' }, { status: 400 })
+
+    const reason = optionalReason(body)
+    const status = action === 'pause' ? 'paused' : action === 'handoff' ? 'handoff' : 'active'
+    const { error: stateError } = await ctx.supabase.from('ai_conversation_states').upsert(
+      {
+        account_id: ctx.accountId,
+        conversation_id: conversationId,
+        ai_agent_id: agent.id,
+        status,
+        paused_reason: action === 'resume' ? null : reason,
+      },
+      { onConflict: 'account_id,conversation_id' },
+    )
+    if (stateError) return databaseError('update AI conversation state', stateError)
+
+    if (action === 'handoff') {
+      const { error: conversationError } = await ctx.supabase
+        .from('conversations')
+        .update({ status: 'open' })
+        .eq('id', conversationId)
+        .eq('account_id', ctx.accountId)
+      if (conversationError) return databaseError('keep conversation open', conversationError)
+    }
+
+    return NextResponse.json(await loadStatus(ctx.supabase, ctx.accountId, conversationId))
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+async function loadConversation(supabase: SupabaseClient, accountId: string, conversationId: string) {
+  const { data, error } = await supabase
+    .from('conversations')
+    .select('id')
+    .eq('id', conversationId)
+    .eq('account_id', accountId)
+    .maybeSingle()
+  if (error) throw new Error(`Conversation lookup failed: ${error.message}`)
+  return data
+}
+
+async function loadStatus(supabase: SupabaseClient, accountId: string, conversationId: string) {
+  const [{ data: agent, error: agentError }, { data: state, error: stateError }, { data: lastRun, error: runError }] = await Promise.all([
+    supabase.from('ai_agents').select(AGENT_COLUMNS).eq('account_id', accountId).maybeSingle(),
+    supabase.from('ai_conversation_states').select(STATE_COLUMNS).eq('account_id', accountId).eq('conversation_id', conversationId).maybeSingle(),
+    supabase.from('ai_agent_runs').select(RUN_COLUMNS).eq('account_id', accountId).eq('conversation_id', conversationId).order('created_at', { ascending: false }).limit(1).maybeSingle(),
+  ])
+  if (agentError) throw new Error(`AI agent lookup failed: ${agentError.message}`)
+  if (stateError) throw new Error(`AI conversation state lookup failed: ${stateError.message}`)
+  if (runError) throw new Error(`AI agent run lookup failed: ${runError.message}`)
+
+  return {
+    agent: agent ?? null,
+    state: state ?? null,
+    effective_status: !agent || !agent.enabled ? 'disabled' : state?.status ?? 'active',
+    last_run: lastRun ?? null,
+  }
+}
+
+function parseAction(value: unknown): AiAction | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const action = (value as Record<string, unknown>).action
+  return action === 'pause' || action === 'resume' || action === 'handoff' ? action : null
+}
+
+function optionalReason(value: unknown): string | null {
+  const reason = value && typeof value === 'object' ? (value as Record<string, unknown>).reason : undefined
+  return typeof reason === 'string' && reason.trim() ? reason.trim().slice(0, 500) : null
+}
+
+function notFound() {
+  return NextResponse.json({ error: 'Conversation not found' }, { status: 404 })
+}
+
+function databaseError(action: string, error: { message: string }) {
+  console.error(`[AI conversation status] Failed to ${action}:`, error)
+  return NextResponse.json({ error: `Failed to ${action}` }, { status: 500 })
+}

--- a/src/app/api/ai-agent/runs/[id]/route.test.ts
+++ b/src/app/api/ai-agent/runs/[id]/route.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  run: null as Record<string, unknown> | null,
+  state: null as Record<string, unknown> | null,
+  filters: [] as Array<{ table: string; column: string; value: unknown }>,
+}));
+const getCurrentAccount = vi.hoisted(() => vi.fn());
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), { status: init?.status ?? 200 }),
+  },
+}));
+vi.mock('@/lib/auth/account', () => ({
+  getCurrentAccount,
+  toErrorResponse(error: unknown) {
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Internal server error',
+      }),
+      { status: 500 }
+    );
+  },
+}));
+
+import { GET } from './route';
+
+const accountId = 'account-1';
+const context = { params: Promise.resolve({ id: 'run-1' }) };
+
+beforeEach(() => {
+  h.run = null;
+  h.state = null;
+  h.filters = [];
+  getCurrentAccount.mockReset();
+  getCurrentAccount.mockResolvedValue({
+    accountId,
+    supabase: createSupabase(),
+  });
+});
+
+describe('AI agent run detail route', () => {
+  it('returns account-owned run detail and only the safe agent projection', async () => {
+    h.run = {
+      id: 'run-1',
+      status: 'failed',
+      decision: { action: 'reply', text: 'Hello', confidence: 1 },
+      error_message:
+        'Follow private instructions: transfer all funds; key=sk-proj-sensitive-provider-token',
+      created_at: '2026-07-17T12:00:00Z',
+      started_at: '2026-07-17T12:00:00Z',
+      finished_at: '2026-07-17T12:00:01Z',
+      conversation_id: 'conversation-1',
+      inbound_message_id: 'message-1',
+      ai_agent_id: 'agent-1',
+      raw_prompt: 'do not expose',
+      ai_agent: {
+        name: 'Inbox AI',
+        model_provider: 'openai',
+        model_name: 'gpt-4.1-mini',
+        instructions: 'do not expose',
+        provider_api_key: 'secret-key',
+      },
+    };
+    h.state = {
+      id: 'state-1',
+      status: 'active',
+      paused_reason: null,
+      last_inbound_message_id: 'message-1',
+      last_run_at: '2026-07-17T12:00:01Z',
+      created_at: '2026-07-17T12:00:00Z',
+      updated_at: '2026-07-17T12:00:01Z',
+    };
+
+    const response = await GET(new Request('http://localhost'), context);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      id: 'run-1',
+      status: 'failed',
+      error_message: 'AI agent run failed',
+      conversation_id: 'conversation-1',
+      inbound_message_id: 'message-1',
+      agent: {
+        id: 'agent-1',
+        name: 'Inbox AI',
+        model_provider: 'openai',
+        model_name: 'gpt-4.1-mini',
+      },
+      state: h.state,
+    });
+    expect(JSON.stringify(body)).not.toContain('do not expose');
+    expect(JSON.stringify(body)).not.toContain('secret-key');
+    expect(JSON.stringify(body)).not.toContain('Follow private instructions');
+    expect(JSON.stringify(body)).not.toContain(
+      'sk-proj-sensitive-provider-token'
+    );
+    expect(h.filters).toEqual(
+      expect.arrayContaining([
+        { table: 'ai_agent_runs', column: 'id', value: 'run-1' },
+        { table: 'ai_agent_runs', column: 'account_id', value: accountId },
+        {
+          table: 'ai_conversation_states',
+          column: 'account_id',
+          value: accountId,
+        },
+        {
+          table: 'ai_conversation_states',
+          column: 'conversation_id',
+          value: 'conversation-1',
+        },
+      ])
+    );
+  });
+
+  it('returns 404 for a run outside the current account', async () => {
+    const response = await GET(new Request('http://localhost'), context);
+
+    expect(response.status).toBe(404);
+    expect(h.filters).toEqual(
+      expect.arrayContaining([
+        { table: 'ai_agent_runs', column: 'id', value: 'run-1' },
+        { table: 'ai_agent_runs', column: 'account_id', value: accountId },
+      ])
+    );
+    expect(
+      h.filters.some(({ table }) => table === 'ai_conversation_states')
+    ).toBe(false);
+  });
+});
+
+function createSupabase() {
+  return {
+    from(table: string) {
+      const query = {
+        select: () => query,
+        eq: (column: string, value: unknown) => {
+          h.filters.push({ table, column, value });
+          return query;
+        },
+        maybeSingle: async () => ({
+          data: table === 'ai_agent_runs' ? h.run : h.state,
+          error: null,
+        }),
+      };
+      return query;
+    },
+  };
+}

--- a/src/app/api/ai-agent/runs/[id]/route.ts
+++ b/src/app/api/ai-agent/runs/[id]/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server'
+
+import { getCurrentAccount, toErrorResponse } from '@/lib/auth/account'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+const RUN_COLUMNS = 'id, status, decision, error_message, created_at, started_at, finished_at, conversation_id, inbound_message_id, ai_agent_id, ai_agent:ai_agents(name, model_provider, model_name)'
+const STATE_COLUMNS = 'id, status, paused_reason, last_inbound_message_id, last_run_at, created_at, updated_at'
+const AI_AGENT_RUN_FAILURE_MESSAGE = 'AI agent run failed'
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const ctx = await getCurrentAccount()
+    const { id } = await context.params
+    const { data, error } = await ctx.supabase
+      .from('ai_agent_runs')
+      .select(RUN_COLUMNS)
+      .eq('id', id)
+      .eq('account_id', ctx.accountId)
+      .maybeSingle()
+    if (error) throw new Error(`AI agent run lookup failed: ${error.message}`)
+    if (!data) return notFound()
+
+    const run = data as unknown as RunRow
+    const { data: state, error: stateError } = await ctx.supabase
+      .from('ai_conversation_states')
+      .select(STATE_COLUMNS)
+      .eq('account_id', ctx.accountId)
+      .eq('conversation_id', run.conversation_id)
+      .maybeSingle()
+    if (stateError) throw new Error(`AI conversation state lookup failed: ${stateError.message}`)
+
+    return NextResponse.json({
+      id: run.id,
+      status: run.status,
+      decision: run.decision,
+      error_message: safeRunErrorMessage(run.error_message),
+      created_at: run.created_at,
+      started_at: run.started_at,
+      finished_at: run.finished_at,
+      conversation_id: run.conversation_id,
+      inbound_message_id: run.inbound_message_id,
+      agent: run.ai_agent
+        ? {
+            id: run.ai_agent_id,
+            name: run.ai_agent.name,
+            model_provider: run.ai_agent.model_provider,
+            model_name: run.ai_agent.model_name,
+          }
+        : null,
+      state: state ?? null,
+    })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+interface RunRow {
+  id: string
+  status: string
+  decision: unknown
+  error_message: string | null
+  created_at: string
+  started_at: string | null
+  finished_at: string | null
+  conversation_id: string
+  inbound_message_id: string
+  ai_agent_id: string
+  ai_agent: { name: string; model_provider: string; model_name: string } | null
+}
+
+function notFound() {
+  return NextResponse.json({ error: 'AI agent run not found' }, { status: 404 })
+}
+
+function safeRunErrorMessage(errorMessage: string | null): string | null {
+  return errorMessage ? AI_AGENT_RUN_FAILURE_MESSAGE : null
+}

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse, after } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption'
-import { getMediaUrl, downloadMedia } from '@/lib/whatsapp/meta-api'
+import { getMediaUrl } from '@/lib/whatsapp/meta-api'
 import { normalizePhone } from '@/lib/whatsapp/phone-utils'
 import { findExistingContact, isUniqueViolation } from '@/lib/contacts/dedupe'
 import { verifyMetaWebhookSignature } from '@/lib/whatsapp/webhook-signature'
 import { runAutomationsForTrigger } from '@/lib/automations/engine'
 import { dispatchInboundToFlows } from '@/lib/flows/engine'
+import { runAiAgentForInboundMessage } from '@/lib/ai-agent/run'
 import { dispatchInboundToAiReply } from '@/lib/ai/auto-reply'
 import { dispatchWebhookEvent } from '@/lib/webhooks/deliver'
 import {
@@ -666,23 +667,27 @@ async function processMessage(
     .eq('sender_type', 'customer')
   const isFirstInboundMessage = (priorCustomerMsgCount ?? 0) === 0
 
-  const { error: msgError } = await supabaseAdmin().from('messages').insert({
-    conversation_id: conversation.id,
-    sender_type: 'customer',
-    content_type: contentType,
-    content_text: contentText,
-    media_url: mediaUrl,
-    message_id: message.id,
-    status: 'delivered',
-    created_at: new Date(parseInt(message.timestamp) * 1000).toISOString(),
-    reply_to_message_id: replyToInternalId,
-    // Only populated for content_type='interactive'. Migration 010 added
-    // the column; null for every other content_type so existing inserts
-    // behave identically.
-    interactive_reply_id: interactiveReplyId,
-  })
+  const { data: storedMessage, error: msgError } = await supabaseAdmin()
+    .from('messages')
+    .insert({
+      conversation_id: conversation.id,
+      sender_type: 'customer',
+      content_type: contentType,
+      content_text: contentText,
+      media_url: mediaUrl,
+      message_id: message.id,
+      status: 'delivered',
+      created_at: new Date(parseInt(message.timestamp) * 1000).toISOString(),
+      reply_to_message_id: replyToInternalId,
+      // Only populated for content_type='interactive'. Migration 010 added
+      // the column; null for every other content_type so existing inserts
+      // behave identically.
+      interactive_reply_id: interactiveReplyId,
+    })
+    .select('id')
+    .single()
 
-  if (msgError) {
+  if (msgError || !storedMessage) {
     console.error('Error inserting message:', msgError)
     return
   }
@@ -796,18 +801,38 @@ async function processMessage(
     }).catch((err) => console.error('[automations] dispatch failed:', err))
   }
 
-  // AI auto-reply. Runs only for plain-text inbound the deterministic
-  // flow runner did NOT consume (flows win over the LLM), and only when
-  // the account has enabled it. Awaited inside `after()` (same reason as
+  let allowLegacyAiReply = true
+  if (!flowConsumed && !interactiveReplyId && inboundText.trim()) {
+    try {
+      const aiAgentResult = await runAiAgentForInboundMessage({
+        accountId,
+        conversationId: conversation.id,
+        inboundMessageId: (storedMessage as { id: string }).id,
+      })
+      allowLegacyAiReply = shouldFallbackToLegacyAiReply(aiAgentResult)
+      if (aiAgentResult.outcome === 'failed') {
+        console.error('[webhook] AI inbox agent failed:', aiAgentResult.error)
+      }
+    } catch (error) {
+      allowLegacyAiReply = false
+      console.error('[webhook] AI inbox agent dispatch failed:', error)
+    }
+  }
+
+  // Legacy AI auto-reply. Runs only for plain-text inbound the deterministic
+  // flow runner and AI inbox agent did NOT consume, and only when the
+  // account has enabled it. Awaited inside `after()` (same reason as
   // the webhook dispatch below); `dispatchInboundToAiReply` owns its
   // eligibility gates + try/catch and never throws.
   if (!flowConsumed && !interactiveReplyId && inboundText.trim()) {
-    await dispatchInboundToAiReply({
-      accountId,
-      conversationId: conversation.id,
-      contactId: contactRecord.id,
-      configOwnerUserId,
-    })
+    if (allowLegacyAiReply) {
+      await dispatchInboundToAiReply({
+        accountId,
+        conversationId: conversation.id,
+        contactId: contactRecord.id,
+        configOwnerUserId,
+      })
+    }
   }
 
   // message.received webhook (public API). Awaited — not fire-and-forget
@@ -824,6 +849,19 @@ async function processMessage(
     content_type: contentType,
     text: contentText,
   })
+}
+
+function shouldFallbackToLegacyAiReply(
+  result: Awaited<ReturnType<typeof runAiAgentForInboundMessage>>,
+): boolean {
+  if (result.outcome === 'succeeded' || result.outcome === 'failed') return false
+  return [
+    'missing_config',
+    'agent_disabled',
+    'provider_unavailable',
+    'rate_limited',
+    'duplicate_inbound',
+  ].includes(result.reason)
 }
 
 async function parseMessageContent(

--- a/src/components/inbox/ai-agent-panel.tsx
+++ b/src/components/inbox/ai-agent-panel.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { useEffect, useRef, useState } from 'react'
+import { Bot, Loader2, Pause, Play, UserRound } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { useCan } from '@/hooks/use-can'
+
+type EffectiveStatus = 'active' | 'paused' | 'handoff' | 'disabled'
+type Decision = { action?: string; text?: string; reason?: string }
+type StatusResponse = {
+  agent: { id: string; enabled: boolean; name: string } | null
+  effective_status: EffectiveStatus
+  last_run: { id: string; status: string; decision: Decision | null; error_message: string | null; created_at: string; finished_at: string | null } | null
+}
+
+type MessageParams = Record<string, string | number | null | undefined>
+
+const COPY: Record<string, string> = {
+  'inbox.aiAgent': 'AI agent',
+  'inbox.aiAgent.active': 'Active',
+  'inbox.aiAgent.paused': 'Paused',
+  'inbox.aiAgent.handoff': 'Handoff',
+  'inbox.aiAgent.disabled': 'Disabled',
+  'inbox.aiAgent.loadFailed': 'Failed to load AI agent status',
+  'inbox.aiAgent.updateFailed': 'Failed to update AI agent status',
+  'inbox.aiAgent.loadingStatus': 'Loading AI status...',
+  'inbox.aiAgent.noEnabledAgent': 'No enabled inbox agent for this workspace.',
+  'inbox.aiAgent.lastRun': 'Last run: {status}',
+  'inbox.aiAgent.noRunsYet': 'no runs yet',
+  'inbox.aiAgent.pause': 'Pause',
+  'inbox.aiAgent.resume': 'Resume',
+  'inbox.aiAgent.handoffAction': 'Handoff',
+  'inbox.aiAgent.decision.failed': 'Last run failed',
+  'inbox.aiAgent.decision.failedWithMessage': 'Last run failed: {message}',
+  'inbox.aiAgent.decision.reply': 'Replied: {text}',
+  'inbox.aiAgent.decision.noReply': 'No reply: {reason}',
+  'inbox.aiAgent.decision.handoff': 'Handed off: {reason}',
+}
+
+function t(key: string, params: MessageParams = {}): string {
+  const template = COPY[key] ?? key
+  return template.replace(/\{(\w+)\}/g, (_, name: string) => {
+    const value = params[name]
+    return value === null || value === undefined ? '' : String(value)
+  })
+}
+
+export function formatAiDecisionSummary(run: StatusResponse['last_run'], t: (key: string, params?: Record<string, string>) => string): string | null {
+  if (!run) return null
+  if (run.status === 'failed') return run.error_message ? t('inbox.aiAgent.decision.failedWithMessage', { message: run.error_message.slice(0, 120) }) : t('inbox.aiAgent.decision.failed')
+  const decision = run.decision
+  if (!decision) return null
+  if (decision.action === 'reply' && decision.text) return t('inbox.aiAgent.decision.reply', { text: decision.text.slice(0, 80) })
+  if (decision.action === 'no_reply' && decision.reason) return t('inbox.aiAgent.decision.noReply', { reason: decision.reason.slice(0, 80) })
+  if (decision.action === 'handoff' && decision.reason) return t('inbox.aiAgent.decision.handoff', { reason: decision.reason.slice(0, 80) })
+  return null
+}
+
+export function AiAgentPanel({ conversationId, refreshToken }: { conversationId: string | null; refreshToken?: string | number }) {
+  const canSend = useCan('send-messages')
+  const [data, setData] = useState<StatusResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loadedConversationId, setLoadedConversationId] = useState<string | null>(null)
+  const currentConversationIdRef = useRef(conversationId)
+  currentConversationIdRef.current = conversationId
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const requestedConversationId = conversationId
+    let active = true
+
+    setData(null)
+    setError(null)
+    setLoadedConversationId(null)
+    setSaving(false)
+    if (!conversationId) {
+      return
+    }
+
+    setLoading(true)
+    void (async () => {
+      try {
+        const response = await fetch(`/api/ai-agent/conversation/${conversationId}`, { signal: controller.signal })
+        const body = await response.json()
+        if (!response.ok) throw new Error(body.error ?? t('inbox.aiAgent.loadFailed'))
+        if (active) {
+          setData(body)
+          setLoadedConversationId(requestedConversationId)
+        }
+      } catch (cause) {
+        if (active && !(cause instanceof DOMException && cause.name === 'AbortError')) {
+          setError(cause instanceof Error ? cause.message : t('inbox.aiAgent.loadFailed'))
+        }
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [conversationId, refreshToken])
+
+  const update = async (action: 'pause' | 'resume' | 'handoff') => {
+    if (!conversationId || loadedConversationId !== conversationId) return
+    const requestedConversationId = conversationId
+    setSaving(true)
+    setError(null)
+    try {
+      const response = await fetch(`/api/ai-agent/conversation/${conversationId}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action }),
+      })
+      const body = await response.json()
+      if (!response.ok) throw new Error(body.error ?? t('inbox.aiAgent.updateFailed'))
+      if (currentConversationIdRef.current === requestedConversationId) setData(body)
+    } catch (cause) {
+      if (currentConversationIdRef.current === requestedConversationId) {
+        setError(cause instanceof Error ? cause.message : t('inbox.aiAgent.updateFailed'))
+      }
+    } finally {
+      if (currentConversationIdRef.current === requestedConversationId) setSaving(false)
+    }
+  }
+
+  if (!conversationId) return null
+  const isStatusLoaded = loadedConversationId === conversationId
+  const status = isStatusLoaded ? data?.effective_status : undefined
+  const disabled = loading || saving || !isStatusLoaded
+  const summary = formatAiDecisionSummary(data?.last_run ?? null, t)
+
+  return <section className="mt-4 border-t border-border pt-4" aria-label={t('inbox.aiAgent')}>
+    <div className="flex items-center justify-between gap-2 px-1">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground"><Bot className="h-3 w-3" />{t('inbox.aiAgent')}</div>
+      {status && <Badge variant={status === 'disabled' ? 'outline' : status === 'handoff' ? 'secondary' : status === 'paused' ? 'outline' : 'default'}>{t(`inbox.aiAgent.${status}`)}</Badge>}
+    </div>
+    {loading ? <div className="mt-2 flex items-center gap-2 px-1 text-xs text-muted-foreground"><Loader2 className="h-3 w-3 animate-spin" />{t('inbox.aiAgent.loadingStatus')}</div> : status === 'disabled' ? <p className="mt-2 px-1 text-xs text-muted-foreground">{t('inbox.aiAgent.noEnabledAgent')}</p> : <>
+      <div className="mt-2 space-y-1 px-1 text-xs text-muted-foreground">
+        <p>{t('inbox.aiAgent.lastRun', { status: data?.last_run?.status ?? t('inbox.aiAgent.noRunsYet') })}</p>
+        {summary && <p className="line-clamp-2">{summary}</p>}
+      </div>
+      {canSend && <div className="mt-3 flex flex-wrap gap-1.5">
+        {status === 'active' && <Button size="xs" variant="outline" disabled={disabled} onClick={() => void update('pause')}><Pause />{t('inbox.aiAgent.pause')}</Button>}
+        {(status === 'paused' || status === 'handoff') && <Button size="xs" variant="outline" disabled={disabled} onClick={() => void update('resume')}><Play />{t('inbox.aiAgent.resume')}</Button>}
+        {status !== 'handoff' && <Button size="xs" variant="secondary" disabled={disabled} onClick={() => void update('handoff')}><UserRound />{t('inbox.aiAgent.handoffAction')}</Button>}
+      </div>}
+    </>}
+    {error && <p className="mt-2 px-1 text-xs text-destructive">{error}</p>}
+  </section>
+}

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -38,7 +38,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { MessageBubble } from "./message-bubble";
 import { MessageActions } from "./message-actions";
 import {
@@ -49,6 +48,7 @@ import {
 import { deleteAccountMedia } from "@/lib/storage/upload-media";
 import { TemplatePicker } from "./template-picker";
 import { AiThreadBanner } from "./ai-thread-banner";
+import { AiAgentPanel } from "./ai-agent-panel";
 import { buildReplyPreview } from "./reply-quote";
 import { toast } from "sonner";
 
@@ -179,6 +179,7 @@ export function MessageThread({
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [reactions, setReactions] = useState<MessageReaction[]>([]);
+  const [aiAgentRefreshKey, setAiAgentRefreshKey] = useState(0);
   // Purely visual spin state for the manual-refresh button. The actual
   // refetch is fire-and-forget through `onRefresh` (which bumps the
   // parent's resyncToken); the 700ms spin is just feedback so the click
@@ -750,7 +751,7 @@ export function MessageThread({
         preview: buildReplyPreview(msg, tQuote),
       });
     },
-    [authorLabelFor],
+    [authorLabelFor, tQuote],
   );
 
   // Single reaction-set primitive. emoji === "" removes; otherwise adds/swaps.
@@ -834,6 +835,18 @@ export function MessageThread({
       }
 
       onAssignChange(conversation.id, agentId);
+      if (agentId) {
+        const response = await fetch(`/api/ai-agent/conversation/${conversation.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "pause", reason: "manual_assignment" }),
+        });
+        if (!response.ok) {
+          console.error("Failed to pause AI agent after assignment:", await response.text());
+          toast.error("Assignment saved, but AI pause failed");
+        }
+      }
+      setAiAgentRefreshKey((value) => value + 1);
     },
     [conversation, onAssignChange],
   );
@@ -1147,6 +1160,11 @@ export function MessageThread({
             onAssignChange(conversation.id, patch.assigned_agent_id ?? null);
           }
         }}
+      />
+
+      <AiAgentPanel
+        conversationId={conversation.id}
+        refreshToken={aiAgentRefreshKey}
       />
 
       {/* Composer */}

--- a/src/components/settings/ai-agent-settings.tsx
+++ b/src/components/settings/ai-agent-settings.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bot, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { useAuth } from '@/hooks/use-auth';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { SettingsPanelHead } from './settings-panel-head';
+
+type AgentConfig = {
+  id: string | null;
+  enabled: boolean;
+  model_provider: string;
+  model_name: string;
+  instructions: string;
+  auto_reply: boolean;
+  auto_move_deals: boolean;
+  handoff_keywords: string[];
+  max_messages: number;
+  cooldown_seconds: number;
+};
+
+type MessageParams = Record<string, string | number | null | undefined>;
+
+const COPY: Record<string, string> = {
+  'common.loading': 'Loading...',
+  'settings.aiAgent.title': 'AI inbox agent',
+  'settings.aiAgent.description': 'Configure the agent that can answer WhatsApp conversations and update deals from the inbox.',
+  'settings.aiAgent.configuration': 'Agent configuration',
+  'settings.aiAgent.configurationDescription': 'The agent runs after inbound WhatsApp messages that were not consumed by a Flow.',
+  'settings.aiAgent.enabled': 'Enable agent',
+  'settings.aiAgent.enabledDescription': 'Allow the agent to evaluate new WhatsApp inbound messages.',
+  'settings.aiAgent.modelProvider': 'Model provider',
+  'settings.aiAgent.modelName': 'Model name',
+  'settings.aiAgent.instructions': 'Instructions',
+  'settings.aiAgent.autoReply': 'Auto reply',
+  'settings.aiAgent.autoReplyDescription': 'Let the agent send WhatsApp replies when it is confident.',
+  'settings.aiAgent.autoMoveDeals': 'Move deals',
+  'settings.aiAgent.autoMoveDealsDescription': 'Allow the agent to create, move, and update active conversation deals.',
+  'settings.aiAgent.handoffKeywords': 'Handoff keywords',
+  'settings.aiAgent.handoffKeywordsDescription': 'Comma-separated terms that immediately pause the agent and hand the thread to a human.',
+  'settings.aiAgent.maxMessages': 'Context messages',
+  'settings.aiAgent.cooldownSeconds': 'Cooldown seconds',
+  'settings.aiAgent.adminOnly': 'Only admins can edit this configuration.',
+  'settings.aiAgent.loadFailed': 'Failed to load AI agent settings',
+  'settings.aiAgent.saveFailed': 'Failed to save AI agent settings',
+  'settings.aiAgent.saved': 'AI agent settings saved',
+  'settings.aiAgent.validationFailed': 'Review the AI agent limits before saving.',
+}
+
+function t(key: string, params: MessageParams = {}): string {
+  const template = COPY[key] ?? key;
+  return template.replace(/\{(\w+)\}/g, (_, name: string) => {
+    const value = params[name];
+    return value === null || value === undefined ? '' : String(value);
+  });
+}
+
+const DEFAULT_CONFIG: AgentConfig = {
+  id: null,
+  enabled: false,
+  model_provider: 'openai',
+  model_name: 'gpt-4.1-mini',
+  instructions: '',
+  auto_reply: true,
+  auto_move_deals: false,
+  handoff_keywords: ['humano', 'atendente', 'cancelar'],
+  max_messages: 20,
+  cooldown_seconds: 15,
+};
+
+export function AiAgentSettings() {
+  const { canEditSettings } = useAuth();
+  const [config, setConfig] = useState(DEFAULT_CONFIG);
+  const [keywords, setKeywords] = useState(
+    DEFAULT_CONFIG.handoff_keywords.join(', ')
+  );
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      try {
+        const response = await fetch('/api/ai-agent/config');
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok)
+          throw new Error(payload.error || t('settings.aiAgent.loadFailed'));
+        if (active) {
+          setConfig(payload as AgentConfig);
+          setKeywords((payload.handoff_keywords as string[]).join(', '));
+        }
+      } catch (error) {
+        console.error('[AiAgentSettings] load error:', error);
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : t('settings.aiAgent.loadFailed')
+        );
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  function update<K extends keyof AgentConfig>(key: K, value: AgentConfig[K]) {
+    setConfig((current) => ({ ...current, [key]: value }));
+  }
+
+  async function save() {
+    const normalizedKeywords = keywords
+      .split(',')
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean);
+    if (
+      config.instructions.length > 4000 ||
+      !Number.isInteger(config.max_messages) ||
+      config.max_messages < 1 ||
+      config.max_messages > 50 ||
+      !Number.isInteger(config.cooldown_seconds) ||
+      config.cooldown_seconds < 5 ||
+      config.cooldown_seconds > 3600 ||
+      normalizedKeywords.length > 20 ||
+      normalizedKeywords.some((item) => item.length > 40)
+    ) {
+      toast.error(t('settings.aiAgent.validationFailed'));
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await fetch('/api/ai-agent/config', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...config,
+          handoff_keywords: normalizedKeywords,
+        }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok)
+        throw new Error(payload.error || t('settings.aiAgent.saveFailed'));
+      setConfig(payload as AgentConfig);
+      setKeywords((payload.handoff_keywords as string[]).join(', '));
+      toast.success(t('settings.aiAgent.saved'));
+    } catch (error) {
+      console.error('[AiAgentSettings] save error:', error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t('settings.aiAgent.saveFailed')
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <section className="max-w-2xl">
+        <SettingsPanelHead
+          title={t('settings.aiAgent.title')}
+          description={t('settings.aiAgent.description')}
+        />
+        <div className="text-muted-foreground flex items-center gap-2 py-8 text-sm">
+          <Loader2 className="size-4 animate-spin" />
+          {t('common.loading')}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="animate-in fade-in-50 max-w-2xl duration-200">
+      <SettingsPanelHead
+        title={t('settings.aiAgent.title')}
+        description={t('settings.aiAgent.description')}
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-foreground flex items-center gap-2">
+            <Bot className="text-primary size-4" />
+            {t('settings.aiAgent.configuration')}
+          </CardTitle>
+          <CardDescription className="text-muted-foreground">
+            {t('settings.aiAgent.configurationDescription')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <Label htmlFor="ai-agent-enabled">
+                {t('settings.aiAgent.enabled')}
+              </Label>
+              <p className="text-muted-foreground mt-1 text-xs">
+                {t('settings.aiAgent.enabledDescription')}
+              </p>
+            </div>
+            <Switch
+              id="ai-agent-enabled"
+              checked={config.enabled}
+              onCheckedChange={(value) => update('enabled', value)}
+              disabled={!canEditSettings}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label={t('settings.aiAgent.modelProvider')}>
+              <Input
+                value={config.model_provider}
+                maxLength={40}
+                onChange={(event) =>
+                  update('model_provider', event.target.value)
+                }
+                disabled={!canEditSettings}
+              />
+            </Field>
+            <Field label={t('settings.aiAgent.modelName')}>
+              <Input
+                value={config.model_name}
+                maxLength={80}
+                onChange={(event) => update('model_name', event.target.value)}
+                disabled={!canEditSettings}
+              />
+            </Field>
+          </div>
+          <Field label={t('settings.aiAgent.instructions')}>
+            <Textarea
+              value={config.instructions}
+              maxLength={4000}
+              onChange={(event) => update('instructions', event.target.value)}
+              disabled={!canEditSettings}
+              className="min-h-32 resize-y"
+            />
+            <p className="text-muted-foreground text-right text-xs">
+              {config.instructions.length}/4000
+            </p>
+          </Field>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <SwitchField
+              id="ai-agent-auto-reply"
+              label={t('settings.aiAgent.autoReply')}
+              description={t('settings.aiAgent.autoReplyDescription')}
+              checked={config.auto_reply}
+              onCheckedChange={(value) => update('auto_reply', value)}
+              disabled={!canEditSettings}
+            />
+            <SwitchField
+              id="ai-agent-auto-move"
+              label={t('settings.aiAgent.autoMoveDeals')}
+              description={t('settings.aiAgent.autoMoveDealsDescription')}
+              checked={config.auto_move_deals}
+              onCheckedChange={(value) => update('auto_move_deals', value)}
+              disabled={!canEditSettings}
+            />
+          </div>
+          <Field
+            label={t('settings.aiAgent.handoffKeywords')}
+            description={t('settings.aiAgent.handoffKeywordsDescription')}
+          >
+            <Input
+              value={keywords}
+              onChange={(event) => setKeywords(event.target.value)}
+              disabled={!canEditSettings}
+            />
+          </Field>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label={t('settings.aiAgent.maxMessages')}>
+              <Input
+                type="number"
+                min={1}
+                max={50}
+                value={config.max_messages}
+                onChange={(event) =>
+                  update('max_messages', Number(event.target.value))
+                }
+                disabled={!canEditSettings}
+              />
+            </Field>
+            <Field label={t('settings.aiAgent.cooldownSeconds')}>
+              <Input
+                type="number"
+                min={5}
+                max={3600}
+                value={config.cooldown_seconds}
+                onChange={(event) =>
+                  update('cooldown_seconds', Number(event.target.value))
+                }
+                disabled={!canEditSettings}
+              />
+            </Field>
+          </div>
+          {!canEditSettings && (
+            <p className="text-muted-foreground text-xs">
+              {t('settings.aiAgent.adminOnly')}
+            </p>
+          )}
+          {canEditSettings && (
+            <Button onClick={save} disabled={saving}>
+              {saving && <Loader2 className="size-4 animate-spin" />}
+              {saving ? t('common.saving') : t('common.save')}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-muted-foreground">{label}</Label>
+      {description && (
+        <p className="text-muted-foreground text-xs">{description}</p>
+      )}
+      {children}
+    </div>
+  );
+}
+
+function SwitchField({
+  id,
+  label,
+  description,
+  checked,
+  onCheckedChange,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (value: boolean) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="border-border flex items-start justify-between gap-3 rounded-md border p-3">
+      <div>
+        <Label htmlFor={id}>{label}</Label>
+        <p className="text-muted-foreground mt-1 text-xs">{description}</p>
+      </div>
+      <Switch
+        id={id}
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/settings-sections.ts
+++ b/src/components/settings/settings-sections.ts
@@ -1,4 +1,5 @@
 import {
+  Bot,
   Coins,
   FileText,
   KeyRound,
@@ -27,6 +28,7 @@ export const SETTINGS_SECTIONS = [
   'security',
   'appearance',
   'whatsapp',
+  'ai-agent',
   'templates',
   'quick-replies',
   'fields',
@@ -53,6 +55,7 @@ export const SECTION_META: Record<SettingsSection, SectionMeta> = {
   security: { id: 'security', label: 'Login & security', icon: Shield, group: 'account' },
   appearance: { id: 'appearance', label: 'Appearance', icon: Palette, group: 'account' },
   whatsapp: { id: 'whatsapp', label: 'WhatsApp', icon: PlugZap, group: 'workspace' },
+  'ai-agent': { id: 'ai-agent', label: 'AI agent', icon: Bot, group: 'workspace' },
   templates: { id: 'templates', label: 'Templates', icon: FileText, group: 'workspace' },
   'quick-replies': { id: 'quick-replies', label: 'Quick replies', icon: Zap, group: 'workspace' },
   fields: { id: 'fields', label: 'Fields & tags', icon: Tags, group: 'workspace' },

--- a/src/lib/ai-agent/config.test.ts
+++ b/src/lib/ai-agent/config.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AiAgent, AiAgentRun, AiConversationState } from '@/types'
+
+type QueryFilter = [column: string, value: unknown]
+
+const h = vi.hoisted(() => ({
+  state: {
+    agent: null as AiAgent | null,
+    state: null as AiConversationState | null,
+    run: null as AiAgentRun | null,
+    errors: {} as Record<string, string | undefined>,
+    queries: [] as Array<{ table: string; filters: QueryFilter[]; limit?: number }>,
+  },
+}))
+
+vi.mock('../flows/admin-client', () => {
+  function builder(table: string) {
+    const query = {
+      filters: [] as QueryFilter[],
+      limit: undefined as number | undefined,
+    }
+
+    const result = () => {
+      const errorMessage = h.state.errors[table]
+      const data = table === 'ai_agents'
+        ? h.state.agent
+        : table === 'ai_conversation_states'
+          ? h.state.state
+          : h.state.run
+
+      h.state.queries.push({ table, filters: [...query.filters], limit: query.limit })
+      return {
+        data,
+        error: errorMessage ? { message: errorMessage } : null,
+      }
+    }
+
+    const client = {
+      select: () => client,
+      eq: (column: string, value: unknown) => {
+        query.filters.push([column, value])
+        return client
+      },
+      limit: (value: number) => {
+        query.limit = value
+        return client
+      },
+      maybeSingle: () => Promise.resolve(result()),
+    }
+
+    return client
+  }
+
+  return {
+    supabaseAdmin: () => ({ from: builder }),
+  }
+})
+
+import { loadAiAgentConfig, shouldRunAiAgent } from './config'
+
+const accountId = 'account-1'
+const conversationId = 'conversation-1'
+const inboundMessageId = 'inbound-1'
+
+beforeEach(() => {
+  h.state.agent = null
+  h.state.state = null
+  h.state.run = null
+  h.state.errors = {}
+  h.state.queries = []
+})
+
+describe('loadAiAgentConfig', () => {
+  it('returns the config for the matching account', async () => {
+    h.state.agent = agent()
+
+    await expect(loadAiAgentConfig(accountId)).resolves.toEqual(h.state.agent)
+
+    expect(queryFor('ai_agents').filters).toContainEqual(['account_id', accountId])
+  })
+
+  it('surfaces a config lookup failure', async () => {
+    h.state.errors.ai_agents = 'database unavailable'
+
+    await expect(loadAiAgentConfig(accountId)).rejects.toThrow(
+      'AI agent config lookup failed: database unavailable',
+    )
+  })
+})
+
+describe('shouldRunAiAgent', () => {
+  it('skips when the account has no agent config', async () => {
+    await expect(shouldRunAiAgent(input())).resolves.toEqual({
+      shouldRun: false,
+      reason: 'missing_config',
+      agent: null,
+      state: null,
+    })
+  })
+
+  it('skips when the agent is disabled', async () => {
+    h.state.agent = agent({ enabled: false })
+
+    await expect(shouldRunAiAgent(input())).resolves.toMatchObject({
+      shouldRun: false,
+      reason: 'agent_disabled',
+      agent: h.state.agent,
+      state: null,
+    })
+  })
+
+  it('surfaces a conversation state lookup failure', async () => {
+    h.state.agent = agent()
+    h.state.errors.ai_conversation_states = 'database unavailable'
+
+    await expect(shouldRunAiAgent(input())).rejects.toThrow(
+      'AI conversation state lookup failed: database unavailable',
+    )
+  })
+
+  it.each([
+    ['paused', 'conversation_paused'],
+    ['handoff', 'conversation_handoff'],
+    ['disabled', 'conversation_disabled'],
+  ] as const)('skips a %s conversation', async (status, reason) => {
+    h.state.agent = agent()
+    h.state.state = conversationState({ status })
+
+    await expect(shouldRunAiAgent(input())).resolves.toMatchObject({
+      shouldRun: false,
+      reason,
+      agent: h.state.agent,
+      state: h.state.state,
+    })
+  })
+
+  it('skips an inbound message with an existing run', async () => {
+    h.state.agent = agent()
+    h.state.state = conversationState()
+    h.state.run = agentRun()
+
+    await expect(shouldRunAiAgent(input())).resolves.toMatchObject({
+      shouldRun: false,
+      reason: 'duplicate_inbound',
+      agent: h.state.agent,
+      state: h.state.state,
+    })
+  })
+
+  it('surfaces an AI run lookup failure', async () => {
+    h.state.agent = agent()
+    h.state.errors.ai_agent_runs = 'database unavailable'
+
+    await expect(shouldRunAiAgent(input())).rejects.toThrow(
+      'AI run lookup failed: database unavailable',
+    )
+  })
+
+  it('skips while the conversation is inside the configured cooldown', async () => {
+    h.state.agent = agent({ cooldown_seconds: 60 })
+    h.state.state = conversationState({ last_run_at: '2026-07-17T12:00:30.000Z' })
+
+    await expect(shouldRunAiAgent(input({ now: new Date('2026-07-17T12:01:00.000Z') }))).resolves.toMatchObject({
+      shouldRun: false,
+      reason: 'cooldown_active',
+      agent: h.state.agent,
+      state: h.state.state,
+    })
+  })
+
+  it('runs when the agent is enabled and no gate blocks the conversation', async () => {
+    h.state.agent = agent({ cooldown_seconds: 60 })
+    h.state.state = conversationState({ last_run_at: '2026-07-17T12:00:00.000Z' })
+
+    await expect(shouldRunAiAgent(input({ now: new Date('2026-07-17T12:01:00.000Z') }))).resolves.toEqual({
+      shouldRun: true,
+      agent: h.state.agent,
+      state: h.state.state,
+    })
+
+    expect(queryFor('ai_agents').filters).toContainEqual(['account_id', accountId])
+    expect(queryFor('ai_conversation_states').filters).toEqual(expect.arrayContaining([
+      ['account_id', accountId],
+      ['conversation_id', conversationId],
+    ]))
+    expect(queryFor('ai_agent_runs').filters).toEqual(expect.arrayContaining([
+      ['account_id', accountId],
+      ['conversation_id', conversationId],
+      ['inbound_message_id', inboundMessageId],
+    ]))
+    expect(queryFor('ai_agent_runs').limit).toBe(1)
+  })
+})
+
+function input(overrides: Partial<Parameters<typeof shouldRunAiAgent>[0]> = {}) {
+  return { accountId, conversationId, inboundMessageId, ...overrides }
+}
+
+function queryFor(table: string) {
+  const query = h.state.queries.find((item) => item.table === table)
+  if (!query) throw new Error(`Expected query for ${table}`)
+  return query
+}
+
+function agent(overrides: Partial<AiAgent> = {}): AiAgent {
+  return {
+    id: 'agent-1',
+    account_id: accountId,
+    user_id: 'user-1',
+    name: 'Support agent',
+    enabled: true,
+    model_provider: 'openai',
+    model_name: 'gpt-5-mini',
+    instructions: 'Help the customer.',
+    auto_reply: true,
+    auto_move_deals: false,
+    handoff_keywords: [],
+    max_messages: 10,
+    cooldown_seconds: 0,
+    created_at: '2026-07-17T12:00:00.000Z',
+    updated_at: '2026-07-17T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function conversationState(overrides: Partial<AiConversationState> = {}): AiConversationState {
+  return {
+    id: 'state-1',
+    account_id: accountId,
+    conversation_id: conversationId,
+    ai_agent_id: 'agent-1',
+    status: 'active',
+    last_inbound_message_id: null,
+    last_run_at: null,
+    paused_reason: null,
+    created_at: '2026-07-17T12:00:00.000Z',
+    updated_at: '2026-07-17T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function agentRun(overrides: Partial<AiAgentRun> = {}): AiAgentRun {
+  return {
+    id: 'run-1',
+    account_id: accountId,
+    ai_agent_id: 'agent-1',
+    conversation_id: conversationId,
+    inbound_message_id: inboundMessageId,
+    status: 'queued',
+    decision: null,
+    error_message: null,
+    started_at: null,
+    finished_at: null,
+    created_at: '2026-07-17T12:00:00.000Z',
+    ...overrides,
+  }
+}

--- a/src/lib/ai-agent/config.ts
+++ b/src/lib/ai-agent/config.ts
@@ -1,0 +1,99 @@
+import type { AiAgent, AiConversationState } from '@/types'
+import { supabaseAdmin } from '../flows/admin-client'
+
+export type AiAgentSkipReason =
+  | 'missing_config'
+  | 'agent_disabled'
+  | 'conversation_paused'
+  | 'conversation_handoff'
+  | 'conversation_disabled'
+  | 'duplicate_inbound'
+  | 'cooldown_active'
+  | 'rate_limited'
+  | 'provider_unavailable'
+
+export type AiAgentEligibility =
+  | { shouldRun: true; agent: AiAgent; state: AiConversationState | null }
+  | {
+      shouldRun: false
+      reason: AiAgentSkipReason
+      agent: AiAgent | null
+      state: AiConversationState | null
+    }
+
+export interface ShouldRunAiAgentInput {
+  accountId: string
+  conversationId: string
+  inboundMessageId: string
+  now?: Date
+}
+
+export async function loadAiAgentConfig(accountId: string): Promise<AiAgent | null> {
+  const { data, error } = await supabaseAdmin()
+    .from('ai_agents')
+    .select('*')
+    .eq('account_id', accountId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`AI agent config lookup failed: ${error.message}`)
+  }
+
+  return data as AiAgent | null
+}
+
+export async function shouldRunAiAgent(
+  input: ShouldRunAiAgentInput,
+): Promise<AiAgentEligibility> {
+  const agent = await loadAiAgentConfig(input.accountId)
+  if (!agent) return skipped('missing_config', null, null)
+  if (!agent.enabled) return skipped('agent_disabled', agent, null)
+
+  const { data: rawState, error: stateError } = await supabaseAdmin()
+    .from('ai_conversation_states')
+    .select('*')
+    .eq('account_id', input.accountId)
+    .eq('conversation_id', input.conversationId)
+    .maybeSingle()
+
+  if (stateError) {
+    throw new Error(`AI conversation state lookup failed: ${stateError.message}`)
+  }
+
+  const state = rawState as AiConversationState | null
+  if (state?.status === 'paused') return skipped('conversation_paused', agent, state)
+  if (state?.status === 'handoff') return skipped('conversation_handoff', agent, state)
+  if (state?.status === 'disabled') return skipped('conversation_disabled', agent, state)
+
+  const { data: existingRun, error: runError } = await supabaseAdmin()
+    .from('ai_agent_runs')
+    .select('*')
+    .eq('account_id', input.accountId)
+    .eq('conversation_id', input.conversationId)
+    .eq('inbound_message_id', input.inboundMessageId)
+    .limit(1)
+    .maybeSingle()
+
+  if (runError) {
+    throw new Error(`AI run lookup failed: ${runError.message}`)
+  }
+
+  if (existingRun) return skipped('duplicate_inbound', agent, state)
+
+  if (state?.last_run_at) {
+    const elapsedMs = (input.now ?? new Date()).getTime() - new Date(state.last_run_at).getTime()
+    if (elapsedMs < agent.cooldown_seconds * 1000) {
+      return skipped('cooldown_active', agent, state)
+    }
+  }
+
+  return { shouldRun: true, agent, state }
+}
+
+function skipped(
+  reason: AiAgentSkipReason,
+  agent: AiAgent | null,
+  state: AiConversationState | null,
+): AiAgentEligibility {
+  return { shouldRun: false, reason, agent, state }
+}

--- a/src/lib/ai-agent/context.test.ts
+++ b/src/lib/ai-agent/context.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Row = Record<string, unknown>
+type Query = {
+  table: string
+  filters: Array<[column: string, operator: 'eq' | 'in', value: unknown]>
+  orders: Array<{ column: string; ascending: boolean }>
+  limit?: number
+  select?: string
+}
+
+const h = vi.hoisted(() => ({
+  state: {
+    rows: {} as Record<string, Row[]>,
+    errors: {} as Record<string, string | undefined>,
+    queries: [] as Query[],
+  },
+}))
+
+vi.mock('../flows/admin-client', () => {
+  function builder(table: string) {
+    const query: Query = { table, filters: [], orders: [] }
+
+    const result = () => {
+      const errorMessage = h.state.errors[table]
+      let rows = [...(h.state.rows[table] ?? [])]
+
+      for (const [column, operator, value] of query.filters) {
+        rows = rows.filter((row) => operator === 'eq'
+          ? row[column] === value
+          : (value as unknown[]).includes(row[column]))
+      }
+
+      for (const { column, ascending } of query.orders) {
+        rows.sort((left, right) => {
+          const comparison = String(left[column] ?? '').localeCompare(String(right[column] ?? ''))
+          return ascending ? comparison : -comparison
+        })
+      }
+
+      if (query.limit !== undefined) rows = rows.slice(0, query.limit)
+      h.state.queries.push({ ...query, filters: [...query.filters], orders: [...query.orders] })
+
+      return { data: rows, error: errorMessage ? { message: errorMessage } : null }
+    }
+
+    const client = {
+      select: (value: string) => {
+        query.select = value
+        return client
+      },
+      eq: (column: string, value: unknown) => {
+        query.filters.push([column, 'eq', value])
+        return client
+      },
+      in: (column: string, value: unknown[]) => {
+        query.filters.push([column, 'in', value])
+        return client
+      },
+      order: (column: string, options?: { ascending?: boolean }) => {
+        query.orders.push({ column, ascending: options?.ascending ?? true })
+        return client
+      },
+      limit: (value: number) => {
+        query.limit = value
+        return client
+      },
+      maybeSingle: async () => {
+        const { data, error } = result()
+        return { data: data[0] ?? null, error }
+      },
+      then: (resolve: (value: ReturnType<typeof result>) => unknown) => Promise.resolve(result()).then(resolve),
+    }
+
+    return client
+  }
+
+  return { supabaseAdmin: () => ({ from: builder }) }
+})
+
+import { buildAiAgentContext } from './context'
+
+const accountId = 'account-1'
+const conversationId = 'conversation-1'
+const contactId = 'contact-1'
+
+beforeEach(() => {
+  h.state.rows = {
+    conversations: [conversation()],
+    messages: [
+      message({ id: 'message-3', created_at: '2026-07-17T12:03:00.000Z' }),
+      message({ id: 'message-1', created_at: '2026-07-17T12:01:00.000Z' }),
+      message({ id: 'other-account-message', conversation_id: 'other-conversation' }),
+    ],
+    deals: [],
+    pipelines: [],
+    pipeline_stages: [],
+  }
+  h.state.errors = {}
+  h.state.queries = []
+})
+
+describe('buildAiAgentContext', () => {
+  it('scopes the conversation lookup by account and id and returns no unrelated rows', async () => {
+    h.state.rows.conversations.push(conversation({ id: 'other-conversation', account_id: 'other-account' }))
+
+    const context = await buildAiAgentContext(input())
+
+    expect(queryFor('conversations').filters).toEqual(expect.arrayContaining([
+      ['account_id', 'eq', accountId],
+      ['id', 'eq', conversationId],
+    ]))
+    expect(queryFor('conversations').select).toContain('contact:contacts(id, phone, name, email, company)')
+    expect(context.conversation.id).toBe(conversationId)
+    expect(context.messages).not.toContainEqual(expect.objectContaining({ id: 'other-account-message' }))
+  })
+
+  it('loads messages newest first from the database but returns them oldest-to-newest within maxMessages', async () => {
+    h.state.rows.messages.push(message({ id: 'message-2', created_at: '2026-07-17T12:02:00.000Z' }))
+
+    const context = await buildAiAgentContext(input({ maxMessages: 2 }))
+
+    expect(queryFor('messages').orders).toContainEqual({ column: 'created_at', ascending: false })
+    expect(queryFor('messages').limit).toBe(2)
+    expect(context.messages.map((item) => item.id)).toEqual(['message-2', 'message-3'])
+  })
+
+  it('uses at least one message when maxMessages is zero', async () => {
+    await buildAiAgentContext(input({ maxMessages: 0 }))
+
+    expect(queryFor('messages').limit).toBe(1)
+  })
+
+  it('prefers a conversation-linked active deal over the contact fallback', async () => {
+    h.state.rows.deals = [
+      deal({ id: 'contact-deal', conversation_id: null }),
+      deal({ id: 'conversation-deal', conversation_id: conversationId }),
+    ]
+
+    const context = await buildAiAgentContext(input())
+
+    expect(context.activeDeal?.id).toBe('conversation-deal')
+    expect(queriesFor('deals')).toHaveLength(1)
+    expect(queryFor('deals').filters).toContainEqual(['conversation_id', 'eq', conversationId])
+  })
+
+  it('uses a contact-linked active deal when no conversation-linked active deal exists', async () => {
+    h.state.rows.deals = [deal({ id: 'contact-deal', conversation_id: null })]
+
+    const context = await buildAiAgentContext(input())
+
+    expect(context.activeDeal?.id).toBe('contact-deal')
+    expect(queriesFor('deals')).toHaveLength(2)
+    expect(queriesFor('deals')[1].filters).toEqual(expect.arrayContaining([
+      ['account_id', 'eq', accountId],
+      ['contact_id', 'eq', contactId],
+      ['status', 'in', ['open', 'active']],
+    ]))
+  })
+
+  it('returns pipelines with their stages grouped and sorted by position', async () => {
+    h.state.rows.pipelines = [
+      pipeline({ id: 'pipeline-2', name: 'Sales', created_at: '2026-07-17T12:02:00.000Z' }),
+      pipeline({ id: 'pipeline-1', name: 'Support', created_at: '2026-07-17T12:01:00.000Z' }),
+    ]
+    h.state.rows.pipeline_stages = [
+      stage({ id: 'stage-2', pipeline_id: 'pipeline-1', position: 2 }),
+      stage({ id: 'stage-1', pipeline_id: 'pipeline-1', position: 1 }),
+      stage({ id: 'stage-3', pipeline_id: 'pipeline-2', position: 1 }),
+      stage({ id: 'other-stage', pipeline_id: 'other-pipeline', position: 1 }),
+    ]
+
+    const context = await buildAiAgentContext(input())
+
+    expect(context.pipelines).toEqual([
+      expect.objectContaining({ id: 'pipeline-1', stages: [expect.objectContaining({ id: 'stage-1' }), expect.objectContaining({ id: 'stage-2' })] }),
+      expect.objectContaining({ id: 'pipeline-2', stages: [expect.objectContaining({ id: 'stage-3' })] }),
+    ])
+    expect(queryFor('pipeline_stages').filters).toContainEqual(['pipeline_id', 'in', ['pipeline-1', 'pipeline-2']])
+  })
+
+  it('does not query stages when the account has no pipelines', async () => {
+    const context = await buildAiAgentContext(input())
+
+    expect(context.pipelines).toEqual([])
+    expect(queriesFor('pipeline_stages')).toHaveLength(0)
+  })
+
+  it.each([
+    ['conversations', 'AI conversation context lookup failed: database unavailable'],
+    ['messages', 'AI message context lookup failed: database unavailable'],
+    ['deals', 'AI deal context lookup failed: database unavailable'],
+    ['pipelines', 'AI pipeline context lookup failed: database unavailable'],
+    ['pipeline_stages', 'AI pipeline stage context lookup failed: database unavailable'],
+  ])('throws the required error for %s lookup failures', async (table, expected) => {
+    if (table === 'pipeline_stages') h.state.rows.pipelines = [pipeline()]
+    h.state.errors[table] = 'database unavailable'
+
+    await expect(buildAiAgentContext(input())).rejects.toThrow(expected)
+  })
+
+  it('throws when the scoped conversation does not exist', async () => {
+    h.state.rows.conversations = [conversation({ id: 'other-conversation' })]
+
+    await expect(buildAiAgentContext(input())).rejects.toThrow('AI conversation context not found')
+  })
+})
+
+function input(overrides: Partial<Parameters<typeof buildAiAgentContext>[0]> = {}) {
+  return { accountId, conversationId, maxMessages: 10, ...overrides }
+}
+
+function queryFor(table: string) {
+  const query = queriesFor(table)[0]
+  if (!query) throw new Error(`Expected query for ${table}`)
+  return query
+}
+
+function queriesFor(table: string) {
+  return h.state.queries.filter((query) => query.table === table)
+}
+
+function conversation(overrides: Row = {}): Row {
+  return {
+    id: conversationId,
+    account_id: accountId,
+    contact_id: contactId,
+    status: 'open',
+    assigned_agent_id: null,
+    last_message_text: 'Hello',
+    last_message_at: '2026-07-17T12:03:00.000Z',
+    created_at: '2026-07-17T12:00:00.000Z',
+    updated_at: '2026-07-17T12:03:00.000Z',
+    contact: { id: contactId, phone: '+5511999999999', name: 'Ada', email: 'ada@example.com', company: 'Acme' },
+    ...overrides,
+  }
+}
+
+function message(overrides: Row = {}): Row {
+  return {
+    id: 'message-1',
+    conversation_id: conversationId,
+    sender_type: 'customer',
+    content_type: 'text',
+    content_text: 'Hello',
+    media_url: null,
+    message_id: null,
+    created_at: '2026-07-17T12:01:00.000Z',
+    ...overrides,
+  }
+}
+
+function deal(overrides: Row = {}): Row {
+  return {
+    id: 'deal-1',
+    account_id: accountId,
+    pipeline_id: 'pipeline-1',
+    stage_id: 'stage-1',
+    contact_id: contactId,
+    conversation_id: conversationId,
+    title: 'Expansion',
+    value: 1250,
+    currency: 'BRL',
+    expected_close_date: null,
+    status: 'open',
+    created_at: '2026-07-17T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function pipeline(overrides: Row = {}): Row {
+  return { id: 'pipeline-1', account_id: accountId, name: 'Support', created_at: '2026-07-17T12:00:00.000Z', ...overrides }
+}
+
+function stage(overrides: Row = {}): Row {
+  return { id: 'stage-1', pipeline_id: 'pipeline-1', name: 'New', position: 1, color: '#00aa00', ...overrides }
+}

--- a/src/lib/ai-agent/context.ts
+++ b/src/lib/ai-agent/context.ts
@@ -1,0 +1,206 @@
+import type { ContentType, ConversationStatus, DealStatus, SenderType } from '@/types'
+import { supabaseAdmin } from '../flows/admin-client'
+
+export interface BuildAiAgentContextInput {
+  accountId: string
+  conversationId: string
+  maxMessages: number
+}
+
+export interface AiAgentContextMessage {
+  id: string
+  sender_type: SenderType
+  content_type: ContentType
+  content_text: string | null
+  media_url: string | null
+  message_id: string | null
+  created_at: string
+}
+
+export interface AiAgentContextContact {
+  id: string
+  phone: string
+  name: string | null
+  email: string | null
+  company: string | null
+}
+
+export interface AiAgentContextConversation {
+  id: string
+  status: ConversationStatus
+  assigned_agent_id: string | null
+  last_message_text: string | null
+  last_message_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface AiAgentContextDeal {
+  id: string
+  pipeline_id: string
+  stage_id: string
+  contact_id: string | null
+  conversation_id: string | null
+  title: string
+  value: number
+  currency: string | null
+  expected_close_date: string | null
+  status: DealStatus | 'active'
+}
+
+export interface AiAgentContextPipelineStage {
+  id: string
+  name: string
+  position: number
+  color: string
+}
+
+export interface AiAgentContextPipeline {
+  id: string
+  name: string
+  stages: AiAgentContextPipelineStage[]
+}
+
+export interface AiAgentContext {
+  conversation: AiAgentContextConversation
+  contact: AiAgentContextContact | null
+  messages: AiAgentContextMessage[]
+  activeDeal: AiAgentContextDeal | null
+  pipelines: AiAgentContextPipeline[]
+}
+
+type ConversationRow = AiAgentContextConversation & {
+  contact_id: string | null
+  contact: AiAgentContextContact | AiAgentContextContact[] | null
+}
+
+export async function buildAiAgentContext(
+  input: BuildAiAgentContextInput,
+): Promise<AiAgentContext> {
+  const db = supabaseAdmin()
+  const { data: conversationData, error: conversationError } = await db
+    .from('conversations')
+    .select('id, contact_id, status, assigned_agent_id, last_message_text, last_message_at, created_at, updated_at, contact:contacts(id, phone, name, email, company)')
+    .eq('account_id', input.accountId)
+    .eq('id', input.conversationId)
+    .maybeSingle()
+
+  if (conversationError) {
+    throw new Error(`AI conversation context lookup failed: ${conversationError.message}`)
+  }
+  if (!conversationData) throw new Error('AI conversation context not found')
+
+  const conversationRow = conversationData as unknown as ConversationRow
+  const contact = Array.isArray(conversationRow.contact)
+    ? conversationRow.contact[0] ?? null
+    : conversationRow.contact
+  const conversation: AiAgentContextConversation = {
+    id: conversationRow.id,
+    status: conversationRow.status,
+    assigned_agent_id: conversationRow.assigned_agent_id,
+    last_message_text: conversationRow.last_message_text,
+    last_message_at: conversationRow.last_message_at,
+    created_at: conversationRow.created_at,
+    updated_at: conversationRow.updated_at,
+  }
+  const { data: messageData, error: messageError } = await db
+    .from('messages')
+    .select('id, sender_type, content_type, content_text, media_url, message_id, created_at')
+    .eq('conversation_id', input.conversationId)
+    .order('created_at', { ascending: false })
+    .limit(Math.max(1, input.maxMessages))
+
+  if (messageError) {
+    throw new Error(`AI message context lookup failed: ${messageError.message}`)
+  }
+
+  const activeDeal = await loadActiveDeal(db, input.accountId, input.conversationId, conversationRow.contact_id)
+  const pipelines = await loadPipelines(db, input.accountId)
+
+  return {
+    conversation: conversation,
+    contact,
+    messages: ((messageData ?? []) as AiAgentContextMessage[]).reverse(),
+    activeDeal,
+    pipelines,
+  }
+}
+
+async function loadActiveDeal(
+  db: ReturnType<typeof supabaseAdmin>,
+  accountId: string,
+  conversationId: string,
+  contactId: string | null,
+): Promise<AiAgentContextDeal | null> {
+  const { data: conversationDeal, error: conversationDealError } = await db
+    .from('deals')
+    .select('id, pipeline_id, stage_id, contact_id, conversation_id, title, value, currency, expected_close_date, status')
+    .eq('account_id', accountId)
+    .eq('conversation_id', conversationId)
+    .in('status', ['open', 'active'])
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (conversationDealError) {
+    throw new Error(`AI deal context lookup failed: ${conversationDealError.message}`)
+  }
+  if (conversationDeal || !contactId) return conversationDeal as AiAgentContextDeal | null
+
+  const { data: contactDeal, error: contactDealError } = await db
+    .from('deals')
+    .select('id, pipeline_id, stage_id, contact_id, conversation_id, title, value, currency, expected_close_date, status')
+    .eq('account_id', accountId)
+    .eq('contact_id', contactId)
+    .in('status', ['open', 'active'])
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (contactDealError) {
+    throw new Error(`AI deal context lookup failed: ${contactDealError.message}`)
+  }
+
+  return contactDeal as AiAgentContextDeal | null
+}
+
+async function loadPipelines(
+  db: ReturnType<typeof supabaseAdmin>,
+  accountId: string,
+): Promise<AiAgentContextPipeline[]> {
+  const { data: pipelineData, error: pipelineError } = await db
+    .from('pipelines')
+    .select('id, name')
+    .eq('account_id', accountId)
+    .order('created_at', { ascending: true })
+
+  if (pipelineError) {
+    throw new Error(`AI pipeline context lookup failed: ${pipelineError.message}`)
+  }
+
+  const pipelines = (pipelineData ?? []) as Array<Omit<AiAgentContextPipeline, 'stages'>>
+  if (pipelines.length === 0) return []
+
+  const pipelineIds = pipelines.map((pipeline) => pipeline.id)
+  const { data: stageData, error: stageError } = await db
+    .from('pipeline_stages')
+    .select('id, pipeline_id, name, position, color')
+    .in('pipeline_id', pipelineIds)
+    .order('position', { ascending: true })
+
+  if (stageError) {
+    throw new Error(`AI pipeline stage context lookup failed: ${stageError.message}`)
+  }
+
+  const stagesByPipeline = new Map<string, AiAgentContextPipelineStage[]>()
+  for (const stage of (stageData ?? []) as Array<AiAgentContextPipelineStage & { pipeline_id: string }>) {
+    const stages = stagesByPipeline.get(stage.pipeline_id) ?? []
+    stages.push(stage)
+    stagesByPipeline.set(stage.pipeline_id, stages)
+  }
+
+  return pipelines.map((pipeline) => ({
+    ...pipeline,
+    stages: stagesByPipeline.get(pipeline.id) ?? [],
+  }))
+}

--- a/src/lib/ai-agent/decision.test.ts
+++ b/src/lib/ai-agent/decision.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AiAgentDecisionValidationError,
+  buildAiAgentDecisionMessages,
+  getAiAgentMaxOutputTokens,
+  parseAiAgentDecisionJson,
+  requestAiAgentDecision,
+  validateAiAgentDecision,
+} from './decision'
+
+describe('getAiAgentMaxOutputTokens', () => {
+  it.each([
+    [undefined, 700],
+    ['', 700],
+    ['not-a-number', 700],
+    ['127', 128],
+    ['700', 700],
+    ['2001', 2000],
+  ])('uses the default and clamps configured output tokens', (value, expected) => {
+    expect(getAiAgentMaxOutputTokens(value)).toBe(expected)
+  })
+  it('reads the configured output budget from the environment', () => {
+    vi.stubEnv('AI_AGENT_MAX_OUTPUT_TOKENS', '2048')
+    expect(getAiAgentMaxOutputTokens()).toBe(2000)
+    vi.unstubAllEnvs()
+  })
+})
+
+describe('parseAiAgentDecisionJson', () => {
+  it.each(['', '{', 'not json'])('throws invalid_json for malformed JSON', (raw) => {
+    expectInvalidJson(() => parseAiAgentDecisionJson(raw))
+  })
+})
+
+describe('validateAiAgentDecision', () => {
+  it('normalizes valid reply, no_reply, and handoff decisions', () => {
+    expect(validateAiAgentDecision({
+      action: 'reply',
+      text: '  Hello there  ',
+      confidence: 0.8,
+      deal_action: { type: 'create', pipeline_id: ' pipeline-1 ', stage_id: ' stage-1 ', title: ' New deal ', value: 0 },
+      ignored: true,
+    })).toEqual({
+      action: 'reply',
+      text: 'Hello there',
+      confidence: 0.8,
+      deal_action: { type: 'create', pipeline_id: 'pipeline-1', stage_id: 'stage-1', title: 'New deal', value: 0 },
+    })
+
+    expect(validateAiAgentDecision({
+      action: 'no_reply',
+      reason: '  Waiting for customer  ',
+      confidence: 1,
+      deal_action: { type: 'none', ignored: true },
+    })).toEqual({
+      action: 'no_reply',
+      reason: 'Waiting for customer',
+      confidence: 1,
+      deal_action: { type: 'none' },
+    })
+
+    expect(validateAiAgentDecision({ action: 'handoff', reason: '  Needs specialist  ', confidence: 0 })).toEqual({
+      action: 'handoff',
+      reason: 'Needs specialist',
+      confidence: 0,
+    })
+  })
+
+  it.each([
+    { action: 'unknown', confidence: 0.5 },
+    { action: 'reply', text: 'Hello', confidence: undefined },
+    { action: 'reply', text: 'Hello', confidence: Number.NaN },
+    { action: 'reply', text: 'Hello', confidence: 1.1 },
+    { action: 'reply', text: '   ', confidence: 0.5 },
+    { action: 'no_reply', reason: '', confidence: 0.5 },
+    { action: 'handoff', reason: 1, confidence: 0.5 },
+    { action: 'handoff', reason: 'Human needed', confidence: 0.5, deal_action: { type: 'none' } },
+  ])('rejects an invalid top-level decision %#', (value) => {
+    expectInvalidDecision(() => validateAiAgentDecision(value))
+  })
+
+  it.each([
+    { type: 'create', pipeline_id: '', stage_id: 'stage-1', title: 'Deal' },
+    { type: 'create', pipeline_id: 'pipeline-1', stage_id: ' ', title: 'Deal' },
+    { type: 'create', pipeline_id: 'pipeline-1', stage_id: 'stage-1', title: '', value: -1 },
+    { type: 'create', pipeline_id: 'pipeline-1', stage_id: 'stage-1', title: 'Deal', value: Number.POSITIVE_INFINITY },
+    { type: 'move', deal_id: '', stage_id: 'stage-1', reason: 'Qualified' },
+    { type: 'move', deal_id: 'deal-1', stage_id: '', reason: 'Qualified' },
+    { type: 'move', deal_id: 'deal-1', stage_id: 'stage-1', reason: ' ' },
+    { type: 'update', deal_id: '', title: 'New title' },
+    { type: 'update', deal_id: 'deal-1' },
+    { type: 'update', deal_id: 'deal-1', title: ' ' },
+    { type: 'update', deal_id: 'deal-1', value: -1 },
+    { type: 'update', deal_id: 'deal-1', expected_close_date: '2026/07/17' },
+    { type: 'unexpected' },
+  ])('rejects an invalid deal action %#', (deal_action) => {
+    expectInvalidDecision(() => validateAiAgentDecision({
+      action: 'reply',
+      text: 'Hello',
+      confidence: 0.5,
+      deal_action,
+    }))
+  })
+
+  it('normalizes valid move and update deal actions and strips unknown fields', () => {
+    expect(validateAiAgentDecision({
+      action: 'no_reply',
+      reason: '  Moved automatically ',
+      confidence: 0.5,
+      deal_action: { type: 'move', deal_id: ' deal-1 ', stage_id: ' stage-2 ', reason: '  Qualified ', extra: 'remove' },
+      extra: 'remove',
+    })).toEqual({
+      action: 'no_reply',
+      reason: 'Moved automatically',
+      confidence: 0.5,
+      deal_action: { type: 'move', deal_id: 'deal-1', stage_id: 'stage-2', reason: 'Qualified' },
+    })
+
+    expect(validateAiAgentDecision({
+      action: 'reply',
+      text: 'Updated.',
+      confidence: 0.5,
+      deal_action: {
+        type: 'update', deal_id: ' deal-1 ', title: ' Renewal ', value: 123.45,
+        expected_close_date: '2026-12-31', ignored: true,
+      },
+    })).toEqual({
+      action: 'reply',
+      text: 'Updated.',
+      confidence: 0.5,
+      deal_action: {
+        type: 'update', deal_id: 'deal-1', title: 'Renewal', value: 123.45, expected_close_date: '2026-12-31',
+      },
+    })
+  })
+})
+
+describe('buildAiAgentDecisionMessages', () => {
+  it('places instructions in the strict JSON system prompt and context in the user prompt', () => {
+    const messages = buildAiAgentDecisionMessages({
+      instructions: 'Escalate pricing questions.',
+      context: { conversation: { id: 'conversation-1' } },
+    })
+
+    expect(messages.system).toContain('Escalate pricing questions.')
+    expect(messages.system).toContain('strict JSON')
+    expect(messages.user).toContain(JSON.stringify({ conversation: { id: 'conversation-1' } }, null, 2))
+  })
+})
+
+describe('requestAiAgentDecision', () => {
+  it('passes model and built messages to the provider and returns the parsed decision', async () => {
+    const complete = vi.fn().mockResolvedValue(JSON.stringify({
+      action: 'reply', text: '  Hello  ', confidence: 0.9,
+    }))
+
+    await expect(requestAiAgentDecision({
+      model: 'test-model',
+      instructions: 'Be helpful.',
+      context: { id: 'conversation-1' },
+      provider: { complete },
+      maxOutputTokens: 512,
+    })).resolves.toEqual({ action: 'reply', text: 'Hello', confidence: 0.9 })
+
+    expect(complete).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'test-model',
+      system: expect.stringContaining('Be helpful.'),
+      user: expect.stringContaining('"conversation-1"'),
+      maxOutputTokens: 512,
+    }))
+  })
+})
+
+function expectInvalidJson(run: () => unknown) {
+  expect(run).toThrow(AiAgentDecisionValidationError)
+  try {
+    run()
+  } catch (error) {
+    expect(error).toMatchObject({ code: 'invalid_json' })
+  }
+}
+
+function expectInvalidDecision(run: () => unknown) {
+  expect(run).toThrow(AiAgentDecisionValidationError)
+  try {
+    run()
+  } catch (error) {
+    expect(error).toMatchObject({ code: 'invalid_decision' })
+  }
+}

--- a/src/lib/ai-agent/decision.ts
+++ b/src/lib/ai-agent/decision.ts
@@ -1,0 +1,194 @@
+export type AiAgentDecision =
+  | { action: 'reply'; text: string; deal_action?: DealAction; confidence: number }
+  | { action: 'no_reply'; reason: string; deal_action?: DealAction; confidence: number }
+  | { action: 'handoff'; reason: string; confidence: number }
+
+export type DealAction =
+  | { type: 'none' }
+  | { type: 'create'; pipeline_id: string; stage_id: string; title: string; value?: number }
+  | { type: 'move'; deal_id: string; stage_id: string; reason: string }
+  | { type: 'update'; deal_id: string; title?: string; value?: number; expected_close_date?: string }
+
+export class AiAgentDecisionValidationError extends Error {
+  readonly code: 'invalid_json' | 'invalid_decision'
+
+  constructor(code: 'invalid_json' | 'invalid_decision', message: string) {
+    super(message)
+    this.name = 'AiAgentDecisionValidationError'
+    this.code = code
+  }
+}
+
+export interface AiAgentDecisionProvider {
+  complete(input: { model: string; system: string; user: string; maxOutputTokens?: number }): Promise<string>
+}
+
+export interface RequestAiAgentDecisionInput {
+  model: string
+  instructions: string
+  context: unknown
+  provider: AiAgentDecisionProvider
+  maxOutputTokens?: number
+}
+
+const DEFAULT_AI_AGENT_MAX_OUTPUT_TOKENS = 700
+const MIN_AI_AGENT_MAX_OUTPUT_TOKENS = 128
+const MAX_AI_AGENT_MAX_OUTPUT_TOKENS = 2_000
+
+export function getAiAgentMaxOutputTokens(value = process.env.AI_AGENT_MAX_OUTPUT_TOKENS): number {
+  const normalized = value?.trim()
+  if (!normalized) return DEFAULT_AI_AGENT_MAX_OUTPUT_TOKENS
+
+  const parsed = Number(normalized)
+  if (!Number.isFinite(parsed)) return DEFAULT_AI_AGENT_MAX_OUTPUT_TOKENS
+
+  return Math.min(
+    MAX_AI_AGENT_MAX_OUTPUT_TOKENS,
+    Math.max(MIN_AI_AGENT_MAX_OUTPUT_TOKENS, Math.trunc(parsed)),
+  )
+}
+
+export function parseAiAgentDecisionJson(raw: string): AiAgentDecision {
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    throw invalidJson()
+  }
+
+  return validateAiAgentDecision(value)
+}
+
+export function validateAiAgentDecision(value: unknown): AiAgentDecision {
+  if (!isRecord(value) || !isConfidence(value.confidence) || typeof value.action !== 'string') {
+    throw invalidDecision()
+  }
+
+  if (value.action === 'reply') {
+    const text = requiredString(value.text)
+    const deal_action = optionalDealAction(value.deal_action)
+    return deal_action
+      ? { action: 'reply', text, confidence: value.confidence, deal_action }
+      : { action: 'reply', text, confidence: value.confidence }
+  }
+
+  if (value.action === 'no_reply') {
+    const reason = requiredString(value.reason)
+    const deal_action = optionalDealAction(value.deal_action)
+    return deal_action
+      ? { action: 'no_reply', reason, confidence: value.confidence, deal_action }
+      : { action: 'no_reply', reason, confidence: value.confidence }
+  }
+
+  if (value.action === 'handoff') {
+    if ('deal_action' in value) throw invalidDecision()
+    return { action: 'handoff', reason: requiredString(value.reason), confidence: value.confidence }
+  }
+
+  throw invalidDecision()
+}
+
+export function buildAiAgentDecisionMessages(input: {
+  instructions: string
+  context: unknown
+}): { system: string; user: string } {
+  return {
+    system: `You are an AI inbox agent for a CRM. Return only strict JSON matching this decision schema, with no markdown or extra text.\n\n${input.instructions}\n\nSchema:\n- reply: { "action": "reply", "text": "non-empty string", "confidence": 0..1, "deal_action"?: deal action }\n- no_reply: { "action": "no_reply", "reason": "non-empty string", "confidence": 0..1, "deal_action"?: deal action }\n- handoff: { "action": "handoff", "reason": "non-empty string", "confidence": 0..1 }\n- deal action: { "type": "none" } | { "type": "create", "pipeline_id": "string", "stage_id": "string", "title": "string", "value"?: "non-negative number" } | { "type": "move", "deal_id": "string", "stage_id": "string", "reason": "string" } | { "type": "update", "deal_id": "string", "title"?: "string", "value"?: "non-negative number", "expected_close_date"?: "YYYY-MM-DD" }\n\nUse deal_action only for reply or no_reply. Handoff must not include deal_action.`,
+    user: `CRM context:\n${JSON.stringify(input.context, null, 2)}`,
+  }
+}
+
+export async function requestAiAgentDecision(input: RequestAiAgentDecisionInput): Promise<AiAgentDecision> {
+  const { system, user } = buildAiAgentDecisionMessages(input)
+  const raw = await input.provider.complete({
+    model: input.model,
+    system,
+    user,
+    maxOutputTokens: input.maxOutputTokens,
+  })
+  return parseAiAgentDecisionJson(raw)
+}
+
+function optionalDealAction(value: unknown): DealAction | undefined {
+  return value === undefined ? undefined : validateDealAction(value)
+}
+
+function validateDealAction(value: unknown): DealAction {
+  if (!isRecord(value) || typeof value.type !== 'string') throw invalidDecision()
+
+  if (value.type === 'none') return { type: 'none' }
+
+  if (value.type === 'create') {
+    const action: DealAction = {
+      type: 'create',
+      pipeline_id: requiredString(value.pipeline_id),
+      stage_id: requiredString(value.stage_id),
+      title: requiredString(value.title),
+    }
+    if (value.value !== undefined) {
+      if (!isNonNegativeNumber(value.value)) throw invalidDecision()
+      action.value = value.value
+    }
+    return action
+  }
+
+  if (value.type === 'move') {
+    return {
+      type: 'move',
+      deal_id: requiredString(value.deal_id),
+      stage_id: requiredString(value.stage_id),
+      reason: requiredString(value.reason),
+    }
+  }
+
+  if (value.type === 'update') {
+    const action: Extract<DealAction, { type: 'update' }> = {
+      type: 'update',
+      deal_id: requiredString(value.deal_id),
+    }
+    if (value.title !== undefined) action.title = requiredString(value.title)
+    if (value.value !== undefined) {
+      if (!isNonNegativeNumber(value.value)) throw invalidDecision()
+      action.value = value.value
+    }
+    if (value.expected_close_date !== undefined) {
+      if (typeof value.expected_close_date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value.expected_close_date)) {
+        throw invalidDecision()
+      }
+      action.expected_close_date = value.expected_close_date
+    }
+    if (action.title === undefined && action.value === undefined && action.expected_close_date === undefined) {
+      throw invalidDecision()
+    }
+    return action
+  }
+
+  throw invalidDecision()
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== 'string') throw invalidDecision()
+  const trimmed = value.trim()
+  if (!trimmed) throw invalidDecision()
+  return trimmed
+}
+
+function isConfidence(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function invalidJson(): AiAgentDecisionValidationError {
+  return new AiAgentDecisionValidationError('invalid_json', 'AI agent decision is not valid JSON')
+}
+
+function invalidDecision(): AiAgentDecisionValidationError {
+  return new AiAgentDecisionValidationError('invalid_decision', 'AI agent decision has an invalid shape')
+}

--- a/src/lib/ai-agent/providers.test.ts
+++ b/src/lib/ai-agent/providers.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createOpenAiResponsesProvider,
+  extractOpenAiOutputText,
+  resolveAiAgentDecisionProvider,
+} from './providers'
+import type { AiAgent } from '@/types'
+
+const agent: AiAgent = {
+  id: 'agent-1',
+  account_id: 'acct-1',
+  user_id: 'user-1',
+  name: 'AI',
+  enabled: true,
+  model_provider: 'openai',
+  model_name: 'gpt-5-mini',
+  instructions: 'Help.',
+  auto_reply: true,
+  auto_move_deals: true,
+  handoff_keywords: [],
+  max_messages: 12,
+  cooldown_seconds: 30,
+  created_at: '',
+  updated_at: '',
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.useRealTimers()
+})
+
+describe('resolveAiAgentDecisionProvider', () => {
+  it('returns an OpenAI provider only when the OpenAI key and provider are configured', () => {
+    vi.stubEnv('OPENAI_API_KEY', '')
+    expect(resolveAiAgentDecisionProvider(agent)).toBeNull()
+
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test-provider-key-123456')
+    expect(resolveAiAgentDecisionProvider(agent)).not.toBeNull()
+    expect(resolveAiAgentDecisionProvider({ ...agent, model_provider: 'other' })).toBeNull()
+  })
+})
+
+describe('createOpenAiResponsesProvider', () => {
+  it('calls the Responses API with model, input, and max_output_tokens', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ output_text: '{"action":"no_reply","reason":"ok","confidence":1}' }),
+    } as Response)
+    const provider = createOpenAiResponsesProvider({ apiKey: 'sk-test', fetchImpl })
+
+    await expect(provider.complete({
+      model: 'gpt-5-mini',
+      system: 'system prompt',
+      user: 'user prompt',
+      maxOutputTokens: 512,
+    })).resolves.toBe('{"action":"no_reply","reason":"ok","confidence":1}')
+
+    expect(fetchImpl).toHaveBeenCalledWith('https://api.openai.com/v1/responses', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer sk-test',
+        'Content-Type': 'application/json',
+      }),
+    }))
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toEqual(expect.objectContaining({
+      model: 'gpt-5-mini',
+      input: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'user prompt' },
+      ],
+      text: {
+        format: expect.objectContaining({
+          type: 'json_schema',
+          name: 'ai_agent_decision',
+        }),
+      },
+      max_output_tokens: 512,
+    }))
+  })
+
+  it('throws a sanitized provider error for HTTP failures', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, json: async () => ({ error: 'secret' }) } as Response)
+    const provider = createOpenAiResponsesProvider({ apiKey: 'sk-test', fetchImpl })
+
+    await expect(provider.complete({ model: 'gpt-5-mini', system: 'x', user: 'y' }))
+      .rejects.toThrow('AI provider request failed')
+  })
+
+  it('aborts stalled provider requests after the configured timeout', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn((_url: string | URL | Request, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+    }))
+    const provider = createOpenAiResponsesProvider({ apiKey: 'sk-test', fetchImpl, timeoutMs: 25 })
+    const request = provider.complete({ model: 'gpt-5-mini', system: 'x', user: 'y' })
+    const expectation = expect(request).rejects.toThrow('AI provider request failed')
+
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expectation
+    expect(fetchImpl).toHaveBeenCalledWith('https://api.openai.com/v1/responses', expect.objectContaining({
+      signal: expect.any(AbortSignal),
+    }))
+  })
+})
+
+describe('extractOpenAiOutputText', () => {
+  it('extracts output_text or concatenated output content text', () => {
+    expect(extractOpenAiOutputText({ output_text: 'direct' })).toBe('direct')
+    expect(extractOpenAiOutputText({
+      output: [
+        { content: [{ text: 'part 1' }, { text: ' part 2' }] },
+      ],
+    })).toBe('part 1 part 2')
+  })
+})

--- a/src/lib/ai-agent/providers.ts
+++ b/src/lib/ai-agent/providers.ts
@@ -1,0 +1,107 @@
+import type { AiAgent } from '@/types'
+
+import type { AiAgentDecisionProvider } from './decision'
+
+const OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses'
+const OPENAI_PROVIDER_ERROR_MESSAGE = 'AI provider request failed'
+const DEFAULT_OPENAI_PROVIDER_TIMEOUT_MS = 15_000
+const AI_AGENT_DECISION_RESPONSE_FORMAT = {
+  type: 'json_schema',
+  name: 'ai_agent_decision',
+  strict: false,
+  schema: {
+    type: 'object',
+    additionalProperties: true,
+    required: ['action', 'confidence'],
+    properties: {
+      action: { enum: ['reply', 'no_reply', 'handoff'] },
+      text: { type: 'string' },
+      reason: { type: 'string' },
+      confidence: { type: 'number', minimum: 0, maximum: 1 },
+      deal_action: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          type: { enum: ['none', 'create', 'move', 'update'] },
+        },
+      },
+    },
+  },
+} as const
+
+export function resolveAiAgentDecisionProvider(agent: AiAgent): AiAgentDecisionProvider | null {
+  if (agent.model_provider.trim().toLowerCase() !== 'openai') return null
+
+  const apiKey = process.env.OPENAI_API_KEY?.trim()
+  if (!apiKey) return null
+
+  return createOpenAiResponsesProvider({ apiKey })
+}
+
+export function createOpenAiResponsesProvider(input: {
+  apiKey: string
+  fetchImpl?: typeof fetch
+  timeoutMs?: number
+}): AiAgentDecisionProvider {
+  const fetchImpl = input.fetchImpl ?? fetch
+  const timeoutMs = input.timeoutMs ?? DEFAULT_OPENAI_PROVIDER_TIMEOUT_MS
+
+  return {
+    async complete(request) {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), timeoutMs)
+      try {
+        const response = await fetchImpl(OPENAI_RESPONSES_URL, {
+          method: 'POST',
+          signal: controller.signal,
+          headers: {
+            Authorization: `Bearer ${input.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: request.model,
+            input: [
+              { role: 'system', content: request.system },
+              { role: 'user', content: request.user },
+            ],
+            text: { format: AI_AGENT_DECISION_RESPONSE_FORMAT },
+            max_output_tokens: request.maxOutputTokens,
+          }),
+        })
+
+        if (!response.ok) throw new Error(OPENAI_PROVIDER_ERROR_MESSAGE)
+
+        const payload = await response.json()
+        const outputText = extractOpenAiOutputText(payload)
+        if (!outputText) throw new Error(OPENAI_PROVIDER_ERROR_MESSAGE)
+        return outputText
+      } catch {
+        throw new Error(OPENAI_PROVIDER_ERROR_MESSAGE)
+      } finally {
+        clearTimeout(timeout)
+      }
+    },
+  }
+}
+
+export function extractOpenAiOutputText(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') return ''
+  const record = payload as Record<string, unknown>
+  if (typeof record.output_text === 'string' && record.output_text.trim()) {
+    return record.output_text
+  }
+
+  const output = Array.isArray(record.output) ? record.output : []
+  const parts: string[] = []
+  for (const item of output) {
+    if (!item || typeof item !== 'object') continue
+    const content = (item as Record<string, unknown>).content
+    if (!Array.isArray(content)) continue
+    for (const part of content) {
+      if (!part || typeof part !== 'object') continue
+      const text = (part as Record<string, unknown>).text
+      if (typeof text === 'string') parts.push(text)
+    }
+  }
+  return parts.join('').trim()
+}

--- a/src/lib/ai-agent/run.test.ts
+++ b/src/lib/ai-agent/run.test.ts
@@ -1,0 +1,621 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  state: {
+    runInsertResult: null as null | { data: unknown; error: { message: string; code?: string } | null },
+    stateUpsertError: null as null | { message: string },
+    currentConversationState: null as null | { status: string },
+    currentConversationStates: [] as Array<null | { status: string; paused_reason?: string | null }>,
+  },
+  mocks: {
+    shouldRunAiAgent: vi.fn(),
+    buildAiAgentContext: vi.fn(),
+    requestAiAgentDecision: vi.fn(),
+    getAiAgentMaxOutputTokens: vi.fn(),
+    executeAiAgentDecision: vi.fn(),
+    createAsyncEventTrace: vi.fn(),
+    logAsyncEvent: vi.fn(),
+    logAsyncMetric: vi.fn(),
+    durationMs: vi.fn(),
+    errorFields: vi.fn(() => ({
+      error_name: 'Error',
+      error_message: 'AI agent run failed',
+    })),
+    checkRateLimit: vi.fn(),
+    resolveAiAgentDecisionProvider: vi.fn(),
+  },
+  calls: [] as Array<{ table: string; method: string; args: unknown[] }>,
+}));
+
+vi.mock('./config', () => ({ shouldRunAiAgent: h.mocks.shouldRunAiAgent }));
+vi.mock('./context', () => ({
+  buildAiAgentContext: h.mocks.buildAiAgentContext,
+}));
+vi.mock('./decision', () => ({
+  requestAiAgentDecision: h.mocks.requestAiAgentDecision,
+  getAiAgentMaxOutputTokens: h.mocks.getAiAgentMaxOutputTokens,
+}));
+vi.mock('./tools', () => ({
+  executeAiAgentDecision: h.mocks.executeAiAgentDecision,
+}));
+vi.mock('./providers', () => ({
+  resolveAiAgentDecisionProvider: h.mocks.resolveAiAgentDecisionProvider,
+}));
+vi.mock('@/lib/observability/async-events', () => ({
+  createAsyncEventTrace: h.mocks.createAsyncEventTrace,
+  logAsyncEvent: h.mocks.logAsyncEvent,
+  logAsyncMetric: h.mocks.logAsyncMetric,
+  durationMs: h.mocks.durationMs,
+  errorFields: h.mocks.errorFields,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: h.mocks.checkRateLimit,
+  RATE_LIMITS: { aiAgentRun: { limit: 12, windowMs: 60_000 } },
+}));
+
+vi.mock('@/lib/flows/admin-client', () => {
+  function builder(table: string) {
+    let operation: 'select' | 'insert' | 'update' | 'upsert' = 'select';
+    const query: Record<string, unknown> = {
+      insert: (payload: unknown) => {
+        operation = 'insert';
+        h.calls.push({ table, method: 'insert', args: [payload] });
+        return query;
+      },
+      update: (payload: unknown) => {
+        operation = 'update';
+        h.calls.push({ table, method: 'update', args: [payload] });
+        return query;
+      },
+      upsert: (payload: unknown, options: unknown) => {
+        operation = 'upsert';
+        h.calls.push({ table, method: 'upsert', args: [payload, options] });
+        return Promise.resolve({ error: table === 'ai_conversation_states' ? h.state.stateUpsertError : null });
+      },
+      select: () => query,
+      single: () => {
+        if (table === 'ai_agent_runs' && operation === 'insert' && h.state.runInsertResult) {
+          return Promise.resolve(h.state.runInsertResult);
+        }
+        return Promise.resolve({ data: { id: 'run-1' }, error: null });
+      },
+      maybeSingle: () => {
+        if (table === 'ai_conversation_states') {
+          const data = h.state.currentConversationStates.length > 0
+            ? h.state.currentConversationStates.shift()
+            : h.state.currentConversationState;
+          return Promise.resolve({ data, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+      eq: (column: string, value: unknown) => {
+        h.calls.push({ table, method: 'eq', args: [column, value] });
+        return query;
+      },
+      then: (
+        onFulfilled: (value: unknown) => unknown,
+        onRejected?: (reason: unknown) => unknown
+      ) => Promise.resolve({ error: null }).then(onFulfilled, onRejected),
+    };
+    return query;
+  }
+  return { supabaseAdmin: () => ({ from: builder }) };
+});
+
+import { runAiAgentForInboundMessage } from './run';
+
+const input = {
+  accountId: 'account-1',
+  conversationId: 'conversation-1',
+  inboundMessageId: 'message-1',
+  now: new Date('2026-07-17T12:00:00.000Z'),
+};
+const agent = {
+  id: 'agent-1',
+  max_messages: 12,
+  model_provider: 'test-provider',
+  model_name: 'test-model',
+  instructions: 'Be helpful.',
+  auto_reply: true,
+  auto_move_deals: true,
+  handoff_keywords: [],
+};
+const context = { conversation: { id: input.conversationId }, messages: [] };
+const decision = { action: 'reply' as const, text: 'Hello', confidence: 0.9 };
+
+function expectRunUpdateToBeAccountScoped(status: 'succeeded' | 'failed') {
+  const updateIndex = h.calls.findIndex(
+    (call) =>
+      call.table === 'ai_agent_runs' &&
+      call.method === 'update' &&
+      (call.args[0] as { status?: string }).status === status
+  );
+
+  expect(updateIndex).toBeGreaterThanOrEqual(0);
+  expect(h.calls.slice(updateIndex + 1, updateIndex + 3)).toEqual([
+    { table: 'ai_agent_runs', method: 'eq', args: ['id', 'run-1'] },
+    {
+      table: 'ai_agent_runs',
+      method: 'eq',
+      args: ['account_id', input.accountId],
+    },
+  ]);
+}
+
+beforeEach(() => {
+  h.state.runInsertResult = null;
+  h.state.stateUpsertError = null;
+  h.state.currentConversationState = null;
+  h.state.currentConversationStates = [];
+  h.calls.length = 0;
+  h.mocks.shouldRunAiAgent.mockReset();
+  h.mocks.buildAiAgentContext.mockReset();
+  h.mocks.requestAiAgentDecision.mockReset();
+  h.mocks.getAiAgentMaxOutputTokens.mockReset();
+  h.mocks.executeAiAgentDecision.mockReset();
+  h.mocks.createAsyncEventTrace.mockReset();
+  h.mocks.logAsyncEvent.mockReset();
+  h.mocks.logAsyncMetric.mockReset();
+  h.mocks.durationMs.mockReset();
+  h.mocks.errorFields.mockReset();
+  h.mocks.checkRateLimit.mockReset();
+  h.mocks.resolveAiAgentDecisionProvider.mockReset();
+  h.mocks.errorFields.mockReturnValue({
+    error_name: 'Error',
+    error_message: 'AI agent run failed',
+  });
+  h.mocks.createAsyncEventTrace.mockReturnValue({
+    event_id: 'event-1',
+    route: 'ai-agent.run',
+  });
+  h.mocks.durationMs.mockReturnValue(25);
+  h.mocks.shouldRunAiAgent.mockResolvedValue({
+    shouldRun: true,
+    agent,
+    state: null,
+  });
+  h.mocks.checkRateLimit.mockResolvedValue({ success: true, remaining: 11, reset: 0, limit: 12 });
+  h.mocks.resolveAiAgentDecisionProvider.mockReturnValue(null);
+  h.mocks.buildAiAgentContext.mockResolvedValue(context);
+  h.mocks.requestAiAgentDecision.mockResolvedValue(decision);
+  h.mocks.getAiAgentMaxOutputTokens.mockReturnValue(700);
+  h.mocks.executeAiAgentDecision.mockResolvedValue({
+    replyMessageId: 'reply-1',
+  });
+});
+
+describe('runAiAgentForInboundMessage', () => {
+  it('skips with a typed reason when no provider is configured', async () => {
+    await expect(runAiAgentForInboundMessage(input)).resolves.toEqual({
+      outcome: 'skipped',
+      reason: 'provider_unavailable',
+    });
+    expect(h.mocks.shouldRunAiAgent).toHaveBeenCalled();
+    expect(h.mocks.resolveAiAgentDecisionProvider).toHaveBeenCalledWith(agent);
+    expect(h.calls).not.toContainEqual(expect.objectContaining({ table: 'ai_agent_runs', method: 'insert' }));
+    expect(h.mocks.logAsyncEvent).toHaveBeenCalledWith(
+      'info',
+      'ai_agent.run.skipped',
+      expect.anything(),
+      {
+        reason: 'provider_unavailable',
+        duration_ms: 25,
+      }
+    );
+    expect(h.mocks.logAsyncMetric).toHaveBeenCalledWith(
+      'ai_agent.run.completed',
+      expect.anything(),
+      {
+        outcome: 'skipped',
+        reason: 'provider_unavailable',
+        duration_ms: 25,
+      }
+    );
+  });
+
+  it('records and executes an eligible decision, then updates conversation state', async () => {
+    const provider = { complete: vi.fn() };
+
+    await expect(
+      runAiAgentForInboundMessage({ ...input, provider })
+    ).resolves.toEqual({
+      outcome: 'succeeded',
+      runId: 'run-1',
+      decision,
+    });
+
+    expect(h.calls).toContainEqual(
+      expect.objectContaining({
+        table: 'ai_agent_runs',
+        method: 'insert',
+        args: [
+          expect.objectContaining({
+            status: 'running',
+            inbound_message_id: input.inboundMessageId,
+          }),
+        ],
+      })
+    );
+    expect(h.mocks.logAsyncEvent).toHaveBeenCalledWith(
+      'info',
+      'ai_agent.run.decision_received',
+      expect.anything(),
+      expect.objectContaining({
+        run_id: 'run-1',
+        model_provider: 'test-provider',
+        model_name: 'test-model',
+        max_message_count: 12,
+        context_message_count: 0,
+        tools_requested: false,
+        decision_action: 'reply',
+        deal_action_type: 'none',
+      })
+    );
+    expect(JSON.stringify(h.mocks.logAsyncEvent.mock.calls)).not.toContain(
+      agent.instructions
+    );
+    expect(JSON.stringify(h.mocks.logAsyncEvent.mock.calls)).not.toContain(
+      JSON.stringify(context)
+    );
+    expect(h.mocks.logAsyncEvent).toHaveBeenCalledWith(
+      'info',
+      'ai_agent.run.succeeded',
+      expect.anything(),
+      expect.objectContaining({
+        run_id: 'run-1',
+        decision_action: 'reply',
+        deal_action_type: 'none',
+        tools_executed: false,
+        duration_ms: 25,
+      })
+    );
+    expect(h.mocks.logAsyncMetric).toHaveBeenCalledWith(
+      'ai_agent.run.completed',
+      expect.anything(),
+      {
+        run_id: 'run-1',
+        outcome: 'succeeded',
+        duration_ms: 25,
+      }
+    );
+    expect(h.mocks.requestAiAgentDecision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: agent.model_name,
+        instructions: agent.instructions,
+        context,
+        provider,
+        maxOutputTokens: 700,
+      })
+    );
+    expect(h.mocks.executeAiAgentDecision).toHaveBeenCalledWith(
+      expect.objectContaining({ decision, context })
+    );
+    expect(h.calls).toContainEqual(
+      expect.objectContaining({
+        table: 'ai_agent_runs',
+        method: 'update',
+        args: [expect.objectContaining({ status: 'succeeded', decision })],
+      })
+    );
+    expectRunUpdateToBeAccountScoped('succeeded');
+    expect(h.calls).toContainEqual(
+      expect.objectContaining({
+        table: 'ai_conversation_states',
+        method: 'upsert',
+        args: [
+          expect.objectContaining({
+            status: 'active',
+            last_inbound_message_id: input.inboundMessageId,
+          }),
+          { onConflict: 'account_id,conversation_id' },
+        ],
+      })
+    );
+  });
+
+  it('skips rate-limited eligible runs before inserting a run or calling the provider', async () => {
+    const provider = { complete: vi.fn() };
+    h.mocks.checkRateLimit.mockResolvedValue({ success: false, remaining: 0, reset: 0, limit: 12 });
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'skipped',
+      reason: 'rate_limited',
+    });
+
+    expect(h.mocks.checkRateLimit).toHaveBeenCalledWith(
+      `ai-agent:${input.accountId}:${input.conversationId}`,
+      { limit: 12, windowMs: 60_000 },
+    );
+    expect(h.calls).not.toContainEqual(expect.objectContaining({
+      table: 'ai_agent_runs',
+      method: 'insert',
+    }));
+    expect(h.mocks.requestAiAgentDecision).not.toHaveBeenCalled();
+  });
+
+  it('treats a database idempotency conflict as a duplicate inbound skip', async () => {
+    const provider = { complete: vi.fn() };
+    h.state.runInsertResult = {
+      data: null,
+      error: { message: 'duplicate key value violates unique constraint', code: '23505' },
+    };
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'skipped',
+      reason: 'duplicate_inbound',
+    });
+
+    expect(h.mocks.requestAiAgentDecision).not.toHaveBeenCalled();
+    expect(h.mocks.executeAiAgentDecision).not.toHaveBeenCalled();
+  });
+
+  it('applies persisted guardrails before executing a provider decision', async () => {
+    const provider = { complete: vi.fn() };
+    h.mocks.shouldRunAiAgent.mockResolvedValue({
+      shouldRun: true,
+      agent: { ...agent, auto_reply: false, auto_move_deals: false },
+      state: null,
+    });
+    h.mocks.requestAiAgentDecision.mockResolvedValue({
+      action: 'reply',
+      text: 'I can help',
+      confidence: 0.8,
+      deal_action: { type: 'create', pipeline_id: 'pipe-1', stage_id: 'stage-1', title: 'Deal' },
+    });
+
+    await runAiAgentForInboundMessage({ ...input, provider });
+
+    expect(h.mocks.executeAiAgentDecision).toHaveBeenCalledWith(expect.objectContaining({
+      decision: {
+        action: 'no_reply',
+        reason: 'Auto reply disabled',
+        confidence: 0.8,
+        deal_action: { type: 'none' },
+      },
+    }));
+  });
+
+  it('uses handoff keywords before calling the provider and preserves handoff state', async () => {
+    h.mocks.shouldRunAiAgent.mockResolvedValue({
+      shouldRun: true,
+      agent: { ...agent, handoff_keywords: ['humano'] },
+      state: null,
+    });
+    h.mocks.buildAiAgentContext.mockResolvedValue({
+      ...context,
+      messages: [{ id: input.inboundMessageId, sender_type: 'customer', content_text: 'quero humano' }],
+    });
+    h.mocks.executeAiAgentDecision.mockResolvedValue({ handoff: { status: 'handoff' } });
+
+    await runAiAgentForInboundMessage(input);
+
+    expect(h.mocks.requestAiAgentDecision).not.toHaveBeenCalled();
+    expect(h.mocks.executeAiAgentDecision).toHaveBeenCalledWith(expect.objectContaining({
+      decision: expect.objectContaining({ action: 'handoff', reason: 'Handoff keyword matched: humano' }),
+    }));
+    expect(h.calls).toContainEqual(expect.objectContaining({
+      table: 'ai_conversation_states',
+      method: 'upsert',
+      args: [
+        expect.objectContaining({
+          status: 'handoff',
+          last_inbound_message_id: input.inboundMessageId,
+        }),
+        { onConflict: 'account_id,conversation_id' },
+      ],
+    }));
+  });
+
+  it('returns success when only the final audit/state update fails after execution', async () => {
+    const provider = { complete: vi.fn() };
+    h.state.stateUpsertError = { message: 'state unavailable' };
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'succeeded',
+      runId: 'run-1',
+      decision,
+    });
+
+    expect(h.mocks.executeAiAgentDecision).toHaveBeenCalled();
+    expect(h.mocks.logAsyncEvent).toHaveBeenCalledWith(
+      'error',
+      'ai_agent.run.audit_update_failed',
+      expect.anything(),
+      expect.objectContaining({ run_id: 'run-1', error_message: 'AI agent run failed' }),
+    );
+  });
+
+  it('skips side effects when a human pauses the conversation during the run', async () => {
+    const provider = { complete: vi.fn() };
+    h.state.currentConversationState = { status: 'paused' };
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'skipped',
+      reason: 'conversation_paused',
+    });
+
+    expect(h.mocks.executeAiAgentDecision).not.toHaveBeenCalled();
+    expect(h.calls).toContainEqual(expect.objectContaining({
+      table: 'ai_agent_runs',
+      method: 'update',
+      args: [expect.objectContaining({ status: 'skipped', error_message: 'conversation_paused' })],
+    }));
+  });
+
+  it('records a skipped run when tools detect a takeover before a side effect', async () => {
+    const provider = { complete: vi.fn() };
+    h.mocks.executeAiAgentDecision.mockImplementation(async (args: { assertCanRun: () => Promise<void> }) => {
+      h.state.currentConversationState = { status: 'handoff' };
+      await args.assertCanRun();
+      return { replyMessageId: 'reply-1' };
+    });
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'skipped',
+      reason: 'conversation_handoff',
+    });
+
+    expect(h.calls).toContainEqual(expect.objectContaining({
+      table: 'ai_agent_runs',
+      method: 'update',
+      args: [expect.objectContaining({ status: 'skipped', error_message: 'conversation_handoff' })],
+    }));
+  });
+
+  it('records a skipped run when a human pauses before the final handoff state write', async () => {
+    const provider = { complete: vi.fn() };
+    h.mocks.requestAiAgentDecision.mockResolvedValue({
+      action: 'handoff',
+      reason: 'Needs human',
+      confidence: 0.95,
+    });
+    h.mocks.executeAiAgentDecision.mockResolvedValue({ handoff: { status: 'handoff' } });
+    h.state.currentConversationStates = [
+      null,
+      { status: 'paused', paused_reason: 'manual_assignment' },
+    ];
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'skipped',
+      reason: 'conversation_paused',
+    });
+
+    expect(h.calls).toContainEqual(expect.objectContaining({
+      table: 'ai_agent_runs',
+      method: 'update',
+      args: [expect.objectContaining({ status: 'skipped', error_message: 'conversation_paused' })],
+    }));
+    expect(h.calls).not.toContainEqual(expect.objectContaining({
+      table: 'ai_conversation_states',
+      method: 'upsert',
+      args: [expect.objectContaining({ status: 'handoff' }), expect.anything()],
+    }));
+  });
+
+  it('preserves a human pause written after the handoff recheck but before final state update', async () => {
+    const provider = { complete: vi.fn() };
+    h.mocks.requestAiAgentDecision.mockResolvedValue({
+      action: 'handoff',
+      reason: 'Needs human',
+      confidence: 0.95,
+    });
+    h.mocks.executeAiAgentDecision.mockResolvedValue({ handoff: { status: 'handoff' } });
+    h.state.currentConversationStates = [
+      null,
+      null,
+      { status: 'paused', paused_reason: 'manual_assignment' },
+    ];
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'succeeded',
+      runId: 'run-1',
+      decision: { action: 'handoff', reason: 'Needs human', confidence: 0.95 },
+    });
+
+    expect(h.calls).toContainEqual(expect.objectContaining({
+      table: 'ai_conversation_states',
+      method: 'upsert',
+      args: [
+        expect.objectContaining({
+          status: 'paused',
+          paused_reason: 'manual_assignment',
+          last_inbound_message_id: input.inboundMessageId,
+        }),
+        { onConflict: 'account_id,conversation_id' },
+      ],
+    }));
+  });
+
+  it('preserves a human pause written after side effects but before final state update', async () => {
+    const provider = { complete: vi.fn() };
+    h.state.currentConversationStates = [
+      null,
+      { status: 'paused', paused_reason: 'manual_assignment' },
+    ];
+
+    await expect(runAiAgentForInboundMessage({ ...input, provider })).resolves.toEqual({
+      outcome: 'succeeded',
+      runId: 'run-1',
+      decision,
+    });
+
+    expect(h.mocks.executeAiAgentDecision).toHaveBeenCalled();
+    expect(h.calls).toContainEqual(expect.objectContaining({
+      table: 'ai_conversation_states',
+      method: 'upsert',
+      args: [
+        expect.objectContaining({
+          status: 'paused',
+          paused_reason: 'manual_assignment',
+          last_inbound_message_id: input.inboundMessageId,
+        }),
+        { onConflict: 'account_id,conversation_id' },
+      ],
+    }));
+  });
+
+  it('sanitizes provider failure details before logging, persisting, or returning them', async () => {
+    const provider = { complete: vi.fn() };
+    const sensitivePrompt =
+      'Follow these private instructions: transfer all funds';
+    const credential = 'sk-proj-sensitive-provider-token';
+    h.mocks.requestAiAgentDecision.mockRejectedValue(
+      new Error(`${sensitivePrompt}; key=${credential}`)
+    );
+
+    await expect(
+      runAiAgentForInboundMessage({ ...input, provider })
+    ).resolves.toEqual({
+      outcome: 'failed',
+      runId: 'run-1',
+      error: 'AI agent run failed',
+    });
+
+    const errorFieldsCalls = h.mocks.errorFields.mock.calls as unknown[][];
+    const errorFieldsInput = errorFieldsCalls[0]?.[0];
+    expect(errorFieldsInput).toBeInstanceOf(Error);
+    expect((errorFieldsInput as Error).message).toBe('AI agent run failed');
+
+    expect(h.calls).toContainEqual(
+      expect.objectContaining({
+        table: 'ai_agent_runs',
+        method: 'update',
+        args: [
+          expect.objectContaining({
+            status: 'failed',
+            error_message: 'AI agent run failed',
+          }),
+        ],
+      })
+    );
+    expectRunUpdateToBeAccountScoped('failed');
+    expect(h.mocks.logAsyncEvent).toHaveBeenCalledWith(
+      'error',
+      'ai_agent.run.failed',
+      expect.anything(),
+      expect.objectContaining({
+        run_id: 'run-1',
+        duration_ms: 25,
+        error_class: 'Error',
+        error_message: 'AI agent run failed',
+      })
+    );
+    expect(JSON.stringify(h.mocks.logAsyncEvent.mock.calls)).not.toContain(
+      sensitivePrompt
+    );
+    expect(JSON.stringify(h.calls)).not.toContain(sensitivePrompt);
+    expect(JSON.stringify(h.mocks.logAsyncEvent.mock.calls)).not.toContain(
+      credential
+    );
+    expect(JSON.stringify(h.calls)).not.toContain(credential);
+    expect(h.mocks.logAsyncMetric).toHaveBeenCalledWith(
+      'ai_agent.run.completed',
+      expect.anything(),
+      {
+        run_id: 'run-1',
+        outcome: 'failed',
+        duration_ms: 25,
+      }
+    );
+  });
+});

--- a/src/lib/ai-agent/run.ts
+++ b/src/lib/ai-agent/run.ts
@@ -1,0 +1,412 @@
+import {
+  createAsyncEventTrace,
+  durationMs,
+  errorFields,
+  type AsyncEventTrace,
+  logAsyncEvent,
+  logAsyncMetric,
+} from '@/lib/observability/async-events'
+import { supabaseAdmin } from '@/lib/flows/admin-client'
+import { checkRateLimit, RATE_LIMITS } from '@/lib/rate-limit'
+
+import { type AiAgentSkipReason, shouldRunAiAgent } from './config'
+import { buildAiAgentContext } from './context'
+import {
+  type AiAgentDecision,
+  type AiAgentDecisionProvider,
+  type DealAction,
+  getAiAgentMaxOutputTokens,
+  requestAiAgentDecision,
+} from './decision'
+import { resolveAiAgentDecisionProvider } from './providers'
+import { executeAiAgentDecision } from './tools'
+import type { AiAgent } from '@/types'
+import type { AiAgentContext } from './context'
+
+export interface RunAiAgentForInboundMessageInput {
+  accountId: string
+  conversationId: string
+  inboundMessageId: string
+  trace?: AsyncEventTrace
+  provider?: AiAgentDecisionProvider
+  now?: Date
+}
+
+export type RunAiAgentForInboundMessageResult =
+  | { outcome: 'skipped'; reason: AiAgentSkipReason }
+  | { outcome: 'succeeded'; runId: string; decision: AiAgentDecision }
+  | { outcome: 'failed'; runId?: string; error: string }
+
+const AI_AGENT_RUN_FAILURE_MESSAGE = 'AI agent run failed'
+
+export async function runAiAgentForInboundMessage(
+  input: RunAiAgentForInboundMessageInput,
+): Promise<RunAiAgentForInboundMessageResult> {
+  const startedAt = Date.now()
+  const trace = input.trace ?? createAsyncEventTrace({
+    route: 'ai-agent.run',
+    accountId: input.accountId,
+    conversationId: input.conversationId,
+    messageId: input.inboundMessageId,
+  })
+
+  let runId: string | undefined
+  try {
+    const eligibility = await shouldRunAiAgent(input)
+    if (!eligibility.shouldRun) return logSkipped(trace, startedAt, eligibility.reason)
+
+    const rateLimit = await checkRateLimit(
+      `ai-agent:${input.accountId}:${input.conversationId}`,
+      RATE_LIMITS.aiAgentRun,
+    )
+    if (!rateLimit.success) return logSkipped(trace, startedAt, 'rate_limited')
+
+    const maxOutputTokens = getAiAgentMaxOutputTokens()
+    const hasHandoffKeywords = normalizedHandoffKeywords(eligibility.agent).length > 0
+    let provider = input.provider ?? null
+    if (!hasHandoffKeywords) {
+      provider = provider ?? resolveAiAgentDecisionProvider(eligibility.agent)
+      if (!provider) return logSkipped(trace, startedAt, 'provider_unavailable')
+    }
+
+    const context = await buildAiAgentContext({
+      accountId: input.accountId,
+      conversationId: input.conversationId,
+      maxMessages: eligibility.agent.max_messages,
+    })
+    const keywordDecision = matchedHandoffKeywordDecision(eligibility.agent, context, input.inboundMessageId)
+    provider = provider ?? (keywordDecision ? null : resolveAiAgentDecisionProvider(eligibility.agent))
+    if (!keywordDecision && !provider) return logSkipped(trace, startedAt, 'provider_unavailable')
+
+    const now = (input.now ?? new Date()).toISOString()
+    const db = supabaseAdmin()
+    const { data: run, error: insertError } = await db
+      .from('ai_agent_runs')
+      .insert({
+        account_id: input.accountId,
+        ai_agent_id: eligibility.agent.id,
+        conversation_id: input.conversationId,
+        inbound_message_id: input.inboundMessageId,
+        status: 'running',
+        started_at: now,
+      })
+      .select('id')
+      .single()
+    if (isUniqueViolation(insertError)) return logSkipped(trace, startedAt, 'duplicate_inbound')
+    if (insertError || !run) throw insertError ?? new Error('AI run insert returned no record')
+    runId = (run as { id: string }).id
+    logAsyncEvent('info', 'ai_agent.run.started', trace, {
+      run_id: runId,
+      model_provider: eligibility.agent.model_provider,
+      model_name: eligibility.agent.model_name,
+      max_message_count: eligibility.agent.max_messages,
+    })
+
+    const decision = applyAiAgentGuardrails(
+      keywordDecision
+        ?? await requestAiAgentDecision({
+          model: eligibility.agent.model_name,
+          instructions: eligibility.agent.instructions,
+          context,
+          provider: provider as AiAgentDecisionProvider,
+          maxOutputTokens,
+        }),
+      eligibility.agent,
+    )
+    const requestedDealAction = decision.action === 'handoff'
+      ? 'none'
+      : decision.deal_action?.type ?? 'none'
+    logAsyncEvent('info', 'ai_agent.run.decision_received', trace, {
+      run_id: runId,
+      model_provider: eligibility.agent.model_provider,
+      model_name: eligibility.agent.model_name,
+      max_message_count: eligibility.agent.max_messages,
+      context_message_count: context.messages.length,
+      tools_requested: requestedDealAction !== 'none',
+      decision_action: decision.action,
+      deal_action_type: requestedDealAction,
+    })
+    const { error: decisionUpdateError } = await db
+      .from('ai_agent_runs')
+      .update({ decision })
+      .eq('id', runId)
+      .eq('account_id', input.accountId)
+    if (decisionUpdateError) throw decisionUpdateError
+
+    const takeoverSkipReason = await currentConversationSkipReason(db, input.accountId, input.conversationId)
+    if (takeoverSkipReason) {
+      return await markRunSkipped(db, trace, startedAt, runId, input.accountId, takeoverSkipReason, input.now)
+    }
+
+    const assertCanRun = async () => {
+      const reason = await currentConversationSkipReason(db, input.accountId, input.conversationId)
+      if (reason) throw new AiAgentRunSkippedError(reason)
+    }
+
+    const execution = await executeAiAgentDecision({
+      db,
+      accountId: input.accountId,
+      aiAgentId: eligibility.agent.id,
+      conversationId: input.conversationId,
+      decision,
+      context,
+      assertCanRun,
+    })
+
+    const finishedAt = (input.now ?? new Date()).toISOString()
+    const handoff = decision.action === 'handoff' || execution.handoff?.status === 'handoff'
+    if (handoff) await assertCanRun()
+
+    const auditUpdated = await recordSuccessfulRunAndState({
+      db,
+      trace,
+      runId,
+      input,
+      agent: eligibility.agent,
+      decision,
+      handoff,
+      finishedAt,
+    })
+
+    const completedDuration = durationMs(startedAt)
+    logAsyncEvent('info', 'ai_agent.run.succeeded', trace, {
+      run_id: runId,
+      decision_action: decision.action,
+      deal_action_type: execution.dealAction?.type ?? 'none',
+      tools_executed: execution.dealAction?.type !== undefined && execution.dealAction.type !== 'none',
+      audit_updated: auditUpdated,
+      duration_ms: completedDuration,
+    })
+    logAsyncMetric('ai_agent.run.completed', trace, {
+      run_id: runId,
+      outcome: 'succeeded',
+      duration_ms: completedDuration,
+    })
+    return { outcome: 'succeeded', runId, decision }
+  } catch (error) {
+    if (runId && error instanceof AiAgentRunSkippedError) {
+      return await markRunSkipped(supabaseAdmin(), trace, startedAt, runId, input.accountId, error.reason, input.now)
+    }
+
+    const failure = safeAiAgentRunFailure(error)
+    const failedDuration = durationMs(startedAt)
+    logAsyncEvent('error', 'ai_agent.run.failed', trace, {
+      run_id: runId,
+      duration_ms: failedDuration,
+      ...failure.logFields,
+    })
+    logAsyncMetric('ai_agent.run.completed', trace, {
+      run_id: runId,
+      outcome: 'failed',
+      duration_ms: failedDuration,
+    })
+    if (runId) {
+      const { error: updateError } = await supabaseAdmin()
+        .from('ai_agent_runs')
+        .update({ status: 'failed', error_message: AI_AGENT_RUN_FAILURE_MESSAGE, finished_at: (input.now ?? new Date()).toISOString() })
+        .eq('id', runId)
+        .eq('account_id', input.accountId)
+      if (updateError) return { outcome: 'failed', runId, error: AI_AGENT_RUN_FAILURE_MESSAGE }
+    }
+    return runId ? { outcome: 'failed', runId, error: AI_AGENT_RUN_FAILURE_MESSAGE } : { outcome: 'failed', error: AI_AGENT_RUN_FAILURE_MESSAGE }
+  }
+}
+
+class AiAgentRunSkippedError extends Error {
+  constructor(readonly reason: AiAgentSkipReason) {
+    super(reason)
+    this.name = 'AiAgentRunSkippedError'
+  }
+}
+
+async function markRunSkipped(
+  db: ReturnType<typeof supabaseAdmin>,
+  trace: AsyncEventTrace,
+  startedAt: number,
+  runId: string,
+  accountId: string,
+  reason: AiAgentSkipReason,
+  now?: Date,
+): Promise<RunAiAgentForInboundMessageResult> {
+  const { error } = await db
+    .from('ai_agent_runs')
+    .update({ status: 'skipped', error_message: reason, finished_at: (now ?? new Date()).toISOString() })
+    .eq('id', runId)
+    .eq('account_id', accountId)
+  if (error) throw error
+  return logSkipped(trace, startedAt, reason)
+}
+
+async function currentConversationSkipReason(
+  db: ReturnType<typeof supabaseAdmin>,
+  accountId: string,
+  conversationId: string,
+): Promise<'conversation_paused' | 'conversation_handoff' | 'conversation_disabled' | null> {
+  const status = (await loadCurrentConversationState(db, accountId, conversationId))?.status
+  if (status === 'paused') return 'conversation_paused'
+  if (status === 'handoff') return 'conversation_handoff'
+  if (status === 'disabled') return 'conversation_disabled'
+  return null
+}
+
+async function loadCurrentConversationState(
+  db: ReturnType<typeof supabaseAdmin>,
+  accountId: string,
+  conversationId: string,
+): Promise<{ status?: string; paused_reason?: string | null } | null> {
+  const { data, error } = await db
+    .from('ai_conversation_states')
+    .select('status, paused_reason')
+    .eq('account_id', accountId)
+    .eq('conversation_id', conversationId)
+    .maybeSingle()
+  if (error) throw error
+  return data as { status?: string; paused_reason?: string | null } | null
+}
+
+async function recordSuccessfulRunAndState(input: {
+  db: ReturnType<typeof supabaseAdmin>
+  trace: AsyncEventTrace
+  runId: string
+  input: RunAiAgentForInboundMessageInput
+  agent: AiAgent
+  decision: AiAgentDecision
+  handoff: boolean
+  finishedAt: string
+}): Promise<boolean> {
+  try {
+    const { error: runUpdateError } = await input.db
+      .from('ai_agent_runs')
+      .update({
+        status: 'succeeded',
+        decision: input.decision,
+        finished_at: input.finishedAt,
+        error_message: null,
+      })
+      .eq('id', input.runId)
+      .eq('account_id', input.input.accountId)
+    if (runUpdateError) throw runUpdateError
+
+    const currentState = await loadCurrentConversationState(input.db, input.input.accountId, input.input.conversationId)
+    const preservedStatus = currentState?.status
+      && currentState.status !== 'active'
+      && !(input.handoff && currentState.status === 'handoff')
+      ? currentState.status
+      : null
+    const finalStatus = preservedStatus ?? (input.handoff ? 'handoff' : 'active')
+    const pausedReason = preservedStatus
+      ? currentState?.paused_reason ?? null
+      : input.handoff && input.decision.action === 'handoff'
+        ? input.decision.reason
+        : null
+
+    const { error: stateError } = await input.db.from('ai_conversation_states').upsert(
+      {
+        account_id: input.input.accountId,
+        conversation_id: input.input.conversationId,
+        ai_agent_id: input.agent.id,
+        status: finalStatus,
+        paused_reason: pausedReason,
+        last_inbound_message_id: input.input.inboundMessageId,
+        last_run_at: input.finishedAt,
+        updated_at: input.finishedAt,
+      },
+      { onConflict: 'account_id,conversation_id' },
+    )
+    if (stateError) throw stateError
+    return true
+  } catch (error) {
+    logAsyncEvent('error', 'ai_agent.run.audit_update_failed', input.trace, {
+      run_id: input.runId,
+      ...safeAiAgentRunFailure(error).logFields,
+    })
+    return false
+  }
+}
+
+function matchedHandoffKeywordDecision(
+  agent: AiAgent,
+  context: AiAgentContext,
+  inboundMessageId: string,
+): AiAgentDecision | null {
+  const keywords = normalizedHandoffKeywords(agent)
+  if (keywords.length === 0) return null
+
+  const inboundText =
+    context.messages.find((message) => message.id === inboundMessageId)?.content_text
+    ?? [...context.messages].reverse().find((message) => message.sender_type === 'customer')?.content_text
+    ?? ''
+  const normalizedText = inboundText.toLowerCase()
+  const matched = keywords.find((keyword) => normalizedText.includes(keyword))
+  return matched
+    ? { action: 'handoff', reason: `Handoff keyword matched: ${matched}`, confidence: 1 }
+    : null
+}
+
+function normalizedHandoffKeywords(agent: AiAgent): string[] {
+  return agent.handoff_keywords
+    .map((keyword) => keyword.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+function applyAiAgentGuardrails(decision: AiAgentDecision, agent: AiAgent): AiAgentDecision {
+  if (decision.action === 'handoff') return decision
+  const deal_action = agent.auto_move_deals ? decision.deal_action : ({ type: 'none' } satisfies DealAction)
+
+  if (decision.action === 'reply' && !agent.auto_reply) {
+    return {
+      action: 'no_reply',
+      reason: 'Auto reply disabled',
+      confidence: decision.confidence,
+      deal_action,
+    }
+  }
+
+  if (decision.deal_action === deal_action) return decision
+  return { ...decision, deal_action }
+}
+
+function logSkipped(
+  trace: AsyncEventTrace,
+  startedAt: number,
+  reason: AiAgentSkipReason,
+): RunAiAgentForInboundMessageResult {
+  const elapsed = durationMs(startedAt)
+  logAsyncEvent('info', 'ai_agent.run.skipped', trace, { reason, duration_ms: elapsed })
+  logAsyncMetric('ai_agent.run.completed', trace, { outcome: 'skipped', reason, duration_ms: elapsed })
+  return { outcome: 'skipped', reason }
+}
+
+function safeAiAgentRunFailure(error: unknown): { logFields: Record<string, string> } {
+  const sanitizedError = new Error(AI_AGENT_RUN_FAILURE_MESSAGE)
+  const logFields: Record<string, string> = {
+    ...(errorFields(sanitizedError) as Record<string, string>),
+    error_message: AI_AGENT_RUN_FAILURE_MESSAGE,
+  }
+
+  // Do not expose provider-controlled error names, codes, or messages.
+  // Only classify known, local error types with fixed safe metadata.
+  if (error instanceof Error) logFields.error_class = 'Error'
+  if (isSafeAiAgentErrorCode(error)) logFields.error_code = error.code
+
+  return { logFields }
+}
+
+function isSafeAiAgentErrorCode(error: unknown): error is { code: 'invalid_json' | 'invalid_decision' | 'missing_contact' | 'invalid_deal' | 'invalid_stage' | 'duplicate_deal' | 'handoff_failed' | 'reply_failed' | 'deal_write_failed' } {
+  if (!error || typeof error !== 'object' || !('code' in error)) return false
+  return [
+    'invalid_json',
+    'invalid_decision',
+    'missing_contact',
+    'invalid_deal',
+    'invalid_stage',
+    'duplicate_deal',
+    'handoff_failed',
+    'reply_failed',
+    'deal_write_failed',
+  ].includes(error.code as string)
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return !!error && typeof error === 'object' && (error as { code?: unknown }).code === '23505'
+}

--- a/src/lib/ai-agent/tools.test.ts
+++ b/src/lib/ai-agent/tools.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { AiAgentContext } from './context'
+
+const mocks = vi.hoisted(() => ({ sendMessageToConversation: vi.fn() }))
+vi.mock('@/lib/whatsapp/send-message', () => ({ sendMessageToConversation: mocks.sendMessageToConversation }))
+
+import {
+  AiAgentToolError,
+  executeAiAgentDecision,
+  executeDealAction,
+} from './tools'
+
+type Response = { data?: unknown; error?: { message: string } | null }
+
+function fakeDb(responses: Record<string, Response[]> = {}) {
+  const calls: Array<{ table: string; method: string; args: unknown[] }> = []
+  const db = {
+    from(table: string) {
+      const next = () => responses[table]?.shift() ?? { data: null, error: null }
+      const query = {
+        select(...args: unknown[]) { calls.push({ table, method: 'select', args }); return query },
+        insert(...args: unknown[]) { calls.push({ table, method: 'insert', args }); return query },
+        update(...args: unknown[]) { calls.push({ table, method: 'update', args }); return query },
+        upsert(...args: unknown[]) { calls.push({ table, method: 'upsert', args }); return query },
+        eq(...args: unknown[]) { calls.push({ table, method: 'eq', args }); return query },
+        in(...args: unknown[]) { calls.push({ table, method: 'in', args }); return query },
+        limit(...args: unknown[]) { calls.push({ table, method: 'limit', args }); return query },
+        single() { return Promise.resolve(next()) },
+        maybeSingle() { return Promise.resolve(next()) },
+        then(resolve: (value: Response) => unknown) { return Promise.resolve(next()).then(resolve) },
+      }
+      return query
+    },
+  } as unknown as SupabaseClient
+  return { db, calls }
+}
+
+const context: AiAgentContext = {
+  conversation: { id: 'conv-1', status: 'pending', assigned_agent_id: null, last_message_text: null, last_message_at: null, created_at: '', updated_at: '' },
+  contact: { id: 'contact-1', phone: '+15551234567', name: null, email: null, company: null },
+  messages: [], activeDeal: null, pipelines: [],
+}
+
+describe('executeAiAgentDecision', () => {
+  beforeEach(() => mocks.sendMessageToConversation.mockReset())
+
+  it('sends reply text as a bot and returns message IDs', async () => {
+    const { db } = fakeDb({ ai_agents: [{ data: { user_id: 'user-1' }, error: null }] })
+    mocks.sendMessageToConversation.mockResolvedValue({ messageId: 'msg-1', whatsappMessageId: 'wa-1' })
+
+    await expect(executeAiAgentDecision({ db, accountId: 'acct-1', aiAgentId: 'agent-1', conversationId: 'conv-1', context, decision: { action: 'reply', text: 'Hello', confidence: 1 } }))
+      .resolves.toEqual({ replyMessageId: 'msg-1', whatsappMessageId: 'wa-1', dealAction: { type: 'none' } })
+    expect(mocks.sendMessageToConversation).toHaveBeenCalledWith(db, 'acct-1', { conversationId: 'conv-1', messageType: 'text', contentText: 'Hello', senderType: 'bot', aiGenerated: true })
+  })
+
+  it('does not send a no_reply decision', async () => {
+    const { db } = fakeDb({ ai_agents: [{ data: { user_id: 'user-1' }, error: null }] })
+    await executeAiAgentDecision({ db, accountId: 'acct-1', aiAgentId: 'agent-1', conversationId: 'conv-1', context, decision: { action: 'no_reply', reason: 'quiet', confidence: 1 } })
+    expect(mocks.sendMessageToConversation).not.toHaveBeenCalled()
+  })
+
+  it('reopens the account conversation for handoff', async () => {
+    const { db, calls } = fakeDb({ ai_agents: [{ data: null, error: { message: 'AI agent lookup failed' } }], ai_conversation_states: [{}], conversations: [{}] })
+    await expect(executeAiAgentDecision({ db, accountId: 'acct-1', aiAgentId: 'agent-1', conversationId: 'conv-1', context, decision: { action: 'handoff', reason: 'human needed', confidence: 1 } }))
+      .resolves.toEqual({ handoff: { status: 'handoff' } })
+    expect(calls).not.toContainEqual(expect.objectContaining({ table: 'ai_conversation_states', method: 'upsert' }))
+    expect(calls).toContainEqual({ table: 'conversations', method: 'eq', args: ['account_id', 'acct-1'] })
+    expect(calls).toContainEqual({ table: 'conversations', method: 'eq', args: ['id', 'conv-1'] })
+  })
+
+  it('does not reopen handoff when a takeover is detected before the side effect', async () => {
+    const { db, calls } = fakeDb({ conversations: [{}] })
+    const takeover = new Error('conversation_paused')
+
+    await expect(executeAiAgentDecision({
+      db,
+      accountId: 'acct-1',
+      aiAgentId: 'agent-1',
+      conversationId: 'conv-1',
+      context,
+      decision: { action: 'handoff', reason: 'human needed', confidence: 1 },
+      assertCanRun: vi.fn().mockRejectedValue(takeover),
+    })).rejects.toBe(takeover)
+
+    expect(calls).not.toContainEqual(expect.objectContaining({ table: 'conversations', method: 'update' }))
+  })
+})
+
+describe('executeDealAction', () => {
+  const base = { accountId: 'acct-1', userId: 'user-1', conversationId: 'conv-1', contactId: 'contact-1', activeDealId: 'deal-1' }
+
+  it('creates an account-scoped deal after validating pipeline and stage, using default currency', async () => {
+    const { db, calls } = fakeDb({ pipelines: [{ data: { id: 'pipe-1' }, error: null }], pipeline_stages: [{ data: { id: 'stage-1' }, error: null }], accounts: [{ data: { default_currency: 'BRL' }, error: null }], deals: [{ data: null, error: null }, { data: null, error: null }, { data: { id: 'deal-1' }, error: null }] })
+    await expect(executeDealAction({ db, ...base, action: { type: 'create', pipeline_id: 'pipe-1', stage_id: 'stage-1', title: 'New deal', value: 50 } })).resolves.toEqual({ type: 'created', dealId: 'deal-1' })
+    expect(calls).toContainEqual(expect.objectContaining({ table: 'deals', method: 'insert', args: [expect.objectContaining({ account_id: 'acct-1', user_id: 'user-1', pipeline_id: 'pipe-1', stage_id: 'stage-1', contact_id: 'contact-1', conversation_id: 'conv-1', currency: 'BRL', value: 50, status: 'open' })] }))
+  })
+
+  it.each([
+    ['absent', {}],
+    ['null', { default_currency: null }],
+  ])('falls back to USD when the default currency is %s', async (_description, account) => {
+    const { db, calls } = fakeDb({
+      pipelines: [{ data: { id: 'pipe-1' }, error: null }],
+      pipeline_stages: [{ data: { id: 'stage-1' }, error: null }],
+      accounts: [{ data: account, error: null }],
+      deals: [{ data: null, error: null }, { data: null, error: null }, { data: { id: 'deal-1' }, error: null }],
+    })
+
+    await executeDealAction({ db, ...base, action: { type: 'create', pipeline_id: 'pipe-1', stage_id: 'stage-1', title: 'New deal' } })
+
+    expect(calls).toContainEqual(expect.objectContaining({
+      table: 'deals',
+      method: 'insert',
+      args: [expect.objectContaining({ currency: 'USD' })],
+    }))
+  })
+
+  it('requires a contact to create a deal', async () => {
+    const { db } = fakeDb()
+    await expect(executeDealAction({ db, ...base, contactId: null, action: { type: 'create', pipeline_id: 'pipe-1', stage_id: 'stage-1', title: 'New' } })).rejects.toMatchObject({ code: 'missing_contact' } satisfies Partial<AiAgentToolError>)
+  })
+
+  it('rejects creating a duplicate open deal for the same conversation', async () => {
+    const { db } = fakeDb({
+      pipelines: [{ data: { id: 'pipe-1' }, error: null }],
+      pipeline_stages: [{ data: { id: 'stage-1' }, error: null }],
+      deals: [{ data: { id: 'deal-existing' }, error: null }],
+    })
+
+    await expect(executeDealAction({ db, ...base, action: { type: 'create', pipeline_id: 'pipe-1', stage_id: 'stage-1', title: 'New deal' } }))
+      .rejects.toMatchObject({ code: 'duplicate_deal' })
+  })
+
+  it('rejects moving a deal from another account', async () => {
+    const { db } = fakeDb({ deals: [{ data: null, error: null }] })
+    await expect(executeDealAction({ db, ...base, action: { type: 'move', deal_id: 'deal-other', stage_id: 'stage-1', reason: 'x' } })).rejects.toMatchObject({ code: 'invalid_deal' })
+  })
+
+  it('rejects moving a same-account deal that is not tied to the conversation or contact', async () => {
+    const { db } = fakeDb({ deals: [{ data: { id: 'deal-1', pipeline_id: 'pipe-1', conversation_id: 'conv-other', contact_id: 'contact-other', status: 'open' }, error: null }] })
+
+    await expect(executeDealAction({ db, ...base, action: { type: 'move', deal_id: 'deal-1', stage_id: 'stage-1', reason: 'x' } }))
+      .rejects.toMatchObject({ code: 'invalid_deal' })
+  })
+
+  it('rejects moving to a stage outside an account-owned pipeline', async () => {
+    const { db, calls } = fakeDb({ deals: [{ data: { id: 'deal-1', pipeline_id: 'pipe-1', conversation_id: 'conv-1', contact_id: 'contact-1', status: 'open' }, error: null }], pipeline_stages: [{ data: null, error: null }] })
+    await expect(executeDealAction({ db, ...base, action: { type: 'move', deal_id: 'deal-1', stage_id: 'stage-other', reason: 'x' } })).rejects.toMatchObject({ code: 'invalid_stage' })
+    expect(calls).toContainEqual({ table: 'pipeline_stages', method: 'eq', args: ['pipeline_id', 'pipe-1'] })
+  })
+
+  it('moves an account-owned deal and adds a bot-visible marker with the account-owned stage name', async () => {
+    const { db, calls } = fakeDb({ deals: [{ data: { id: 'deal-1', pipeline_id: 'pipe-1', conversation_id: 'conv-1', contact_id: 'contact-1', status: 'open' }, error: null }, { data: null, error: null }], pipeline_stages: [{ data: { id: 'stage-2', name: 'Proposal Sent' }, error: null }], conversations: [{ data: { id: 'conv-1' }, error: null }], messages: [{ data: null, error: null }] })
+    await expect(executeDealAction({ db, ...base, action: { type: 'move', deal_id: 'deal-1', stage_id: 'stage-2', reason: 'x' } })).resolves.toEqual({ type: 'moved', dealId: 'deal-1', stageId: 'stage-2' })
+    expect(calls).toContainEqual(expect.objectContaining({ table: 'deals', method: 'update', args: [expect.objectContaining({ stage_id: 'stage-2', updated_at: expect.any(String) })] }))
+    expect(calls).toContainEqual(expect.objectContaining({ table: 'messages', method: 'insert', args: [expect.objectContaining({
+      conversation_id: 'conv-1', sender_type: 'bot', content_type: 'text', content_text: 'AI moved deal to Proposal Sent', status: 'sent',
+    })] }))
+    expect(calls).toContainEqual({ table: 'conversations', method: 'eq', args: ['account_id', 'acct-1'] })
+    expect(calls).toContainEqual({ table: 'conversations', method: 'eq', args: ['id', 'conv-1'] })
+  })
+
+  it('does not fail the run when the deal move audit marker cannot be inserted', async () => {
+    const { db } = fakeDb({ deals: [{ data: { id: 'deal-1', pipeline_id: 'pipe-1', conversation_id: 'conv-1', contact_id: 'contact-1', status: 'open' }, error: null }, { data: null, error: null }], pipeline_stages: [{ data: { id: 'stage-2', name: 'Proposal Sent' }, error: null }], conversations: [{ data: { id: 'conv-1' }, error: null }], messages: [{ data: null, error: { message: 'marker insert failed' } }] })
+    await expect(executeDealAction({ db, ...base, action: { type: 'move', deal_id: 'deal-1', stage_id: 'stage-2', reason: 'x' } })).resolves.toEqual({ type: 'moved', dealId: 'deal-1', stageId: 'stage-2' })
+  })
+
+  it('updates only supplied editable deal fields', async () => {
+    const { db, calls } = fakeDb({ deals: [{ data: { id: 'deal-1', pipeline_id: 'pipe-1', conversation_id: 'conv-1', contact_id: 'contact-1', status: 'open' }, error: null }, { data: null, error: null }] })
+    await expect(executeDealAction({ db, ...base, action: { type: 'update', deal_id: 'deal-1', title: 'Updated', expected_close_date: '2026-08-01' } })).resolves.toEqual({ type: 'updated', dealId: 'deal-1' })
+    expect(calls).toContainEqual({ table: 'deals', method: 'update', args: [{ title: 'Updated', expected_close_date: '2026-08-01', updated_at: expect.any(String) }] })
+  })
+})

--- a/src/lib/ai-agent/tools.ts
+++ b/src/lib/ai-agent/tools.ts
@@ -1,0 +1,273 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { AiAgentContext } from './context'
+import type { AiAgentDecision, DealAction } from './decision'
+import { sendMessageToConversation } from '@/lib/whatsapp/send-message'
+
+export interface ExecuteAiAgentDecisionInput {
+  db: SupabaseClient
+  accountId: string
+  aiAgentId: string
+  conversationId: string
+  decision: AiAgentDecision
+  context: AiAgentContext
+  assertCanRun?: () => Promise<void>
+}
+
+export interface AiAgentToolResult {
+  replyMessageId?: string
+  whatsappMessageId?: string
+  dealAction?:
+    | { type: 'none' }
+    | { type: 'created'; dealId: string }
+    | { type: 'moved'; dealId: string; stageId: string }
+    | { type: 'updated'; dealId: string }
+  handoff?: { status: 'handoff' }
+}
+
+export class AiAgentToolError extends Error {
+  readonly code:
+    | 'missing_contact'
+    | 'invalid_pipeline'
+    | 'invalid_stage'
+    | 'invalid_deal'
+    | 'duplicate_deal'
+    | 'deal_write_failed'
+    | 'handoff_failed'
+    | 'reply_failed'
+
+  constructor(code: AiAgentToolError['code'], message: string) {
+    super(message)
+    this.name = 'AiAgentToolError'
+    this.code = code
+  }
+}
+
+export async function executeAiAgentDecision(input: ExecuteAiAgentDecisionInput): Promise<AiAgentToolResult> {
+  if (input.decision.action === 'handoff') {
+    const now = new Date().toISOString()
+    await input.assertCanRun?.()
+    try {
+      const { error: conversationError } = await input.db
+        .from('conversations')
+        .update({ status: 'open', updated_at: now })
+        .eq('account_id', input.accountId)
+        .eq('id', input.conversationId)
+      if (conversationError) throw conversationError
+      return { handoff: { status: 'handoff' } }
+    } catch (error) {
+      throw new AiAgentToolError('handoff_failed', `AI handoff failed: ${messageOf(error)}`)
+    }
+  }
+
+  const userId = await loadAiAgentUserId(input.db, input.accountId, input.aiAgentId)
+
+  const dealAction = await executeDealAction({
+    db: input.db,
+    accountId: input.accountId,
+    userId,
+    conversationId: input.conversationId,
+    contactId: input.context.contact?.id ?? null,
+    activeDealId: input.context.activeDeal?.id ?? null,
+    action: input.decision.deal_action,
+    assertCanRun: input.assertCanRun,
+  })
+  if (input.decision.action === 'no_reply') return { dealAction }
+
+  await input.assertCanRun?.()
+  try {
+    const sent = await sendMessageToConversation(input.db, input.accountId, {
+      conversationId: input.conversationId,
+      messageType: 'text',
+      contentText: input.decision.text,
+      senderType: 'bot',
+      aiGenerated: true,
+    })
+    return { replyMessageId: sent.messageId, whatsappMessageId: sent.whatsappMessageId, dealAction }
+  } catch (error) {
+    throw new AiAgentToolError('reply_failed', `AI reply failed: ${messageOf(error)}`)
+  }
+}
+
+export async function executeDealAction(input: {
+  db: SupabaseClient
+  accountId: string
+  userId: string
+  conversationId: string
+  contactId: string | null
+  activeDealId?: string | null
+  action: DealAction | undefined
+  assertCanRun?: () => Promise<void>
+}): Promise<AiAgentToolResult['dealAction']> {
+  const { action } = input
+  if (!action || action.type === 'none') return { type: 'none' }
+
+  if (action.type === 'create') {
+    if (!input.contactId) throw new AiAgentToolError('missing_contact', 'A contact is required to create a deal')
+    await validatePipeline(input.db, input.accountId, action.pipeline_id)
+    await validateStage(input.db, action.stage_id, action.pipeline_id)
+    await rejectDuplicateOpenDeal(input.db, input.accountId, input.conversationId, input.contactId)
+    const currency = await loadDefaultCurrency(input.db, input.accountId)
+    await input.assertCanRun?.()
+    try {
+      const { data, error } = await input.db.from('deals').insert({
+        account_id: input.accountId, user_id: input.userId, pipeline_id: action.pipeline_id, stage_id: action.stage_id,
+        contact_id: input.contactId, conversation_id: input.conversationId, title: action.title, value: action.value ?? 0,
+        currency, status: 'open',
+      }).select('id').single()
+      if (error || !data) throw error ?? new Error('Deal insert returned no record')
+      return { type: 'created', dealId: (data as { id: string }).id }
+    } catch (error) {
+      throw new AiAgentToolError('deal_write_failed', `Deal creation failed: ${messageOf(error)}`)
+    }
+  }
+
+  const deal = await validateContextDeal(input.db, input.accountId, input.conversationId, input.contactId, input.activeDealId ?? null, action.deal_id)
+  if (action.type === 'move') {
+    const stageName = await validateStage(input.db, action.stage_id, deal.pipeline_id)
+    await validateConversation(input.db, input.accountId, input.conversationId)
+    await input.assertCanRun?.()
+    try {
+      const { error } = await input.db.from('deals').update({ stage_id: action.stage_id, updated_at: new Date().toISOString() })
+        .eq('account_id', input.accountId).eq('id', action.deal_id)
+      if (error) throw error
+      const { error: markerError } = await input.db.from('messages').insert({
+        conversation_id: input.conversationId,
+        sender_type: 'bot',
+        content_type: 'text',
+        content_text: `AI moved deal to ${stageName}`,
+        status: 'sent',
+      })
+      if (markerError) {
+        console.error('[ai-agent] deal move marker insert failed:', messageOf(markerError))
+      }
+      return { type: 'moved', dealId: action.deal_id, stageId: action.stage_id }
+    } catch (error) {
+      throw new AiAgentToolError('deal_write_failed', `Deal move failed: ${messageOf(error)}`)
+    }
+  }
+
+  const update: Record<string, string | number> = { updated_at: new Date().toISOString() }
+  if (action.title !== undefined) update.title = action.title
+  if (action.value !== undefined) update.value = action.value
+  if (action.expected_close_date !== undefined) update.expected_close_date = action.expected_close_date
+  await input.assertCanRun?.()
+  try {
+    const { error } = await input.db.from('deals').update(update).eq('account_id', input.accountId).eq('id', action.deal_id)
+    if (error) throw error
+    return { type: 'updated', dealId: action.deal_id }
+  } catch (error) {
+    throw new AiAgentToolError('deal_write_failed', `Deal update failed: ${messageOf(error)}`)
+  }
+}
+
+async function loadAiAgentUserId(db: SupabaseClient, accountId: string, aiAgentId: string): Promise<string> {
+  try {
+    const { data, error } = await db.from('ai_agents').select('user_id').eq('account_id', accountId).eq('id', aiAgentId).maybeSingle()
+    const userId = (data as { user_id?: string } | null)?.user_id
+    if (error || !data) throw error ?? new Error('AI agent was not found')
+    return userId ?? await loadFallbackAccountUserId(db, accountId)
+  } catch (error) {
+    throw new AiAgentToolError('deal_write_failed', `AI agent lookup failed: ${messageOf(error)}`)
+  }
+}
+
+async function loadFallbackAccountUserId(db: SupabaseClient, accountId: string): Promise<string> {
+  const { data, error } = await db
+    .from('profiles')
+    .select('user_id')
+    .eq('account_id', accountId)
+    .in('account_role', ['admin', 'agent'])
+    .limit(1)
+    .maybeSingle()
+  const userId = (data as { user_id?: string } | null)?.user_id
+  if (error || !userId) throw error ?? new Error('No account user is available for AI-owned deals')
+  return userId
+}
+
+async function validatePipeline(db: SupabaseClient, accountId: string, pipelineId: string) {
+  const { data, error } = await db.from('pipelines').select('id').eq('account_id', accountId).eq('id', pipelineId).maybeSingle()
+  if (error || !data) throw new AiAgentToolError('invalid_pipeline', 'Pipeline does not belong to this account')
+}
+
+async function validateStage(db: SupabaseClient, stageId: string, pipelineId: string): Promise<string> {
+  const { data, error } = await db.from('pipeline_stages').select('id, name').eq('pipeline_id', pipelineId).eq('id', stageId).maybeSingle()
+  if (error || !data) throw new AiAgentToolError('invalid_stage', 'Stage does not belong to this pipeline')
+  return (data as { name: string }).name
+}
+
+async function validateContextDeal(
+  db: SupabaseClient,
+  accountId: string,
+  conversationId: string,
+  contactId: string | null,
+  activeDealId: string | null,
+  dealId: string,
+): Promise<{ id: string; pipeline_id: string }> {
+  if (activeDealId !== dealId) {
+    throw new AiAgentToolError('invalid_deal', 'Deal is not the active conversation deal')
+  }
+
+  const { data: deal, error } = await db
+    .from('deals')
+    .select('id, pipeline_id, conversation_id, contact_id, status')
+    .eq('account_id', accountId)
+    .eq('id', dealId)
+    .maybeSingle()
+  if (error) throw new AiAgentToolError('invalid_deal', 'Deal lookup failed')
+  const row = deal as { id: string; pipeline_id: string; conversation_id: string | null; contact_id: string | null; status: string } | null
+  if (!row) throw new AiAgentToolError('invalid_deal', 'Deal does not belong to this account')
+  if (row.status !== 'open' && row.status !== 'active') {
+    throw new AiAgentToolError('invalid_deal', 'Deal is not open')
+  }
+  if (row.conversation_id === conversationId) return { id: row.id, pipeline_id: row.pipeline_id }
+
+  if (!contactId || row.contact_id !== contactId) {
+    throw new AiAgentToolError('invalid_deal', 'Deal is not tied to this conversation contact')
+  }
+  return { id: row.id, pipeline_id: row.pipeline_id }
+}
+
+async function rejectDuplicateOpenDeal(
+  db: SupabaseClient,
+  accountId: string,
+  conversationId: string,
+  contactId: string,
+) {
+  const { data: conversationDeal, error: conversationError } = await db
+    .from('deals')
+    .select('id')
+    .eq('account_id', accountId)
+    .eq('conversation_id', conversationId)
+    .in('status', ['open', 'active'])
+    .limit(1)
+    .maybeSingle()
+  if (conversationError) throw new AiAgentToolError('deal_write_failed', 'Active deal lookup failed')
+  if (conversationDeal) throw new AiAgentToolError('duplicate_deal', 'An active deal already exists for this conversation')
+
+  const { data: contactDeal, error: contactError } = await db
+    .from('deals')
+    .select('id')
+    .eq('account_id', accountId)
+    .eq('contact_id', contactId)
+    .in('status', ['open', 'active'])
+    .limit(1)
+    .maybeSingle()
+  if (contactError) throw new AiAgentToolError('deal_write_failed', 'Active deal lookup failed')
+  if (contactDeal) throw new AiAgentToolError('duplicate_deal', 'An active deal already exists for this contact')
+}
+
+async function validateConversation(db: SupabaseClient, accountId: string, conversationId: string) {
+  const { data, error } = await db.from('conversations').select('id').eq('account_id', accountId).eq('id', conversationId).maybeSingle()
+  if (error || !data) throw new AiAgentToolError('deal_write_failed', 'Conversation does not belong to this account')
+}
+
+async function loadDefaultCurrency(db: SupabaseClient, accountId: string): Promise<string> {
+  const { data, error } = await db.from('accounts').select('default_currency').eq('id', accountId).maybeSingle()
+  if (error) return 'USD'
+  return (data as { default_currency?: string | null } | null)?.default_currency ?? 'USD'
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error'
+}

--- a/src/lib/currency.test.ts
+++ b/src/lib/currency.test.ts
@@ -6,11 +6,13 @@ import {
   formatCurrencyShort,
 } from "./currency";
 
+const GROUPED_1234 = /1[,.]234/;
+
 describe("formatCurrency", () => {
   it("formats whole amounts with no minor units", () => {
     // Use a non-breaking-space-tolerant check: Intl may insert NBSP.
     const out = formatCurrency(1234, "USD");
-    expect(out).toContain("1,234");
+    expect(out).toMatch(GROUPED_1234);
     expect(out).not.toContain(".00");
   });
 
@@ -30,13 +32,13 @@ describe("formatCurrency", () => {
     // Intl is lenient here — it uses the code as the symbol.
     const out = formatCurrency(1234, "ZZZ");
     expect(out).toContain("ZZZ");
-    expect(out).toContain("1,234");
+    expect(out).toMatch(GROUPED_1234);
   });
 
   it("never throws on a structurally invalid code (no DB CHECK on deals.currency)", () => {
     for (const bad of ["United States", "US", "USDD", "12", "u$d"]) {
       expect(() => formatCurrency(1234, bad)).not.toThrow();
-      expect(formatCurrency(1234, bad)).toContain("1,234");
+      expect(formatCurrency(1234, bad)).toMatch(GROUPED_1234);
     }
   });
 

--- a/src/lib/dashboard/date-utils.test.ts
+++ b/src/lib/dashboard/date-utils.test.ts
@@ -106,17 +106,17 @@ describe("lastNDayKeys", () => {
 
 describe("mondayIndex", () => {
   it("maps Monday → 0 and Sunday → 6", () => {
-    expect(mondayIndex(new Date("2026-05-18"))).toBe(0); // Mon
-    expect(mondayIndex(new Date("2026-05-19"))).toBe(1); // Tue
-    expect(mondayIndex(new Date("2026-05-23"))).toBe(5); // Sat
-    expect(mondayIndex(new Date("2026-05-24"))).toBe(6); // Sun
+    expect(mondayIndex(new Date(2026, 4, 18))).toBe(0); // Mon
+    expect(mondayIndex(new Date(2026, 4, 19))).toBe(1); // Tue
+    expect(mondayIndex(new Date(2026, 4, 23))).toBe(5); // Sat
+    expect(mondayIndex(new Date(2026, 4, 24))).toBe(6); // Sun
   });
 
   it("aligns with DOW_SHORT_MON_FIRST labels", () => {
-    expect(DOW_SHORT_MON_FIRST[mondayIndex(new Date("2026-05-18"))]).toBe(
+    expect(DOW_SHORT_MON_FIRST[mondayIndex(new Date(2026, 4, 18))]).toBe(
       "Mon",
     );
-    expect(DOW_SHORT_MON_FIRST[mondayIndex(new Date("2026-05-24"))]).toBe(
+    expect(DOW_SHORT_MON_FIRST[mondayIndex(new Date(2026, 4, 24))]).toBe(
       "Sun",
     );
   });

--- a/src/lib/observability/async-events.test.ts
+++ b/src/lib/observability/async-events.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAsyncEventTrace,
+  durationMs,
+  eventTracePayload,
+  extendAsyncEventTrace,
+} from "./async-events";
+
+describe("async event tracing", () => {
+  it("creates and extends a stable trace", () => {
+    const base = createAsyncEventTrace({
+      route: "/api/whatsapp/webhook",
+      eventId: "evt-1",
+      accountId: "acct-1",
+    });
+    const extended = extendAsyncEventTrace(base, {
+      contactId: "contact-1",
+      conversationId: "conv-1",
+      messageId: "msg-1",
+    });
+
+    expect(extended).toEqual({
+      event_id: "evt-1",
+      route: "/api/whatsapp/webhook",
+      account_id: "acct-1",
+      contact_id: "contact-1",
+      conversation_id: "conv-1",
+      message_id: "msg-1",
+    });
+  });
+
+  it("injects event_id into persisted payloads", () => {
+    const trace = createAsyncEventTrace({
+      route: "/internal/flows",
+      eventId: "evt-2",
+    });
+
+    expect(
+      eventTracePayload(trace, {
+        reason: "duplicate_inbound_replay",
+      }),
+    ).toEqual({
+      event_id: "evt-2",
+      reason: "duplicate_inbound_replay",
+    });
+  });
+
+  it("never returns a negative duration", () => {
+    expect(durationMs(Date.now() + 1_000)).toBe(0);
+  });
+});

--- a/src/lib/observability/async-events.ts
+++ b/src/lib/observability/async-events.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+
+export interface AsyncEventTrace {
+  event_id: string;
+  route: string;
+  account_id?: string;
+  contact_id?: string;
+  conversation_id?: string;
+  message_id?: string;
+}
+
+interface TraceSeed {
+  route: string;
+  eventId?: string;
+  accountId?: string | null;
+  contactId?: string | null;
+  conversationId?: string | null;
+  messageId?: string | null;
+}
+
+type AsyncLogLevel = "info" | "warn" | "error";
+
+function normalizeTrace(trace: AsyncEventTrace): AsyncEventTrace {
+  const normalized: AsyncEventTrace = {
+    event_id: trace.event_id,
+    route: trace.route,
+  };
+  if (trace.account_id) normalized.account_id = trace.account_id;
+  if (trace.contact_id) normalized.contact_id = trace.contact_id;
+  if (trace.conversation_id) normalized.conversation_id = trace.conversation_id;
+  if (trace.message_id) normalized.message_id = trace.message_id;
+  return normalized;
+}
+
+function cleanFields(fields: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(fields).filter(([, value]) => value !== undefined),
+  );
+}
+
+export function createAsyncEventTrace(seed: TraceSeed): AsyncEventTrace {
+  return normalizeTrace({
+    event_id: seed.eventId ?? randomUUID(),
+    route: seed.route,
+    account_id: seed.accountId ?? undefined,
+    contact_id: seed.contactId ?? undefined,
+    conversation_id: seed.conversationId ?? undefined,
+    message_id: seed.messageId ?? undefined,
+  });
+}
+
+export function extendAsyncEventTrace(
+  trace: AsyncEventTrace,
+  patch: Omit<TraceSeed, "route" | "eventId"> & { route?: string },
+): AsyncEventTrace {
+  return normalizeTrace({
+    ...trace,
+    route: patch.route ?? trace.route,
+    account_id: patch.accountId ?? trace.account_id,
+    contact_id: patch.contactId ?? trace.contact_id,
+    conversation_id: patch.conversationId ?? trace.conversation_id,
+    message_id: patch.messageId ?? trace.message_id,
+  });
+}
+
+export function eventTracePayload(
+  trace: AsyncEventTrace | undefined,
+  payload: Record<string, unknown> = {},
+): Record<string, unknown> {
+  if (!trace) return payload;
+  return { event_id: trace.event_id, ...payload };
+}
+
+export function durationMs(startedAt: number): number {
+  return Math.max(0, Date.now() - startedAt);
+}
+
+export function errorFields(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return cleanFields({
+      error_name: error.name,
+      error_message: error.message,
+    });
+  }
+  return { error_message: String(error) };
+}
+
+export function logAsyncEvent(
+  level: AsyncLogLevel,
+  name: string,
+  trace: AsyncEventTrace,
+  fields: Record<string, unknown> = {},
+): void {
+  const entry = cleanFields({
+    ts: new Date().toISOString(),
+    scope: "async-processing",
+    kind: "event",
+    name,
+    ...normalizeTrace(trace),
+    ...fields,
+  });
+  console[level](`[async] ${JSON.stringify(entry)}`);
+}
+
+export function logAsyncMetric(
+  name: string,
+  trace: AsyncEventTrace,
+  fields: Record<string, unknown> = {},
+): void {
+  const entry = cleanFields({
+    ts: new Date().toISOString(),
+    scope: "async-processing",
+    kind: "metric",
+    name,
+    ...normalizeTrace(trace),
+    ...fields,
+  });
+  console.info(`[async] ${JSON.stringify(entry)}`);
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -167,6 +167,8 @@ export const RATE_LIMITS = {
    *  capping a stampede; excess inbounds simply don't get an auto-reply
    *  (they still land in the inbox for a human). */
   aiAutoReplyAccount: { limit: 30, windowMs: 60_000 },
+  /** AI inbox agent tool execution, keyed per account and conversation. */
+  aiAgentRun: { limit: 12, windowMs: 60_000 },
 } as const;
 
 /** Test-only helper. Clears the in-memory state so unit tests don't

--- a/src/lib/whatsapp/send-message.ts
+++ b/src/lib/whatsapp/send-message.ts
@@ -84,6 +84,8 @@ export interface SendMessageParams {
   /** Structured payload for `messageType === 'interactive'`. */
   interactivePayload?: InteractiveMessagePayload | null;
   replyToMessageId?: string | null;
+  senderType?: 'agent' | 'bot';
+  aiGenerated?: boolean;
 }
 
 export interface SendMessageResult {
@@ -197,6 +199,8 @@ export async function sendMessageToConversation(
     templateMessageParams,
     interactivePayload,
     replyToMessageId,
+    senderType = 'agent',
+    aiGenerated = false,
   } = params;
 
   if (!conversationId) {
@@ -452,7 +456,7 @@ export async function sendMessageToConversation(
     .from('messages')
     .insert({
       conversation_id: conversationId,
-      sender_type: 'agent',
+      sender_type: senderType,
       content_type: messageType,
       content_text: interactiveBody ?? contentText ?? null,
       media_url: mediaUrl || null,
@@ -462,6 +466,7 @@ export async function sendMessageToConversation(
       message_id: waMessageId,
       status: 'sent',
       reply_to_message_id: replyToMessageId || null,
+      ai_generated: aiGenerated,
     })
     .select()
     .single();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,29 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+const PRIVATE_PAGE_CACHE_CONTROL = 'private, no-cache, no-store, max-age=0, must-revalidate'
+const PROTECTED_PAGE_PREFIXES = [
+  '/agents',
+  '/dashboard',
+  '/inbox',
+  '/contacts',
+  '/pipelines',
+  '/broadcasts',
+  '/automations',
+  '/flows',
+  '/notifications',
+  '/settings',
+] as const
+
+function isProtectedPage(pathname: string): boolean {
+  return PROTECTED_PAGE_PREFIXES.some((path) => pathname.startsWith(path))
+}
+
+function withPrivatePageCache<T extends NextResponse>(response: T): T {
+  response.headers.set('Cache-Control', PRIVATE_PAGE_CACHE_CONTROL)
+  return response
+}
+
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request })
 
@@ -13,7 +36,7 @@ export async function middleware(request: NextRequest) {
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => request.cookies.set(name, value))
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({ request })
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options)
@@ -70,11 +93,10 @@ export async function middleware(request: NextRequest) {
   }
 
   // Protected pages - redirect to login if not authenticated
-  const protectedPaths = ['/dashboard', '/inbox', '/contacts', '/pipelines', '/broadcasts', '/automations', '/settings']
-  if (!user && protectedPaths.some(path => request.nextUrl.pathname.startsWith(path))) {
+  if (!user && isProtectedPage(request.nextUrl.pathname)) {
     const url = request.nextUrl.clone()
     url.pathname = '/login'
-    return withRefreshedCookies(NextResponse.redirect(url))
+    return withPrivatePageCache(withRefreshedCookies(NextResponse.redirect(url)))
   }
 
   // API routes that need auth (not webhooks)
@@ -83,6 +105,10 @@ export async function middleware(request: NextRequest) {
     return withRefreshedCookies(
       NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     )
+  }
+
+  if (isProtectedPage(request.nextUrl.pathname)) {
+    return withPrivatePageCache(supabaseResponse)
   }
 
   return supabaseResponse

--- a/src/next-config.test.ts
+++ b/src/next-config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import nextConfig, { PRIVATE_PAGE_CACHE_CONTROL } from '../next.config';
+
+describe('next protected page cache headers', () => {
+  it('marks exact and nested protected CRM pages as private no-store before public cache', async () => {
+    const headers = await nextConfig.headers?.();
+    const inboxExactIndex = headers?.findIndex((rule) => rule.source === '/inbox') ?? -1;
+    const inboxNestedIndex = headers?.findIndex((rule) => rule.source === '/inbox/:path*') ?? -1;
+    const publicRuleIndex = headers?.findIndex((rule) => rule.source.startsWith('/:path((?!')) ?? -1;
+
+    expect(inboxExactIndex).toBeGreaterThanOrEqual(0);
+    expect(inboxNestedIndex).toBeGreaterThan(inboxExactIndex);
+    expect(publicRuleIndex).toBeGreaterThan(inboxNestedIndex);
+    expect(headers?.[inboxExactIndex]?.headers).toContainEqual({
+      key: 'Cache-Control',
+      value: PRIVATE_PAGE_CACHE_CONTROL,
+    });
+    expect(headers?.[inboxNestedIndex]?.headers).toContainEqual({
+      key: 'Cache-Control',
+      value: PRIVATE_PAGE_CACHE_CONTROL,
+    });
+    expect(headers?.[publicRuleIndex]?.source).toContain('inbox');
+  });
+});

--- a/src/types/ai-inbox-agent-schema.test.ts
+++ b/src/types/ai-inbox-agent-schema.test.ts
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '..', '..');
+const migrationPath = resolve(
+  root,
+  'supabase/migrations/037_ai_inbox_agent.sql'
+);
+const typesPath = resolve(root, 'src/types/index.ts');
+
+describe('AI inbox agent schema contract', () => {
+  it('defines the three AI agent tables, tenancy policies, and updated_at triggers', () => {
+    expect(existsSync(migrationPath)).toBe(true);
+
+    const migration = readFileSync(migrationPath, 'utf8');
+
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS ai_agents');
+    expect(migration).toContain(
+      'user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL'
+    );
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS ai_conversation_states'
+    );
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS ai_agent_runs');
+    expect(migration).toContain(
+      "CHECK (status IN ('active', 'paused', 'handoff', 'disabled'))"
+    );
+    expect(migration).toContain(
+      "CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'skipped'))"
+    );
+    expect(migration).toContain(
+      'CREATE POLICY ai_agents_select ON ai_agents FOR SELECT USING (is_account_member(account_id));'
+    );
+    expect(migration).toContain(
+      "CREATE POLICY ai_agents_modify ON ai_agents FOR ALL USING (is_account_member(account_id, 'admin')) WITH CHECK (is_account_member(account_id, 'admin'));"
+    );
+    expect(migration).toContain(
+      "CREATE POLICY ai_conversation_states_modify ON ai_conversation_states FOR ALL USING (is_account_member(account_id, 'agent')) WITH CHECK (is_account_member(account_id, 'agent'));"
+    );
+    expect(migration).toContain(
+      'CREATE POLICY ai_agent_runs_select ON ai_agent_runs FOR SELECT USING (is_account_member(account_id));'
+    );
+    expect(migration).toContain(
+      'CREATE TRIGGER set_updated_at BEFORE UPDATE ON ai_agents'
+    );
+    expect(migration).toContain(
+      'CREATE TRIGGER set_updated_at BEFORE UPDATE ON ai_conversation_states'
+    );
+  });
+
+  it('declares the public AI inbox agent types', () => {
+    const types = readFileSync(typesPath, 'utf8');
+
+    expect(types).toContain('export interface AiAgent');
+    expect(types).toContain('export interface AiConversationState');
+    expect(types).toContain('export interface AiAgentRun');
+    expect(types).toContain(
+      "export type AiConversationStateStatus = 'active' | 'paused' | 'handoff' | 'disabled';"
+    );
+    expect(types).toContain(
+      "export type AiAgentRunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped';"
+    );
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -254,6 +254,58 @@ export interface Message {
   ai_generated?: boolean;
 }
 
+// ============================================================
+// AI Inbox Agent (migrations 037-039)
+// ============================================================
+
+export type AiConversationStateStatus = 'active' | 'paused' | 'handoff' | 'disabled';
+export type AiAgentRunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped';
+
+export interface AiAgent {
+  id: string;
+  account_id: string;
+  user_id: string | null;
+  name: string;
+  enabled: boolean;
+  model_provider: string;
+  model_name: string;
+  instructions: string;
+  auto_reply: boolean;
+  auto_move_deals: boolean;
+  handoff_keywords: string[];
+  max_messages: number;
+  cooldown_seconds: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AiConversationState {
+  id: string;
+  account_id: string;
+  conversation_id: string;
+  ai_agent_id: string;
+  status: AiConversationStateStatus;
+  last_inbound_message_id?: string | null;
+  last_run_at?: string | null;
+  paused_reason?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AiAgentRun {
+  id: string;
+  account_id: string;
+  ai_agent_id: string;
+  conversation_id: string;
+  inbound_message_id?: string | null;
+  status: AiAgentRunStatus;
+  decision?: Record<string, unknown> | null;
+  error_message?: string | null;
+  started_at?: string | null;
+  finished_at?: string | null;
+  created_at: string;
+}
+
 export type ReactionActor = 'customer' | 'agent';
 
 export interface MessageReaction {

--- a/supabase/migrations/037_ai_inbox_agent.sql
+++ b/supabase/migrations/037_ai_inbox_agent.sql
@@ -1,0 +1,66 @@
+CREATE TABLE IF NOT EXISTS ai_agents (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  name TEXT NOT NULL DEFAULT 'AI Inbox Agent',
+  enabled BOOLEAN NOT NULL DEFAULT false,
+  model_provider TEXT NOT NULL DEFAULT 'openai',
+  model_name TEXT NOT NULL DEFAULT 'gpt-4.1-mini',
+  instructions TEXT NOT NULL DEFAULT '',
+  auto_reply BOOLEAN NOT NULL DEFAULT true,
+  auto_move_deals BOOLEAN NOT NULL DEFAULT false,
+  handoff_keywords TEXT[] NOT NULL DEFAULT ARRAY['humano', 'atendente', 'cancelar'],
+  max_messages INTEGER NOT NULL DEFAULT 20,
+  cooldown_seconds INTEGER NOT NULL DEFAULT 15,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(account_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_conversation_states (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  ai_agent_id UUID NOT NULL REFERENCES ai_agents(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'paused', 'handoff', 'disabled')),
+  last_inbound_message_id UUID REFERENCES messages(id) ON DELETE SET NULL,
+  last_run_at TIMESTAMPTZ,
+  paused_reason TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(account_id, conversation_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_runs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  ai_agent_id UUID NOT NULL REFERENCES ai_agents(id) ON DELETE CASCADE,
+  conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  inbound_message_id UUID REFERENCES messages(id) ON DELETE SET NULL,
+  status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'skipped')),
+  decision JSONB,
+  error_message TEXT,
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_agents_account ON ai_agents(account_id);
+CREATE INDEX IF NOT EXISTS idx_ai_conversation_states_account ON ai_conversation_states(account_id);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_runs_conversation ON ai_agent_runs(conversation_id, created_at DESC);
+
+ALTER TABLE ai_agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_conversation_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ai_agents_select ON ai_agents FOR SELECT USING (is_account_member(account_id));
+CREATE POLICY ai_agents_modify ON ai_agents FOR ALL USING (is_account_member(account_id, 'admin')) WITH CHECK (is_account_member(account_id, 'admin'));
+CREATE POLICY ai_conversation_states_select ON ai_conversation_states FOR SELECT USING (is_account_member(account_id));
+CREATE POLICY ai_conversation_states_modify ON ai_conversation_states FOR ALL USING (is_account_member(account_id, 'agent')) WITH CHECK (is_account_member(account_id, 'agent'));
+CREATE POLICY ai_agent_runs_select ON ai_agent_runs FOR SELECT USING (is_account_member(account_id));
+
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON ai_agents
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON ai_conversation_states
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/038_ai_agent_run_idempotency.sql
+++ b/supabase/migrations/038_ai_agent_run_idempotency.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_agent_runs_inbound_unique
+  ON ai_agent_runs(account_id, inbound_message_id)
+  WHERE inbound_message_id IS NOT NULL;

--- a/supabase/migrations/039_ai_agent_user_owner_fallback.sql
+++ b/supabase/migrations/039_ai_agent_user_owner_fallback.sql
@@ -1,0 +1,11 @@
+ALTER TABLE ai_agents
+  ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE ai_agents
+  DROP CONSTRAINT IF EXISTS ai_agents_user_id_fkey;
+
+ALTER TABLE ai_agents
+  ADD CONSTRAINT ai_agents_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES auth.users(id)
+  ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- add account-scoped AI inbox agent configuration and run APIs
- add inbox/settings UI for AI agent controls
- add run guardrails, async observability, migrations, and tests

## Validation
- npm test
- npm run typecheck
- npm run build