### PR TITLE
chore: pin packageManager to npm 10 so Dependabot matches CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "packageManager": "npm@10.9.9",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Attempts to retire the recurring lockfile repair that every Dependabot PR currently needs.

### The problem

Every Dependabot PR fails CI at `npm ci` in ~10s, before `lint`/`typecheck`/`test`/`build` get a chance to run:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: @swc/helpers@0.5.23 from lock file
```

This is shared infra drift, not a problem with any individual bump. `next-intl` declares an optional peer `@swc/helpers >=0.5.17`. npm 10 resolves that to a nested `node_modules/next-intl/node_modules/@swc/helpers` entry, which `main`'s committed lockfile contains — so main's CI passes. Dependabot regenerates the lockfile with npm 11, which **drops** that nested optional-peer entry, and CI's Node 20 (npm 10) then rejects it as out of sync.

It has now recurred across three rounds — #380/#382/#383, #434–#437, and #458–#462 — each time needing an identical manual `npm@10 install --package-lock-only` per branch.

### The fix

Dependabot resolves its npm version from `packageManager` **first**, ahead of the `engines` field and the inferred `lockfileVersion` ([`package_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb)), and npm 10 is in its supported set ([`npm_package_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/npm_package_manager.rb)). Pinning it should make the bot emit npm-10-shaped lockfiles that CI accepts unmodified.

### Why this is safe

The field is inert for everything except Dependabot:

- **corepack is not enabled** and the workflow does not opt into it, so `actions/setup-node@v7` keeps using Node 20's bundled npm. npm itself does not enforce `packageManager`.
- Adding it changes **nothing** in `package-lock.json` (verified: `package.json` is the only modified file).
- `npm ci` exits 0 under both **npm 10.9.9** and local **npm 11.11.0** — neither rejects the pin, so contributors on npm 11 are unaffected.
- All four CI steps pass: lint (39 warnings / 0 errors, unchanged baseline), typecheck clean, 654 tests, build succeeds.

`10.9.9` is the current npm 10.x. Lockfiles generated with it are already known-good against CI's bundled npm 10.8.2 — #459, #460 and #461 were regenerated with exactly that version and went green.

### Caveat

Whether Dependabot honours the pin in practice can only be confirmed by observing the **next** bot-raised PR. The code path above says it should; if it does not, this costs nothing and can be reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)