### PR TITLE
fix(pipelines): make the Delete Pipeline button text visible

### DIFF
--- a/src/components/pipelines/pipeline-settings.tsx
+++ b/src/components/pipelines/pipeline-settings.tsx
@@ -337,9 +337,8 @@ export function PipelineSettings({
 
             <DialogFooter className="border-border bg-popover/50">
               <Button
-                variant="destructive"
                 onClick={() => setShowDeleteConfirm(true)}
-                className="mr-auto bg-red-600 hover:bg-red-700"
+                className="mr-auto bg-red-600 text-white hover:bg-red-700"
               >
                 {t("deletePipeline")}
               </Button>


### PR DESCRIPTION
## Summary

The "Delete Pipeline" button in the Manage Pipeline dialog renders as a solid red block with no readable label. Closes #420.

## What changed

`src/components/pipelines/pipeline-settings.tsx` — the button paired `variant="destructive"` with a `bg-red-600` override. The `destructive` variant is the *soft* treatment (`bg-destructive/10 text-destructive`), so the override swapped the tinted background for solid red but left the text red: red on red.

Dropped the variant and added `text-white`. That's how every other solid-red button in the app is written — `members-tab.tsx:599`, `template-manager.tsx:1114`, `deal-form.tsx:404`, `broadcasts/[id]/page.tsx:327`, and the delete-*confirm* button at `pipeline-settings.tsx:233` in this very same dialog. The two buttons in this dialog are now styled identically.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 39 warnings, identical to `main`.
- [x] `npm test` — 645 tests pass.
- [x] `npm run build` succeeds.
- [x] Rendered before/after/reference side by side in the browser and confirmed visually: the current button shows an empty red rectangle, the fixed one reads "Delete Pipeline" in white, and it is pixel-identical to the existing confirm button.

## Related

Closes #420.