### PR TITLE
fix(automations): stop inbound runs being dropped and mislogged

### DIFF
--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -781,8 +781,16 @@ async function processMessage(
   // listens to only one trigger runs only when that trigger matches.
   if (contactOutcome.wasCreated) automationTriggers.unshift('new_contact_created')
   if (isFirstInboundMessage) automationTriggers.unshift('first_inbound_message')
+  // Awaited — not fire-and-forget. We're inside the route's `after()`
+  // block, which only keeps the function alive for promises it can see, so
+  // a detached dispatch can be frozen part-way through: the log row is
+  // inserted, then the steps never run. That is issue #301's failure mode
+  // recurring one level down, and it's what issue #409 reported as runs
+  // logging zero steps. `runAutomationsForTrigger` owns its own try/catch
+  // and never throws; the `.catch` is belt-and-braces so one trigger
+  // type's failure can't skip the rest of the loop.
   for (const triggerType of automationTriggers) {
-    runAutomationsForTrigger({
+    await runAutomationsForTrigger({
       accountId,
       triggerType,
       contactId: contactRecord.id,

--- a/src/lib/automations/engine.test.ts
+++ b/src/lib/automations/engine.test.ts
@@ -11,6 +11,7 @@ const h = vi.hoisted(() => ({
     fromCalls: [] as string[],
     updateCalls: [] as { table: string; filters: [string, string, unknown][] }[],
     upsertCalls: [] as { table: string; payload: unknown }[],
+    logInserts: [] as Record<string, unknown>[],
     logUpdates: [] as Record<string, unknown>[],
   },
 }));
@@ -46,7 +47,10 @@ vi.mock("./admin-client", () => {
     }
     if (table === "automations") return { data: state.automations, error: null };
     if (table === "automation_logs") {
-      if (type === "insert") return { data: { id: "log1" }, error: null };
+      if (type === "insert") {
+        state.logInserts.push(ops.payload as Record<string, unknown>);
+        return { data: { id: "log1" }, error: null };
+      }
       if (type === "update") {
         state.logUpdates.push(ops.payload as Record<string, unknown>);
         return { data: null, error: null };
@@ -113,6 +117,7 @@ beforeEach(() => {
   h.state.fromCalls = [];
   h.state.updateCalls = [];
   h.state.upsertCalls = [];
+  h.state.logInserts = [];
   h.state.logUpdates = [];
 });
 
@@ -167,6 +172,47 @@ describe("runAutomationsForTrigger — tenant isolation", () => {
     const filters = h.state.updateCalls[0].filters;
     expect(filters).toContainEqual(["eq", "id", "c1"]);
     expect(filters).toContainEqual(["eq", "account_id", ACCOUNT]);
+  });
+});
+
+describe("automation_logs — status is seeded pessimistically (issue #409)", () => {
+  it("writes the log row as 'failed' before any step runs", async () => {
+    h.state.owned = { id: "c1" };
+    h.state.automations = [automationWithUpdateStep()];
+    h.state.steps = [updateStep()];
+
+    await runAutomationsForTrigger({
+      accountId: ACCOUNT,
+      triggerType: "new_message_received",
+      contactId: "c1",
+      context: {},
+    });
+
+    // The insert happens before execution, so a run killed mid-flight must
+    // not leave behind a row that claims it succeeded.
+    expect(h.state.logInserts).toHaveLength(1);
+    expect(h.state.logInserts[0]).toMatchObject({
+      status: "failed",
+      steps_executed: [],
+    });
+  });
+
+  it("still promotes the log to 'success' once the steps complete", async () => {
+    h.state.owned = { id: "c1" };
+    h.state.automations = [automationWithUpdateStep()];
+    h.state.steps = [updateStep()];
+
+    await runAutomationsForTrigger({
+      accountId: ACCOUNT,
+      triggerType: "new_message_received",
+      contactId: "c1",
+      context: {},
+    });
+
+    // The seed is only a floor — the outermost scope still writes the real
+    // verdict, so a completed run reports success as it always did.
+    const withStatus = h.state.logUpdates.filter((u) => "status" in u);
+    expect(withStatus.at(-1)).toMatchObject({ status: "success" });
   });
 });
 

--- a/src/lib/automations/engine.ts
+++ b/src/lib/automations/engine.ts
@@ -189,7 +189,15 @@ async function executeAutomation(automation: Automation, input: DispatchInput) {
       contact_id: input.contactId ?? null,
       trigger_event: input.triggerType,
       steps_executed: [],
-      status: 'success',
+      // Seeded pessimistically. The row is written BEFORE any step runs,
+      // and every terminal path below overwrites it (`appendResults` at
+      // the outermost scope, or `finalizeLog`). Seeding 'success' meant a
+      // run that died mid-flight — the process frozen, the pod recycled —
+      // left a permanent `status: 'success'` with `steps_executed: []`,
+      // indistinguishable from an automation that genuinely had nothing
+      // to do. 'failed' inverts that: the status only becomes success if
+      // execution actually reached the end. See issue #409.
+      status: 'failed',
     })
     .select()
     .single()


### PR DESCRIPTION
## Summary

Fixes the two defects behind #409's main symptom — automation logs reading `status: 'success'` with `steps_executed: []` ("No steps recorded"). Both are confirmed against `main`.

## What changed

**1. `src/app/api/whatsapp/webhook/route.ts` — await the dispatch loop.**

`runAutomationsForTrigger` was called fire-and-forget inside the route's `after()` block. `after()` only keeps the function alive for promises it can *see*, so the run could be frozen after the log row was inserted but before any step ran. This is issue #301's failure mode recurring one level down — and the file already documents the invariant: the AI auto-reply dispatch 10 lines below is awaited "(same reason as the webhook dispatch below)", and `dispatchWebhookEvent` below that carries "Awaited — not fire-and-forget — because we're inside the route's `after()` block". The automations loop was the one outlier.

The per-iteration `.catch` is kept, so one trigger type failing can't skip the rest of the loop.

**2. `src/lib/automations/engine.ts` — seed the log status pessimistically.**

`executeAutomation` inserted the log row with `status: 'success'` *before* executing anything. A run that died mid-flight therefore left a permanent `success` with an empty step list — indistinguishable from an automation that genuinely had nothing to do, which is exactly what the issue describes. Seeded as `'failed'` instead: the status only becomes success if execution reaches a terminal path.

No migration needed — `'failed'` is already in the column's `CHECK (status IN ('success','partial','failed'))`, and every terminal path (`appendResults` at the outermost scope, `finalizeLog`) overwrites the seed. The wait-step park path still writes `'partial'` as before.

## Deliberately not in this PR

Two further points from the issue change existing behaviour and want your call rather than mine:

- **Word-boundary keyword matching.** `triggerMatches` does use raw `haystack.includes(k)` for `contains` (`engine.ts:659`), so short keywords do match inside unrelated words. But switching to `\b` alters which automations fire for anyone already relying on substring matches — a behaviour change, not a bug fix.
- **Re-opening a closed conversation on an inbound reply.** Confirmed: the inbound conversation update never touches `status`. Whether a customer reply should reopen a thread an agent deliberately closed is a product decision. Note the issue also claims this blocks automations — it doesn't; dispatch is keyed on the contact, not the conversation status. The real effect is inbox visibility.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 39 warnings, identical to `main`.
- [x] `npm test` — 647 tests pass (2 new).
- [x] `npm run build` succeeds.
- [x] Two regression tests in `engine.test.ts`: the log row is inserted as `failed` with no steps, and a completed run is still promoted to `success`. Mutation-checked — restoring the `'success'` seed fails the first and only the first.

The `after()` change isn't unit-tested; there's no route-level harness on `main` and the behaviour is a runtime lifetime property rather than something the module boundary exposes.

## Related

Refs #409 (partial — see "deliberately not in this PR").