### PR TITLE
fix(i18n): settings-overview role namespace, scopesHint rich-tag, and role SelectValue from #375

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1600,7 +1600,7 @@
       "nameLabel": "Name",
       "namePlaceholder": "e.g. Zapier automation",
       "scopesLabel": "Scopes",
-      "scopesHint": "A key with no scopes can still call <code className=\"text-[11px]\">GET /api/v1/me</code> to verify it works.",
+      "scopesHint": "A key with no scopes can still call <code>GET /api/v1/me</code> to verify it works.",
       "cancel": "Cancel",
       "creating": "Creating…",
       "createKey": "Create key",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1598,7 +1598,7 @@
       "nameLabel": "이름",
       "namePlaceholder": "예: Zapier 자동화",
       "scopesLabel": "권한 범위",
-      "scopesHint": "권한 범위가 없는 키도 <code className=\"text-[11px]\">GET /api/v1/me</code>를 호출해 동작을 확인할 수 있습니다.",
+      "scopesHint": "권한 범위가 없는 키도 <code>GET /api/v1/me</code>를 호출해 동작을 확인할 수 있습니다.",
       "cancel": "취소",
       "creating": "만드는 중…",
       "createKey": "키 생성",

--- a/src/components/settings/invite-member-dialog.tsx
+++ b/src/components/settings/invite-member-dialog.tsx
@@ -274,7 +274,7 @@ export function InviteMemberDialog({
                   onValueChange={(v) => v && setRole(v as InviteRole)}
                 >
                   <SelectTrigger className="w-full bg-muted border-border text-foreground">
-                    <SelectValue />
+                    <SelectValue>{tRoles(role)}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="admin">{tRoles('admin')}</SelectItem>

--- a/src/components/settings/members-tab.tsx
+++ b/src/components/settings/members-tab.tsx
@@ -428,7 +428,7 @@ export function MembersTab() {
                           className="w-32 bg-muted border-border text-foreground"
                           disabled={isBusy}
                         >
-                          <SelectValue />
+                          <SelectValue>{tRoles(member.role)}</SelectValue>
                         </SelectTrigger>
                         <SelectContent>
                           {EDITABLE_ROLES.map((r) => (

--- a/src/components/settings/settings-overview.tsx
+++ b/src/components/settings/settings-overview.tsx
@@ -40,7 +40,7 @@ export function SettingsOverview({
     useAuth();
   const { mode, theme } = useTheme();
   const t = useTranslations('Settings.overview');
-  const tRoles = useTranslations('roles');
+  const tRoles = useTranslations('Settings.roles');
   const tSections = useTranslations('Settings.sections');
 
   const [counts, setCounts] = useState<OverviewCounts | null>(null);


### PR DESCRIPTION
## Summary

Lands the Settings-overview-related i18n bug fixes from #375 (point 3): a namespace mismatch that rendered raw keypaths in English, a phantom rich-tag styling, and a Base UI `SelectValue` limitation. Skips bug 2 (`Settings.sections.quick-replies`) — the label is already present in `en.json:1494`; left for @opastorello to confirm on the issue.

## What changed

- `src/components/settings/settings-overview.tsx` — `useTranslations('roles')` → `useTranslations('Settings.roles')`. Aligns with `invite-member-dialog.tsx:78` and `members-tab.tsx:129`, which already use the `Settings.roles` namespace. The root-level `roles` block in `messages/es-CO.json` and the empty `roles: {}` in `messages/ko.json` were workarounds added to mask this bug; the proper fix makes them unnecessary. **This PR does not touch those locale files** — they belong in the contributors' own locale PRs and are out of scope here.
- `messages/en.json`, `messages/ko.json` — strip `className` from the `scopesHint` `<code>` rich tag. next-intl rich tags must be attribute-less, so the `text-[11px]` Tailwind utility was a phantom; the code rendered at surrounding-text size anyway. The `<code>` element now renders at default size; the smaller styling can be restored globally via CSS (`code { font-size: ... }`) if desired.
- `src/components/settings/members-tab.tsx`, `src/components/settings/invite-member-dialog.tsx` — render the translated label explicitly as `<SelectValue>` children so the trigger shows the human-readable role name instead of the raw enum (`admin` / `agent` / `viewer`).

5 files, 5 lines net change. Three commits, one per bug, for atomic review.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 0 errors, no new warnings (39 pre-existing warnings on files this PR doesn't touch).
- [ ] `npm run build` succeeds (CI on PR open).
- [ ] Manual: sign in, go to `/settings`. The role chip in the identity card (top of the page) should show the role name (e.g. "Owner"), not the raw keypath.
- [ ] Manual: open the invite-member dialog. The role `<SelectValue>` trigger should show the role name and not `admin` / `agent` / `viewer`.
- [ ] Manual: in the members tab, click the role selector on any non-owner row. The trigger should show the current role name and update on selection.
- [ ] Manual: Settings → API keys → "Create key" dialog. The `scopesHint` text should render `GET /api/v1/me` as an inline `<code>` element, with no rendering errors in the browser console.

## Notes

- **Out of scope, tracked under #375:** the same Base UI `<SelectValue>` pattern affects ~5 other sites — `template-manager.tsx` (header format, button type), `ai-config.tsx` (provider, handoff target), plus a couple in flows / broadcasts. They're the same one-line fix and easy to follow up. Left out to keep this PR focused.
- **Pre-existing repo-wide:** `npm run format:check` flags 333 files. The 5 files this PR touches were no more out of format than before. Left untouched to keep the diff focused; happy to do a project-wide Prettier pass in a separate PR if wanted.
- **Local fork work, not in this PR:** my fork is running a `es-CO` translation; `messages/es-CO.json` has a root-level `roles` block (the workaround this fix replaces) and a few other locale additions. The branch was cut clean from upstream `main` (`b24aa79`) and contains only the upstream-relevant changes.

## Related

Part of #375.