### PR TITLE
feat(whatsapp): Evolution API (unofficial) support

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -359,9 +359,9 @@
         "custom": "Custom Fields",
         "deals": "Deals",
         "tags": "Tags",
-      "noTags": "No tags",
-      "noDeals": "No deals",
-      "addNotePlaceholder": "Add a note..."
+        "noTags": "No tags",
+        "noDeals": "No deals",
+        "addNotePlaceholder": "Add a note..."
       },
       "actions": {
         "edit": "Edit",
@@ -1331,13 +1331,11 @@
       "deleteLocallyAria": "Delete template locally",
       "deleteMetaLocallyTitle": "Delete from Meta and locally",
       "deleteLocallyTitle": "Delete locally",
-      
       "dialogEditTitle": "Edit Message Template",
       "dialogNewTitle": "New Message Template",
       "dialogEditDesc": "Save your changes to re-submit to Meta. Status will flip back to PENDING during review.",
       "dialogNewDesc": "Build a template and submit it to Meta for approval. Once approved, you can use it in broadcasts and the inbox.",
       "authWarning": "AUTHENTICATION templates have a fixed body + OTP button shape that needs a different builder. Create them in Meta WhatsApp Manager for now and use <bold>Sync from Meta</bold> to bring them in.",
-      
       "templateName": "Template Name",
       "namePlaceholder": "e.g. order_confirmation",
       "nameFixed": "Name is fixed once a template exists on Meta — create a new template to change it.",
@@ -1346,7 +1344,6 @@
       "language": "Language",
       "langFixed": "Language is fixed once a template exists on Meta.",
       "langHint": "Must match the exact code on Meta — <code>en_US</code> and <code>en</code> are distinct.",
-      
       "header": "Header",
       "headerNone": "None",
       "headerText": "Text",
@@ -1356,7 +1353,6 @@
       "headerTextPlaceholder": "Header text (max 60 chars, optional {{1}})",
       "headerSampleAria": "Sample value for header variable",
       "headerSamplePlaceholder": "Sample value for {{1}} (required for Meta review)",
-      
       "uploadImage": "Upload image",
       "uploadHint": "JPEG or PNG, ≤5 MB",
       "mediaUrlPlaceholder": "https://… (or paste a public {format} link)",
@@ -1364,17 +1360,14 @@
       "mediaHint": "Must be a publicly accessible HTTPS link. Meta fetches it once during review, so it needs to stay live for ~24 hrs.",
       "videoHint": " Recommended: MP4 / 3GPP, ≤16 MB, ≤60 seconds.",
       "documentHint": " Recommended: PDF, ≤100 MB.",
-      
       "bodyText": "Body Text",
       "bodyPlaceholder": "Hello {{1}}, your order {{2}} is confirmed.",
       "bodyHint": "Use {{1}}, {{2}} for variables (must be contiguous starting at {{1}}).",
       "sampleValues": "Sample values (Meta uses these to review your template)",
       "sampleAria": "Sample value for body variable {var}",
       "samplePlaceholder": "Sample for {var}",
-      
       "footer": "Footer (optional)",
       "footerPlaceholder": "Optional footer text (max 60 chars)",
-      
       "buttons": "Buttons (optional)",
       "addButton": "Add Button",
       "buttonsLimit": "Up to {max} buttons. QUICK_REPLY buttons must come before URL / phone / copy-code buttons.",
@@ -1387,19 +1380,16 @@
       "urlSamplePlaceholder": "Example value for {{1}} (required when URL has a variable)",
       "phonePlaceholder": "+15551234567",
       "codePlaceholder": "Example code (e.g. SUMMER20)",
-      
       "cancel": "Cancel",
       "saving": "Saving…",
       "submitting": "Submitting…",
       "saveResubmit": "Save & Resubmit",
       "submitApproval": "Submit for Approval",
-      
       "deleteDialogTitle": "Delete template?",
       "deleteMetaDesc": "\"{name}\" will be deleted from Meta and from wacrm. Active broadcasts using this template will start failing on their next send. This can't be undone.",
       "deleteLocalDesc": "\"{name}\" will be deleted from wacrm. It was never submitted to Meta, so no remote cleanup is needed.",
       "deleting": "Deleting…",
       "delete": "Delete",
-      
       "toastLoadFailed": "Failed to load templates",
       "toastSubmitFailed": "Failed to submit",
       "toastSubmitEditSuccess": "Edit submitted — Meta typically reviews within 24 hours.",
@@ -1492,7 +1482,21 @@
       "step4_3": "Paste the <strong class=\"text-foreground\">Webhook Callback URL</strong> from above",
       "step4_4": "Enter the same <strong class=\"text-foreground\">Verify Token</strong> you set here",
       "step4_5": "Subscribe to \"messages\" webhook field",
-      "metaDocs": "Meta WhatsApp API Documentation"
+      "metaDocs": "Meta WhatsApp API Documentation",
+      "apiTypeLabel": "Connection type",
+      "apiTypeMeta": "Official API (Meta)",
+      "apiTypeEvolution": "Unofficial API (Evolution)",
+      "evoWarning": "Unofficial transport via WhatsApp Web. This violates WhatsApp's Terms of Service and the number can be banned without warning. Use a dedicated number for testing — not your main line.",
+      "evoServerUrl": "Server URL",
+      "evoServerUrlHint": "Base URL of your Evolution API server, e.g. http://localhost:8080",
+      "evoInstanceName": "Instance name",
+      "evoInstanceNameHint": "The instance you created on the Evolution server.",
+      "evoApiKey": "Instance API key",
+      "evoApiKeyPlaceholder": "Your Evolution instance apikey",
+      "evoUrlInstanceRequired": "Server URL and instance name are required.",
+      "evoApiKeyRequired": "Instance API key is required for initial setup.",
+      "evoConnected": "Evolution connected — the instance is linked and ready.",
+      "evoSavedNotConnected": "Saved, but the instance isn't linked yet. Scan the QR code in Evolution, then save again to confirm the connection."
     },
     "sections": {
       "overview": "Overview",
@@ -1539,7 +1543,6 @@
       "profileSaved": "Profile saved",
       "emailChangeFailed": "Email change failed: {message}",
       "profileSavedEmailCheck": "Profile saved — check your email to confirm the address change",
-      
       "passwordTitle": "Password",
       "passwordDesc": "Use at least {min} characters. You will stay signed in on this device after changing it.",
       "currentPassword": "Current password",
@@ -1553,7 +1556,6 @@
       "currentPasswordIncorrect": "Current password is incorrect",
       "passwordUpdateFailed": "Password update failed: {message}",
       "passwordUpdated": "Password updated",
-      
       "sessionsTitle": "Active sessions",
       "sessionsDesc": "Sign out of every device where you're logged in — including this one. Useful if you lost a laptop or shared your password.",
       "signOutAll": "Sign out of all devices",

--- a/src/app/api/whatsapp/config/route.ts
+++ b/src/app/api/whatsapp/config/route.ts
@@ -158,6 +158,175 @@ export async function GET() {
 }
 
 /**
+ * Best-effort probe of an Evolution instance's connection state.
+ * GET {apiUrl}/instance/connectionState/{instance} → { instance: { state } }.
+ * `state === 'open'` means the phone is linked and messages will flow.
+ * Any network/API failure returns false — we still save the row so the
+ * user can fix the URL/instance and retry without re-entering the apikey.
+ */
+async function probeEvolutionConnection(
+  apiUrl: string,
+  instanceName: string,
+  apiKey: string
+): Promise<boolean> {
+  try {
+    const url = `${apiUrl.replace(/\/+$/, '')}/instance/connectionState/${encodeURIComponent(
+      instanceName
+    )}`
+    const res = await fetch(url, {
+      headers: { apikey: apiKey },
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return false
+    const data = await res.json()
+    return data?.instance?.state === 'open'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Save/update an Evolution (unofficial) WhatsApp config. Called from the
+ * POST handler when `api_type === 'evolution'`. Returns the same
+ * NextResponse envelope shape the Meta path uses.
+ */
+async function saveEvolutionConfig(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  accountId: string,
+  userId: string,
+  body: {
+    api_url?: unknown
+    instance_name?: unknown
+    access_token?: unknown
+  }
+) {
+  const apiUrl = typeof body.api_url === 'string' ? body.api_url.trim() : ''
+  const instanceName =
+    typeof body.instance_name === 'string' ? body.instance_name.trim() : ''
+  const rawApiKey =
+    typeof body.access_token === 'string' ? body.access_token.trim() : ''
+
+  if (!apiUrl || !instanceName) {
+    return NextResponse.json(
+      { error: 'Server URL and instance name are required.' },
+      { status: 400 }
+    )
+  }
+  try {
+    const u = new URL(apiUrl)
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error('bad')
+  } catch {
+    return NextResponse.json(
+      { error: 'Server URL must be a valid http(s) URL.' },
+      { status: 400 }
+    )
+  }
+
+  // Reject if another account already claimed this instance name — the
+  // UNIQUE index (migration 037) would trip anyway, but a friendly 409
+  // beats a 500. Mirrors the Meta phone_number_id claim check.
+  const { data: claimed } = await supabaseAdmin()
+    .from('whatsapp_config')
+    .select('account_id')
+    .eq('instance_name', instanceName)
+    .neq('account_id', accountId)
+    .maybeSingle()
+  if (claimed) {
+    return NextResponse.json(
+      { error: 'That instance name is already linked to another account.' },
+      { status: 409 }
+    )
+  }
+
+  // Existing row (if any) so we can reuse the stored apikey when the user
+  // didn't re-enter it (the client sends a masked value on load).
+  const { data: existing } = await supabase
+    .from('whatsapp_config')
+    .select('id, access_token')
+    .eq('account_id', accountId)
+    .maybeSingle()
+
+  const MASKED = '••••••••••••••••'
+  let apiKeyPlain = ''
+  if (rawApiKey && rawApiKey !== MASKED) {
+    apiKeyPlain = rawApiKey
+  } else if (existing?.access_token) {
+    try {
+      apiKeyPlain = decrypt(existing.access_token)
+    } catch {
+      apiKeyPlain = ''
+    }
+  }
+  if (!apiKeyPlain) {
+    return NextResponse.json(
+      { error: 'Instance API key is required.' },
+      { status: 400 }
+    )
+  }
+
+  let encryptedApiKey: string
+  try {
+    encryptedApiKey = encrypt(apiKeyPlain)
+  } catch {
+    return NextResponse.json(
+      {
+        error:
+          'Failed to encrypt the API key. Check that ENCRYPTION_KEY is a valid 64-character hex string.',
+      },
+      { status: 500 }
+    )
+  }
+
+  const connected = await probeEvolutionConnection(apiUrl, instanceName, apiKeyPlain)
+
+  const row = {
+    api_type: 'evolution',
+    api_url: apiUrl,
+    instance_name: instanceName,
+    access_token: encryptedApiKey,
+    // Evolution rows carry no Meta coordinates.
+    phone_number_id: null,
+    waba_id: null,
+    verify_token: null,
+    status: connected ? 'connected' : 'disconnected',
+    connected_at: connected ? new Date().toISOString() : null,
+    updated_at: new Date().toISOString(),
+  }
+
+  if (existing) {
+    const { error } = await supabase
+      .from('whatsapp_config')
+      .update(row)
+      .eq('account_id', accountId)
+    if (error) {
+      console.error('Error updating evolution config:', error)
+      return NextResponse.json(
+        { error: 'Failed to update configuration' },
+        { status: 500 }
+      )
+    }
+  } else {
+    const { error } = await supabase
+      .from('whatsapp_config')
+      .insert({ account_id: accountId, user_id: userId, ...row })
+    if (error) {
+      console.error('Error inserting evolution config:', error)
+      return NextResponse.json(
+        { error: 'Failed to save configuration' },
+        { status: 500 }
+      )
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    saved: true,
+    api_type: 'evolution',
+    connected,
+  })
+}
+
+/**
  * POST /api/whatsapp/config
  *
  * Saves or updates the WhatsApp config for the authenticated user.
@@ -186,6 +355,15 @@ export async function POST(request: Request) {
 
     const body = await request.json()
     const { phone_number_id, waba_id, access_token, verify_token, pin } = body
+
+    // ── Evolution API (unofficial) branch ──────────────────────────
+    // A separate save path: no Meta verification, registration, or
+    // phone_number_id claim. Validates the Evolution coordinates,
+    // encrypts the instance apikey into access_token, best-effort pings
+    // the instance's connection state, and upserts the row.
+    if (body.api_type === 'evolution') {
+      return saveEvolutionConfig(supabase, accountId, user.id, body)
+    }
 
     if (!access_token || !phone_number_id) {
       return NextResponse.json(

--- a/src/app/api/whatsapp/evolution-webhook/route.test.ts
+++ b/src/app/api/whatsapp/evolution-webhook/route.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { safeEqual, jidToPhone, parseContent } from "./route";
+
+describe("safeEqual", () => {
+  it("returns true for identical strings", () => {
+    expect(safeEqual("abc123", "abc123")).toBe(true);
+  });
+
+  it("returns false for different same-length strings", () => {
+    expect(safeEqual("abc123", "abc124")).toBe(false);
+  });
+
+  it("returns false for different-length strings without throwing", () => {
+    expect(safeEqual("short", "a-much-longer-secret")).toBe(false);
+  });
+
+  it("returns false when either side is empty", () => {
+    expect(safeEqual("", "x")).toBe(false);
+    expect(safeEqual("x", "")).toBe(false);
+  });
+});
+
+describe("jidToPhone", () => {
+  it("extracts an E.164 phone from a user JID", () => {
+    expect(jidToPhone("5547999998888@s.whatsapp.net")).toBe("+5547999998888");
+  });
+
+  it("strips a device suffix (:12)", () => {
+    expect(jidToPhone("5547999998888:12@s.whatsapp.net")).toBe(
+      "+5547999998888",
+    );
+  });
+
+  it("returns null for group JIDs", () => {
+    expect(jidToPhone("120363000000000000@g.us")).toBeNull();
+  });
+
+  it("returns null for broadcast / status JIDs", () => {
+    expect(jidToPhone("status@broadcast")).toBeNull();
+    expect(jidToPhone("123@broadcast")).toBeNull();
+  });
+
+  it("returns null for undefined or empty input", () => {
+    expect(jidToPhone(undefined)).toBeNull();
+    expect(jidToPhone("")).toBeNull();
+  });
+});
+
+describe("parseContent", () => {
+  it("reads a plain text conversation", () => {
+    expect(parseContent({ message: { conversation: "oi" } })).toEqual({
+      contentType: "text",
+      contentText: "oi",
+    });
+  });
+
+  it("reads an extended text message (with link preview / reply)", () => {
+    expect(
+      parseContent({ message: { extendedTextMessage: { text: "hey" } } }),
+    ).toEqual({ contentType: "text", contentText: "hey" });
+  });
+
+  it("uses the image caption when present, else a placeholder", () => {
+    expect(
+      parseContent({ message: { imageMessage: { caption: "veja" } } }),
+    ).toEqual({ contentType: "image", contentText: "veja" });
+    expect(parseContent({ message: { imageMessage: {} } })).toEqual({
+      contentType: "image",
+      contentText: "[image]",
+    });
+  });
+
+  it("falls back to fileName for documents without a caption", () => {
+    expect(
+      parseContent({ message: { documentMessage: { fileName: "nf.pdf" } } }),
+    ).toEqual({ contentType: "document", contentText: "nf.pdf" });
+  });
+
+  it("records audio as a placeholder", () => {
+    expect(parseContent({ message: { audioMessage: {} } })).toEqual({
+      contentType: "audio",
+      contentText: "[audio]",
+    });
+  });
+
+  it("handles an unknown/empty message shape without throwing", () => {
+    expect(parseContent({})).toEqual({
+      contentType: "text",
+      contentText: "[unsupported message]",
+    });
+  });
+});

--- a/src/app/api/whatsapp/evolution-webhook/route.ts
+++ b/src/app/api/whatsapp/evolution-webhook/route.ts
@@ -1,0 +1,274 @@
+// ============================================================
+// Inbound webhook for the Evolution API (UNOFFICIAL WhatsApp Web).
+//
+// The Meta Cloud webhook (../webhook/route.ts) routes inbound events by
+// `phone_number_id`. Evolution has no such id — it identifies a
+// connection by its `instance` name and signs nothing (there's no HMAC
+// like Meta's). So this handler:
+//
+//   1. reads the instance name from the event body,
+//   2. looks up the matching whatsapp_config (service-role, by the
+//      UNIQUE instance_name from migration 037),
+//   3. authenticates by comparing the presented `apikey` (header or
+//      body) against the instance apikey we stored (decrypted from the
+//      access_token column) in constant time,
+//   4. reuses `resolveConversationByPhone` — the same find-or-create
+//      the public API and Meta webhook lean on — so a contact/conversation
+//      created here is indistinguishable from any other transport's,
+//   5. persists the inbound message and bumps the conversation.
+//
+// Scope (matches the Phase-1 send transport): text + media metadata.
+// Media *bytes* live on the Evolution server and need a separate
+// download/proxy step — a follow-up — so media messages are recorded
+// with their caption/placeholder text and no media_url for now.
+// ============================================================
+
+import { timingSafeEqual } from 'crypto';
+
+import { supabaseAdmin } from '@/lib/flows/admin-client';
+import { decrypt } from '@/lib/whatsapp/encryption';
+import { resolveConversationByPhone } from '@/lib/whatsapp/resolve-conversation';
+
+export const runtime = 'nodejs';
+
+// Content types the messages.content_type CHECK constraint allows
+// (001 → widened in 010). Anything else maps to 'text'.
+const ALLOWED_CONTENT_TYPES = new Set([
+  'text',
+  'image',
+  'document',
+  'audio',
+  'video',
+  'location',
+  'template',
+  'interactive',
+]);
+
+interface EvolutionKey {
+  remoteJid?: string;
+  fromMe?: boolean;
+  id?: string;
+}
+
+interface EvolutionMessageContent {
+  conversation?: string;
+  extendedTextMessage?: { text?: string };
+  imageMessage?: { caption?: string };
+  videoMessage?: { caption?: string };
+  documentMessage?: { caption?: string; fileName?: string };
+  audioMessage?: unknown;
+}
+
+interface EvolutionMessageData {
+  key?: EvolutionKey;
+  pushName?: string;
+  message?: EvolutionMessageContent;
+  messageType?: string;
+  messageTimestamp?: number | string;
+}
+
+interface EvolutionWebhookBody {
+  event?: string;
+  instance?: string;
+  apikey?: string;
+  data?: EvolutionMessageData | EvolutionMessageData[];
+}
+
+/** Constant-time string compare that never short-circuits on length. */
+export function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Still burn a compare against a same-length buffer so timing doesn't
+    // leak the length relationship.
+    timingSafeEqual(bufA, Buffer.alloc(bufA.length));
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Turn an Evolution `remoteJid` into an E.164-ish phone, or null when it
+ * isn't a routable 1:1 user JID (group, broadcast, status, empty).
+ */
+export function jidToPhone(remoteJid: string | undefined): string | null {
+  if (!remoteJid) return null;
+  if (
+    remoteJid.endsWith('@g.us') ||
+    remoteJid.endsWith('@broadcast') ||
+    remoteJid === 'status@broadcast'
+  ) {
+    return null;
+  }
+  const raw = remoteJid.split('@')[0].split(':')[0].replace(/[^\d]/g, '');
+  return raw ? `+${raw}` : null;
+}
+
+/** Map an Evolution message object to our content_type + text. */
+export function parseContent(data: EvolutionMessageData): {
+  contentType: string;
+  contentText: string;
+} {
+  const m = data.message ?? {};
+  if (typeof m.conversation === 'string' && m.conversation.length > 0) {
+    return { contentType: 'text', contentText: m.conversation };
+  }
+  if (m.extendedTextMessage?.text) {
+    return { contentType: 'text', contentText: m.extendedTextMessage.text };
+  }
+  if (m.imageMessage) {
+    return { contentType: 'image', contentText: m.imageMessage.caption || '[image]' };
+  }
+  if (m.videoMessage) {
+    return { contentType: 'video', contentText: m.videoMessage.caption || '[video]' };
+  }
+  if (m.documentMessage) {
+    return {
+      contentType: 'document',
+      contentText:
+        m.documentMessage.caption || m.documentMessage.fileName || '[document]',
+    };
+  }
+  if (m.audioMessage) {
+    return { contentType: 'audio', contentText: '[audio]' };
+  }
+  // Unknown/unsupported shape — record something rather than dropping it.
+  return { contentType: 'text', contentText: '[unsupported message]' };
+}
+
+export async function POST(request: Request) {
+  let body: EvolutionWebhookBody;
+  try {
+    body = (await request.json()) as EvolutionWebhookBody;
+  } catch {
+    return Response.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  // Only inbound messages. Ack everything else with 200 so Evolution
+  // doesn't retry connection/status/presence events at us.
+  if (body.event !== 'messages.upsert') {
+    return Response.json({ ok: true, ignored: body.event ?? 'unknown' });
+  }
+
+  const instanceName = body.instance;
+  if (!instanceName) {
+    return Response.json({ error: 'missing_instance' }, { status: 400 });
+  }
+
+  // Route to the owning config by instance name (UNIQUE — migration 037).
+  const { data: config, error: configError } = await supabaseAdmin()
+    .from('whatsapp_config')
+    .select('id, account_id, access_token, api_type, instance_name')
+    .eq('instance_name', instanceName)
+    .eq('api_type', 'evolution')
+    .maybeSingle();
+
+  if (configError || !config) {
+    // Unknown instance — don't reveal which. 404 keeps Evolution from
+    // hammering retries the way a 500 would.
+    return Response.json({ error: 'unknown_instance' }, { status: 404 });
+  }
+
+  // Authenticate. Evolution can present the instance apikey via an
+  // `apikey` header or in the JSON body; accept either, compare in
+  // constant time to the stored (decrypted) token.
+  const presented = request.headers.get('apikey') || body.apikey || '';
+  let expected = '';
+  try {
+    expected = config.access_token ? decrypt(config.access_token) : '';
+  } catch {
+    expected = '';
+  }
+  if (!presented || !expected || !safeEqual(presented, expected)) {
+    return Response.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const accountId = config.account_id as string;
+  const events = Array.isArray(body.data) ? body.data : body.data ? [body.data] : [];
+
+  let processed = 0;
+  for (const evt of events) {
+    const key = evt.key ?? {};
+    // Skip our own outbound echoes and non-user JIDs (groups, broadcast).
+    if (key.fromMe) continue;
+    const phone = jidToPhone(key.remoteJid);
+    if (!phone) continue;
+
+    let resolved;
+    try {
+      resolved = await resolveConversationByPhone(
+        supabaseAdmin(),
+        accountId,
+        phone,
+        evt.pushName || null
+      );
+    } catch (err) {
+      console.error(
+        '[evolution-webhook] resolveConversationByPhone failed:',
+        err instanceof Error ? err.message : err
+      );
+      continue;
+    }
+
+    // Dedupe: Evolution can redeliver. Skip if we already stored this id.
+    if (key.id) {
+      const { data: existing } = await supabaseAdmin()
+        .from('messages')
+        .select('id')
+        .eq('conversation_id', resolved.conversationId)
+        .eq('message_id', key.id)
+        .maybeSingle();
+      if (existing) continue;
+    }
+
+    const { contentType, contentText } = parseContent(evt);
+    const safeType = ALLOWED_CONTENT_TYPES.has(contentType) ? contentType : 'text';
+
+    const tsSeconds =
+      typeof evt.messageTimestamp === 'string'
+        ? parseInt(evt.messageTimestamp, 10)
+        : evt.messageTimestamp;
+    const createdAt =
+      tsSeconds && !Number.isNaN(tsSeconds)
+        ? new Date(tsSeconds * 1000).toISOString()
+        : new Date().toISOString();
+
+    const { error: msgError } = await supabaseAdmin().from('messages').insert({
+      conversation_id: resolved.conversationId,
+      sender_type: 'customer',
+      content_type: safeType,
+      content_text: contentText,
+      media_url: null,
+      message_id: key.id || null,
+      status: 'delivered',
+      created_at: createdAt,
+    });
+
+    if (msgError) {
+      console.error('[evolution-webhook] insert message failed:', msgError.message);
+      continue;
+    }
+
+    // Bump the conversation. Read current unread_count first (same
+    // best-effort increment the Meta webhook does).
+    const { data: conv } = await supabaseAdmin()
+      .from('conversations')
+      .select('unread_count')
+      .eq('id', resolved.conversationId)
+      .maybeSingle();
+
+    await supabaseAdmin()
+      .from('conversations')
+      .update({
+        last_message_text: contentText,
+        last_message_at: new Date().toISOString(),
+        unread_count: ((conv?.unread_count as number) || 0) + 1,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', resolved.conversationId);
+
+    processed += 1;
+  }
+
+  return Response.json({ ok: true, processed });
+}

--- a/src/components/settings/whatsapp-config.tsx
+++ b/src/components/settings/whatsapp-config.tsx
@@ -70,6 +70,13 @@ export function WhatsAppConfig() {
   const [pin, setPin] = useState('');
   const [tokenEdited, setTokenEdited] = useState(false);
 
+  // Transport selector. 'meta' = official Cloud API; 'evolution' =
+  // unofficial WhatsApp-Web bridge (Evolution API). Evolution reuses
+  // `accessToken` above as the instance apikey.
+  const [apiType, setApiType] = useState<'meta' | 'evolution'>('meta');
+  const [apiUrl, setApiUrl] = useState('');
+  const [instanceName, setInstanceName] = useState('');
+
   // True once /register has succeeded on Meta's side (timestamp set
   // in the row). When false, the saved config is metadata-only and
   // Meta will silently drop every inbound event — that's the
@@ -91,7 +98,9 @@ export function WhatsAppConfig() {
 
   const webhookUrl =
     typeof window !== 'undefined'
-      ? `${window.location.origin}/api/whatsapp/webhook`
+      ? `${window.location.origin}/api/whatsapp/${
+          apiType === 'evolution' ? 'evolution-webhook' : 'webhook'
+        }`
       : '';
 
   const fetchConfig = useCallback(async (acctId: string) => {
@@ -121,6 +130,9 @@ export function WhatsAppConfig() {
         setVerifyToken('');
         setPin('');
         setTokenEdited(false);
+        setApiType(data.api_type === 'evolution' ? 'evolution' : 'meta');
+        setApiUrl(data.api_url || '');
+        setInstanceName(data.instance_name || '');
       } else {
         setConfig(null);
         setPhoneNumberId('');
@@ -129,12 +141,24 @@ export function WhatsAppConfig() {
         setVerifyToken('');
         setPin('');
         setTokenEdited(false);
+        setApiType('meta');
+        setApiUrl('');
+        setInstanceName('');
       }
       // Clear any stale probe result when reloading the row.
       setRegistrationProbe(null);
 
-      // Then verify health via the API (decrypts token + pings Meta)
-      if (data) {
+      // Evolution rows can't be health-checked through the Meta GET path
+      // (it pings graph.facebook.com with a null phone_number_id). Trust
+      // the stored status, set at save time by the connection-state probe.
+      if (data && data.api_type === 'evolution') {
+        setConnectionStatus(
+          data.status === 'connected' ? 'connected' : 'disconnected'
+        );
+        setResetReason(null);
+        setStatusMessage('');
+      } else if (data) {
+        // Then verify health via the API (decrypts token + pings Meta)
         try {
           const res = await fetch('/api/whatsapp/config', { method: 'GET' });
           const payload = await res.json();
@@ -183,6 +207,9 @@ export function WhatsAppConfig() {
   }, [authLoading, profileLoading, user?.id, accountId, fetchConfig]);
 
   async function handleSave() {
+    if (apiType === 'evolution') {
+      return handleSaveEvolution();
+    }
     if (!phoneNumberId.trim()) {
       toast.error('Phone Number ID is required');
       return;
@@ -271,6 +298,56 @@ export function WhatsAppConfig() {
       if (accountId) await fetchConfig(accountId);
     } catch (err) {
       console.error('Save error:', err);
+      toast.error('Failed to save configuration');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSaveEvolution() {
+    if (!apiUrl.trim() || !instanceName.trim()) {
+      toast.error(t('evoUrlInstanceRequired'));
+      return;
+    }
+    // First save needs the apikey; on update we can reuse the stored one.
+    if (!config && (!accessToken.trim() || !tokenEdited)) {
+      toast.error(t('evoApiKeyRequired'));
+      return;
+    }
+    try {
+      setSaving(true);
+      const payload: Record<string, unknown> = {
+        api_type: 'evolution',
+        api_url: apiUrl.trim(),
+        instance_name: instanceName.trim(),
+      };
+      // Only send the apikey when the user actually typed one — otherwise
+      // the server reuses the stored (encrypted) value.
+      if (tokenEdited && accessToken !== MASKED_TOKEN && accessToken.trim()) {
+        payload.access_token = accessToken.trim();
+      }
+
+      const res = await fetch('/api/whatsapp/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to save configuration');
+        return;
+      }
+
+      if (data.connected) {
+        toast.success(t('evoConnected'));
+      } else {
+        toast.success(t('evoSavedNotConnected'), { duration: 9000 });
+      }
+
+      if (accountId) await fetchConfig(accountId);
+    } catch (err) {
+      console.error('Evolution save error:', err);
       toast.error('Failed to save configuration');
     } finally {
       setSaving(false);
@@ -563,6 +640,42 @@ export function WhatsAppConfig() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
+            {/* Transport selector: official Meta vs unofficial Evolution */}
+            <div className="space-y-2">
+              <Label className="text-muted-foreground">{t('apiTypeLabel')}</Label>
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  onClick={() => setApiType('meta')}
+                  className={`rounded-md border px-3 py-2 text-sm transition-colors ${
+                    apiType === 'meta'
+                      ? 'border-primary bg-primary/10 text-foreground'
+                      : 'border-border bg-muted text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {t('apiTypeMeta')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setApiType('evolution')}
+                  className={`rounded-md border px-3 py-2 text-sm transition-colors ${
+                    apiType === 'evolution'
+                      ? 'border-primary bg-primary/10 text-foreground'
+                      : 'border-border bg-muted text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {t('apiTypeEvolution')}
+                </button>
+              </div>
+              {apiType === 'evolution' && (
+                <p className="text-xs text-amber-500/90 leading-relaxed">
+                  {t('evoWarning')}
+                </p>
+              )}
+            </div>
+
+            {apiType === 'meta' && (
+            <>
             <div className="space-y-2">
               <Label className="text-muted-foreground">{t('phoneNumberId')}</Label>
               <Input
@@ -650,6 +763,66 @@ export function WhatsAppConfig() {
                 <span dangerouslySetInnerHTML={{ __html: t('pinHint') }} />
               </p>
             </div>
+            </>
+            )}
+
+            {apiType === 'evolution' && (
+            <>
+            <div className="space-y-2">
+              <Label className="text-muted-foreground">{t('evoServerUrl')}</Label>
+              <Input
+                placeholder="http://localhost:8080"
+                value={apiUrl}
+                onChange={(e) => setApiUrl(e.target.value)}
+                className="bg-muted border-border text-foreground placeholder:text-muted-foreground font-mono text-sm"
+              />
+              <p className="text-xs text-muted-foreground">{t('evoServerUrlHint')}</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label className="text-muted-foreground">{t('evoInstanceName')}</Label>
+              <Input
+                placeholder="pablo_crm"
+                value={instanceName}
+                onChange={(e) => setInstanceName(e.target.value)}
+                className="bg-muted border-border text-foreground placeholder:text-muted-foreground"
+              />
+              <p className="text-xs text-muted-foreground">{t('evoInstanceNameHint')}</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label className="text-muted-foreground">{t('evoApiKey')}</Label>
+              <div className="relative">
+                <Input
+                  type={showToken ? 'text' : 'password'}
+                  placeholder={t('evoApiKeyPlaceholder')}
+                  value={accessToken}
+                  onChange={(e) => {
+                    setAccessToken(e.target.value);
+                    setTokenEdited(true);
+                  }}
+                  onFocus={() => {
+                    if (accessToken === MASKED_TOKEN) {
+                      setAccessToken('');
+                      setTokenEdited(true);
+                    }
+                  }}
+                  className="bg-muted border-border text-foreground placeholder:text-muted-foreground pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowToken(!showToken)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {showToken ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                </button>
+              </div>
+              {config && !tokenEdited && (
+                <p className="text-xs text-muted-foreground">{t('tokenHidden')}</p>
+              )}
+            </div>
+            </>
+            )}
           </CardContent>
         </Card>
 

--- a/src/lib/whatsapp/evolution-api.test.ts
+++ b/src/lib/whatsapp/evolution-api.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  sendEvolutionText,
+  sendEvolutionMedia,
+} from "./evolution-api";
+
+const BASE_ARGS = {
+  apiUrl: "http://localhost:8080",
+  instanceName: "pablo_crm",
+  apiKey: "secret-apikey",
+  to: "+5547999998888",
+} as const;
+
+// A fetch stub that records the call and returns a canned OK response.
+// Typed args so `mock.calls[0]` reads back as [url, RequestInit].
+function okFetch(json: unknown = { key: { id: "wamid.EVO123" } }) {
+  return vi.fn(async (_url: string, _init: RequestInit) =>
+    new Response(JSON.stringify(json), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+const headersOf = (init: RequestInit) =>
+  init.headers as Record<string, string>;
+const bodyOf = (init: RequestInit) => JSON.parse(init.body as string);
+
+describe("sendEvolutionText", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("POSTs to /message/sendText/{instance} with the apikey header", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await sendEvolutionText({ ...BASE_ARGS, text: "Olá!" });
+
+    expect(result.messageId).toBe("wamid.EVO123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:8080/message/sendText/pablo_crm");
+    expect(init.method).toBe("POST");
+    expect(headersOf(init).apikey).toBe("secret-apikey");
+  });
+
+  it("strips the '+' and separators from the recipient number", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEvolutionText({ ...BASE_ARGS, to: "+55 (47) 99999-8888", text: "hi" });
+
+    const body = bodyOf(fetchMock.mock.calls[0][1]);
+    expect(body.number).toBe("5547999998888");
+    expect(body.text).toBe("hi");
+  });
+
+  it("trims a trailing slash on the base URL", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEvolutionText({
+      ...BASE_ARGS,
+      apiUrl: "http://localhost:8080/",
+      text: "hi",
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://localhost:8080/message/sendText/pablo_crm",
+    );
+  });
+
+  it("throws with the server detail on a non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("instance not found", { status: 404 })),
+    );
+
+    await expect(
+      sendEvolutionText({ ...BASE_ARGS, text: "hi" }),
+    ).rejects.toThrow(/Evolution API error: 404: instance not found/);
+  });
+
+  it("returns an empty messageId when the server omits key.id", async () => {
+    vi.stubGlobal("fetch", okFetch({ status: "PENDING" }));
+
+    const result = await sendEvolutionText({ ...BASE_ARGS, text: "hi" });
+    expect(result.messageId).toBe("");
+  });
+});
+
+describe("sendEvolutionMedia", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("sends image/video/document via /message/sendMedia with mediatype", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEvolutionMedia({
+      ...BASE_ARGS,
+      kind: "image",
+      link: "https://cdn.example.com/pic.jpg",
+      caption: "look",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:8080/message/sendMedia/pablo_crm");
+    const body = bodyOf(init);
+    expect(body.mediatype).toBe("image");
+    expect(body.media).toBe("https://cdn.example.com/pic.jpg");
+    expect(body.caption).toBe("look");
+  });
+
+  it("sets fileName only for documents", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEvolutionMedia({
+      ...BASE_ARGS,
+      kind: "document",
+      link: "https://cdn.example.com/invoice.pdf",
+      filename: "invoice.pdf",
+    });
+
+    const body = bodyOf(fetchMock.mock.calls[0][1]);
+    expect(body.fileName).toBe("invoice.pdf");
+  });
+
+  it("routes audio to /message/sendWhatsAppAudio and never sends a caption", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEvolutionMedia({
+      ...BASE_ARGS,
+      kind: "audio",
+      link: "https://cdn.example.com/note.ogg",
+      caption: "ignored",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "http://localhost:8080/message/sendWhatsAppAudio/pablo_crm",
+    );
+    const body = bodyOf(init);
+    expect(body.audio).toBe("https://cdn.example.com/note.ogg");
+    expect(body.caption).toBeUndefined();
+  });
+
+  it("throws when called without a link", async () => {
+    vi.stubGlobal("fetch", okFetch());
+    await expect(
+      sendEvolutionMedia({ ...BASE_ARGS, kind: "image", link: "" }),
+    ).rejects.toThrow(/requires a link/);
+  });
+});

--- a/src/lib/whatsapp/evolution-api.ts
+++ b/src/lib/whatsapp/evolution-api.ts
@@ -1,0 +1,200 @@
+// ============================================================
+// Evolution API transport (UNOFFICIAL WhatsApp Web).
+//
+// A thin outbound client for a self-hosted Evolution API v2 instance,
+// mirroring the shape of the Meta helpers in `meta-api.ts` (single
+// fetch, throws on non-2xx, returns `{ messageId }`) so the shared
+// `sendMessageToConversation` core can branch on `api_type` without
+// caring which transport runs underneath.
+//
+// ⚠️ Evolution talks to WhatsApp Web on your behalf — this violates
+// WhatsApp's Terms of Service and the number can be banned without
+// warning. It's a zero-cost option for personal / testing use, not a
+// drop-in for the official Cloud API.
+//
+// What this transport does NOT do (by design, for now):
+//   - templates: a Meta-official concept with no Evolution equivalent.
+//   - interactive buttons/lists: WhatsApp is deprecating them on the
+//     Web protocol and Evolution's support is unreliable.
+// The send core rejects those message types up front for Evolution
+// with a clear error rather than silently dropping them.
+// ============================================================
+
+export interface EvolutionSendResult {
+  /** The WhatsApp message id (`key.id`) Evolution echoes back. */
+  messageId: string;
+}
+
+export interface EvolutionBaseArgs {
+  /** Server base URL, no trailing slash (e.g. http://localhost:8080). */
+  apiUrl: string;
+  /** Instance name that identifies this connection on the server. */
+  instanceName: string;
+  /** The instance's apikey (stored encrypted in access_token). */
+  apiKey: string;
+  /** Recipient in E.164 (`+55…`) — the '+' is stripped for Evolution. */
+  to: string;
+}
+
+export interface SendEvolutionTextArgs extends EvolutionBaseArgs {
+  text: string;
+}
+
+/**
+ * Evolution wants the recipient as bare digits (no '+', no separators).
+ * A quoted-reply id or JID suffix is never appended here — Evolution
+ * resolves the JID itself from the number.
+ */
+function toEvolutionNumber(to: string): string {
+  return to.replace(/[^\d]/g, '');
+}
+
+function baseUrl(apiUrl: string): string {
+  return apiUrl.replace(/\/+$/, '');
+}
+
+async function throwEvolutionError(
+  response: Response,
+  fallback: string
+): Promise<never> {
+  let detail = '';
+  try {
+    const body = await response.text();
+    detail = body.slice(0, 500);
+  } catch {
+    /* ignore — use the fallback */
+  }
+  throw new Error(detail ? `${fallback}: ${detail}` : fallback);
+}
+
+/**
+ * Extract the message id from an Evolution send response. v2 returns
+ * `{ key: { id, remoteJid, fromMe }, ... }`; we tolerate a missing id
+ * (some server builds omit it on success) by falling back to an empty
+ * string so the caller can still persist the row.
+ */
+function extractMessageId(data: unknown): string {
+  if (
+    data &&
+    typeof data === 'object' &&
+    'key' in data &&
+    data.key &&
+    typeof data.key === 'object' &&
+    'id' in data.key &&
+    typeof (data.key as { id: unknown }).id === 'string'
+  ) {
+    return (data.key as { id: string }).id;
+  }
+  return '';
+}
+
+/**
+ * Send a plain text message through an Evolution instance.
+ * POST {apiUrl}/message/sendText/{instance} with the `apikey` header.
+ */
+export async function sendEvolutionText(
+  args: SendEvolutionTextArgs
+): Promise<EvolutionSendResult> {
+  const { apiUrl, instanceName, apiKey, to, text } = args;
+  const url = `${baseUrl(apiUrl)}/message/sendText/${encodeURIComponent(
+    instanceName
+  )}`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: apiKey,
+    },
+    // Evolution v2 flattened the old `options` object — `delay` and
+    // `presence` are top-level now. `presence: 'composing'` shows the
+    // "typing…" indicator before the message lands, which reads more
+    // human on a personal number.
+    body: JSON.stringify({
+      number: toEvolutionNumber(to),
+      text,
+      delay: 1000,
+      presence: 'composing',
+    }),
+  });
+
+  if (!response.ok) {
+    await throwEvolutionError(response, `Evolution API error: ${response.status}`);
+  }
+  const data = await response.json();
+  return { messageId: extractMessageId(data) };
+}
+
+export type EvolutionMediaKind = 'image' | 'video' | 'document' | 'audio';
+
+export interface SendEvolutionMediaArgs extends EvolutionBaseArgs {
+  kind: EvolutionMediaKind;
+  /** Public URL Evolution fetches at send time. */
+  link: string;
+  /** Optional caption. Not applied to audio (voice notes carry none). */
+  caption?: string;
+  /** Document-only. File name shown in the recipient's chat. */
+  filename?: string;
+}
+
+/**
+ * Send an image, video, document, or audio through an Evolution
+ * instance. Audio uses the dedicated `/message/sendWhatsAppAudio`
+ * endpoint (renders as a playable voice note); the rest go through
+ * `/message/sendMedia` with a `mediatype`.
+ */
+export async function sendEvolutionMedia(
+  args: SendEvolutionMediaArgs
+): Promise<EvolutionSendResult> {
+  const { apiUrl, instanceName, apiKey, to, kind, link, caption, filename } =
+    args;
+  if (!link) throw new Error('sendEvolutionMedia requires a link.');
+
+  const number = toEvolutionNumber(to);
+  const headers = {
+    'Content-Type': 'application/json',
+    apikey: apiKey,
+  };
+
+  if (kind === 'audio') {
+    const url = `${baseUrl(apiUrl)}/message/sendWhatsAppAudio/${encodeURIComponent(
+      instanceName
+    )}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ number, audio: link, delay: 1000 }),
+    });
+    if (!response.ok) {
+      await throwEvolutionError(
+        response,
+        `Evolution API error: ${response.status}`
+      );
+    }
+    const data = await response.json();
+    return { messageId: extractMessageId(data) };
+  }
+
+  const url = `${baseUrl(apiUrl)}/message/sendMedia/${encodeURIComponent(
+    instanceName
+  )}`;
+  const body: Record<string, unknown> = {
+    number,
+    mediatype: kind,
+    media: link,
+    delay: 1000,
+  };
+  if (caption) body.caption = caption;
+  if (kind === 'document' && filename) body.fileName = filename;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    await throwEvolutionError(response, `Evolution API error: ${response.status}`);
+  }
+  const data = await response.json();
+  return { messageId: extractMessageId(data) };
+}

--- a/src/lib/whatsapp/send-message.ts
+++ b/src/lib/whatsapp/send-message.ts
@@ -30,6 +30,11 @@ import {
   type MediaKind,
 } from '@/lib/whatsapp/meta-api';
 import {
+  sendEvolutionText,
+  sendEvolutionMedia,
+  type EvolutionMediaKind,
+} from '@/lib/whatsapp/evolution-api';
+import {
   validateInteractivePayload,
   interactivePayloadPreviewText,
   type InteractiveMessagePayload,
@@ -329,7 +334,48 @@ export async function sendMessageToConversation(
     templateRow = data ?? null;
   }
 
+  const isEvolution = config.api_type === 'evolution';
+
   const attempt = async (phone: string): Promise<string> => {
+    // Evolution (unofficial WhatsApp Web) transport. Templates and
+    // interactive messages are Meta-Cloud concepts with no reliable
+    // Evolution equivalent — reject them clearly instead of silently
+    // dropping the send. Text + media go through the Evolution client.
+    if (isEvolution) {
+      if (messageType === 'template') {
+        throw new SendMessageError(
+          'unsupported_for_evolution',
+          'Templates are a Meta official-API feature and are not available on the Evolution (unofficial) transport.',
+          400
+        );
+      }
+      if (messageType === 'interactive') {
+        throw new SendMessageError(
+          'unsupported_for_evolution',
+          'Interactive button/list messages are not supported on the Evolution (unofficial) transport.',
+          400
+        );
+      }
+      const evoBase = {
+        apiUrl: config.api_url as string,
+        instanceName: config.instance_name as string,
+        apiKey: accessToken,
+        to: phone,
+      };
+      if (isMediaKind) {
+        const result = await sendEvolutionMedia({
+          ...evoBase,
+          kind: messageType as EvolutionMediaKind,
+          link: mediaUrl!,
+          caption: contentText || undefined,
+          filename: filename || undefined,
+        });
+        return result.messageId;
+      }
+      const result = await sendEvolutionText({ ...evoBase, text: contentText! });
+      return result.messageId;
+    }
+
     if (messageType === 'template') {
       const result = await sendTemplateMessage({
         phoneNumberId: config.phone_number_id,

--- a/supabase/migrations/037_unofficial_api_support.sql
+++ b/supabase/migrations/037_unofficial_api_support.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- 037: Unofficial API support (Evolution API)
+--
+-- Adds a second WhatsApp transport alongside the Meta Cloud API.
+-- When `api_type = 'evolution'`, outbound sends and the inbound
+-- webhook talk to a self-hosted Evolution API instance (WhatsApp
+-- Web protocol) instead of graph.facebook.com. This is an
+-- UNOFFICIAL transport — it violates WhatsApp's ToS and the number
+-- can be banned. It exists as a zero-cost option for personal /
+-- testing use, not as a replacement for the official API.
+--
+-- Storage model: the Evolution `apikey` reuses the existing
+-- (encrypted) `access_token` column, so no new secret column is
+-- introduced and the same AES-256-GCM at-rest protection applies.
+-- ============================================================
+
+-- 1. Meta-only NOT NULL columns become optional — an Evolution row
+--    has no Meta phone_number_id. (access_token still holds the
+--    Evolution apikey, so it stays populated in practice.)
+ALTER TABLE whatsapp_config ALTER COLUMN phone_number_id DROP NOT NULL;
+ALTER TABLE whatsapp_config ALTER COLUMN access_token DROP NOT NULL;
+
+-- 2. Transport selector. Existing rows default to 'meta' — no
+--    behaviour change for anyone already connected to the Cloud API.
+ALTER TABLE whatsapp_config
+  ADD COLUMN IF NOT EXISTS api_type TEXT NOT NULL DEFAULT 'meta'
+    CHECK (api_type IN ('meta', 'evolution'));
+
+-- 3. Evolution-specific coordinates: the server base URL and the
+--    instance name that identifies this connection on that server.
+ALTER TABLE whatsapp_config
+  ADD COLUMN IF NOT EXISTS api_url TEXT,
+  ADD COLUMN IF NOT EXISTS instance_name TEXT;
+
+-- 4. The inbound Evolution webhook routes by `instance_name` (the
+--    Meta webhook routes by `phone_number_id`, which migration 013
+--    made UNIQUE for exactly this reason: the handler does a
+--    `.single()` lookup and two configs sharing the key would make it
+--    error). Enforce the same one-owner-per-key guarantee for
+--    Evolution instances. Partial index so it only constrains
+--    Evolution rows and ignores NULLs on Meta rows.
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_config_instance_name_unique
+  ON whatsapp_config (instance_name)
+  WHERE instance_name IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds an unofficial Evolution API transport for sending WhatsApp messages (text + media), as an alternative to the official Meta Cloud API
- Adds an inbound webhook endpoint for Evolution API (`/api/whatsapp/evolution-webhook`) with HMAC-safe apikey auth and message dedup
- Adds Settings UI to configure Evolution API credentials (API URL, instance name, API key) alongside the existing Meta configuration

## Context
Evolution API talks to WhatsApp Web on the account's behalf and is **not** an official/sanctioned integration — it's opt-in, for internal/personal use, and carries a ban risk per WhatsApp's ToS (documented in migration 037). The official Meta Cloud API remains the recommended path for production/commercial use.

## Test plan
- [ ] Verify Settings → WhatsApp shows the Meta/Evolution toggle and saves correctly
- [ ] Verify `/api/whatsapp/evolution-webhook` accepts a real Evolution API webhook payload and creates a message
- [ ] Send a test message from the CRM through an Evolution API instance and confirm delivery
- [ ] Confirm existing Meta API flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)