### PR TITLE
docs: add referral code to Hostinger deploy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > it, host it.
 
 <p align="center">
-  <a href="https://www.hostinger.com/web-apps-hosting">
+  <a href="https://www.hostinger.com/web-apps-hosting?REFERRALCODE=WACRMHOST">
     <img src="./.github/assets/hostinger-deploy.png" alt="Ship your Node.js app in one click — Deploy to Hostinger" width="900">
   </a>
 </p>
@@ -65,7 +65,7 @@ This is a **template**, not a product. Forking means you get:
   modules you don't, redesign anything. The stack is boring on
   purpose (Next.js + Supabase + Tailwind) so the learning curve is
   short.
-- **Zero ops to start** — [Hostinger](https://www.hostinger.com/web-apps-hosting)
+- **Zero ops to start** — [Hostinger](https://www.hostinger.com/web-apps-hosting?REFERRALCODE=WACRMHOST)
   Managed Node.js deploys a fork in a few clicks. No Docker, no
   Kubernetes, no infra team needed.
   ([See below ↓](#-deploy-on-hostinger-recommended))
@@ -96,7 +96,7 @@ Dockerfile + Docker Compose setup.
 ## 🚀 Deploy on Hostinger (recommended)
 
 <p align="center">
-  <a href="https://www.hostinger.com/web-apps-hosting">
+  <a href="https://www.hostinger.com/web-apps-hosting?REFERRALCODE=WACRMHOST">
     <img src="./.github/assets/hostinger-deploy.png" alt="Ship your Node.js app in one click — Deploy to Hostinger" width="1000">
   </a>
 </p>
@@ -106,7 +106,7 @@ Dockerfile + Docker Compose setup.
   </a>
 </p>
 
-**wacrm is built to run on [Hostinger](https://www.hostinger.com/web-apps-hosting).**
+**wacrm is built to run on [Hostinger](https://www.hostinger.com/web-apps-hosting?REFERRALCODE=WACRMHOST).**
 It's the path we test, document, and recommend — and the fastest way
 to get a production-grade CRM live without owning a VPS or a
 Kubernetes cluster.
@@ -116,7 +116,7 @@ Kubernetes cluster.
 | | |
 |---|---|
 | **One-click Git deploy** | Connect your fork, push to `main`, Hostinger builds and ships it. No SSH, no Docker, no CI to wire up — this repo's own `main` deploys this way. |
-| **Managed Node.js** | Next.js 16 (App Router, server actions, ISR) runs out of the box on [Premium, Business, and Cloud](https://www.hostinger.com/web-apps-hosting) shared plans. You don't manage Node versions, processes, or reverse proxies. |
+| **Managed Node.js** | Next.js 16 (App Router, server actions, ISR) runs out of the box on [Premium, Business, and Cloud](https://www.hostinger.com/web-apps-hosting?REFERRALCODE=WACRMHOST) shared plans. You don't manage Node versions, processes, or reverse proxies. |
 | **Free SSL + free domain** | Automatic Let's Encrypt on your custom domain (or a free one included with annual plans). HTTPS is on by default — required for the WhatsApp Business webhook. |
 | **Global CDN + LiteSpeed** | Static assets cached at the edge, dynamic routes served from LiteSpeed. Snappy dashboards out of the box, no Cloudflare setup required. |
 | **Env vars + logs in hPanel** | Set `SUPABASE_*`, `WHATSAPP_*`, and `ENCRYPTION_KEY` from the panel — no `.env` on the server. Live application logs in the same UI. |


### PR DESCRIPTION
All five outbound Hostinger links in the README now carry `REFERRALCODE=WACRMHOST`, so signups originating from the project are attributed.

## What changed

| Location | Link |
|---|---|
| Deploy banner (top of README) | `/web-apps-hosting?REFERRALCODE=WACRMHOST` |
| "Zero ops to start" bullet | same |
| Deploy banner (Deploy on Hostinger section) | same |
| "wacrm is built to run on Hostinger" | same |
| "Premium, Business, and Cloud" in the Why Hostinger table | same |

## Note on the URL form

The product path (`/web-apps-hosting`) is kept rather than pointing at the homepage. The referral code tracks either way, and the product page is what the surrounding copy is about — a homepage link would also have pinned visitors to a single locale.

Only `README.md` changes here; the matching site-side change is in ArnasDon/wacrm-site.

## Verification

`README.md` is the only file touched, so lint/typecheck/test/build are unaffected. Audit grep returns no bare Hostinger links:

```
grep -oE 'https?://[a-z0-9._-]*hostinger\.com[^)" <>]*' README.md | sort | uniq -c
#   5 https://www.hostinger.com/web-apps-hosting?REFERRALCODE=WACRMHOST
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)