### PR TITLE
fix(i18n): sync ko.json with en.json and add a locale key parity test

### DIFF
--- a/messages/ko.json
+++ b/messages/ko.json
@@ -358,6 +358,7 @@
         "notes": "메모",
         "custom": "커스텀 필드",
         "deals": "딜",
+        "tags": "태그",
         "noTags": "태그 없음",
         "noDeals": "딜 없음",
         "addNotePlaceholder": "메모 추가..."
@@ -1500,6 +1501,7 @@
       "appearance": "화면 설정",
       "whatsapp": "WhatsApp",
       "templates": "템플릿",
+      "quick-replies": "빠른 답장",
       "fields": "필드 & 태그",
       "deals": "딜 & 통화",
       "members": "팀원",

--- a/src/i18n/messages.test.ts
+++ b/src/i18n/messages.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Locale dictionaries are hand-maintained. English is the source of
+// truth (src/i18n/request.ts falls back to en.json only when a whole
+// locale file is missing — there is no per-key fallback), so a key
+// that lands in en.json and not in a translation renders as a raw
+// keypath for users on that locale. This guards the parity.
+
+const MESSAGES_DIR = join(process.cwd(), 'messages');
+const SOURCE_LOCALE = 'en';
+const TRANSLATED_LOCALES = ['ko'];
+
+function loadKeys(locale: string): Set<string> {
+  const raw = readFileSync(join(MESSAGES_DIR, `${locale}.json`), 'utf8');
+  const out = new Set<string>();
+  const walk = (node: unknown, path: string) => {
+    if (node && typeof node === 'object' && !Array.isArray(node)) {
+      for (const [k, v] of Object.entries(node)) {
+        walk(v, path ? `${path}.${k}` : k);
+      }
+      return;
+    }
+    out.add(path);
+  };
+  walk(JSON.parse(raw), '');
+  return out;
+}
+
+describe('message catalogue parity', () => {
+  const source = loadKeys(SOURCE_LOCALE);
+
+  it.each(TRANSLATED_LOCALES)('%s.json covers every en.json key', (locale) => {
+    const translated = loadKeys(locale);
+    const missing = [...source].filter((k) => !translated.has(k)).sort();
+    expect(missing, `${locale}.json is missing these keys`).toEqual([]);
+  });
+
+  it.each(TRANSLATED_LOCALES)('%s.json has no orphaned keys', (locale) => {
+    const translated = loadKeys(locale);
+    const orphaned = [...translated].filter((k) => !source.has(k)).sort();
+    expect(orphaned, `${locale}.json has keys absent from en.json`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #418.

Two keys landed in `en.json` without reaching `ko.json` — `Settings.sections.quick-replies` (8bbbe0a) and `Contacts.detailView.tabs.tags` (6a8744c). `src/i18n/request.ts` only falls back per-file, not per-key, so Korean users see the raw keypaths in the settings nav and on the contact tags tab.

First commit adds the two labels: `빠른 답장` and `태그`, matching the terms `ko.json` already uses for these features (`Inbox.composer.quickReplies*` uses 빠른 답장 six times, and 태그 is what every other tags label uses — `Inbox.sidebar.tags`, `Contacts.page.tableColumns.tags`, etc.). `Inbox.composer.quickRepliesEmpty` literally tells the user `설정 → 빠른 답장에서 추가하세요`, so the nav label has to match that wording.

Second commit adds `src/i18n/messages.test.ts` so this stops recurring. On current `main` it fails naming exactly the two keys above:

```
AssertionError: ko.json is missing these keys: expected [ …(2) ] to deeply equal []
+   "Contacts.detailView.tabs.tags",
+   "Settings.sections.quick-replies",
```

It also checks the reverse direction — keys present in a translation but absent from `en.json` — which would have flagged the root-level `roles` workaround blocks that #417 makes unnecessary. Runs inside `npm test`, so CI picks it up with no workflow change.

Overlap note: the review thread on #417 asked for the same `quick-replies` line; taking it here instead so the parity test lands green on its own. The two PRs touch different parts of `ko.json`, so they don't conflict and merge in either order.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors, no new warnings
- [x] `npm test` — both parity tests pass; suite otherwise unchanged from `main` (the 3 `currency.test.ts` failures on local Node 24 are pre-existing ICU differences; CI runs Node 20 where they pass)
- [x] Rendering verified with next-intl directly: ko `Settings.sections.quick-replies` → 빠른 답장, `Contacts.detailView.tabs.tags` → 태그
- [x] Reverted the two keys locally and confirmed the test fails listing exactly them
