### PR TITLE
fix(i18n): label the contact name field with its own key

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -371,6 +371,7 @@
       "contactInfo": "Contact Information",
       "unnamed": "Unknown",
       "contactDetailsDesc": "Contact details",
+      "name": "Name",
       "phone": "Phone",
       "email": "Email",
       "company": "Company",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -371,6 +371,7 @@
       "contactInfo": "연락처 정보",
       "unnamed": "알 수 없음",
       "contactDetailsDesc": "연락처 정보",
+      "name": "이름",
       "phone": "전화번호",
       "email": "이메일",
       "company": "회사",

--- a/src/components/contacts/contact-detail-view.tsx
+++ b/src/components/contacts/contact-detail-view.tsx
@@ -462,7 +462,7 @@ export function ContactDetailView({
                   value="tags"
                   className="data-active:bg-muted data-active:text-primary text-muted-foreground"
                 >
-                  {t('tabs.tags', { fallback: 'Tags' })}
+                  {t('tabs.tags')}
                 </TabsTrigger>
                 <TabsTrigger
                   value="notes"
@@ -488,7 +488,7 @@ export function ContactDetailView({
               <TabsContent value="details" className="flex-1 overflow-y-auto px-4 py-3">
                 <div className="space-y-3">
                   <div className="space-y-1.5">
-                    <Label className="text-muted-foreground text-xs">{t('company', { fallback: 'Name' })}</Label>
+                    <Label className="text-muted-foreground text-xs">{t('name')}</Label>
                     <Input
                       value={editName}
                       onChange={(e) => setEditName(e.target.value)}


### PR DESCRIPTION
## Summary

The contact Details tab labels the name field with the `company` key, so it renders **"Company"** above the name input — and "Company" again above the actual company input. Wrong in English too, not just `ko`.

## What changed

`src/components/contacts/contact-detail-view.tsx:491` read:

```tsx
<Label>{t('company', { fallback: 'Name' })}</Label>
<Input value={editName} onChange={(e) => setEditName(e.target.value)} />
```

The namespace is `Contacts.detailView`, so that resolves to `Contacts.detailView.company` — `"Company"` / `"회사"`. There is no `Contacts.detailView.name` key in either catalogue; the `{ fallback: 'Name' }` looks like it covers that, but next-intl's second argument is ICU values, not options — confirmed against the installed 4.13.1 types, where `TranslateArgs` is `[values?, formats?]`. So it was silently discarded and the wrong label won.

- `messages/en.json` — add `Contacts.detailView.name` = `"Name"`.
- `messages/ko.json` — add `"이름"`, the term already used for name in six other places in the file.
- `contact-detail-view.tsx` — point the label at `t('name')`, and drop the two decorative `fallback` arguments (`:465` had one too, harmless there since the key exists, but it reads like a guard and isn't one).

Worth noting this is a class of drift the parity test from #419 can't catch: both catalogues have `company`, so key parity is satisfied — the bug is the call site reaching for the wrong key. Flagging it in case it shapes what else is worth guarding.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 39 warnings, same as `main`, no new ones.
- [x] `npm run build` succeeds.
- [x] `npm test` — `src/i18n/messages.test.ts` passes both directions (no missing keys, no orphans); the 5 failures in `currency` / `date-utils` are the known non-UTC/ICU artifacts of a local machine and are identical on `main`.
- [x] Script-checked every `t('…')` in the touched file against both catalogues: 34 keys, all resolving in `en` and `ko`.
- [ ] Not exercised in a browser — the Details tab needs an authenticated session against a live Supabase project. The change is a label key swap covered by the checks above.

Note: `messages/en.json`, `messages/ko.json` and `contact-detail-view.tsx` already fail `prettier --check` on `main`, so I left formatting alone rather than bury a two-line fix in a reformat. My additions follow the surrounding style.

## Related

Follows the `{ fallback: … }` observation in #418.
