### PR TITLE
feat: view and download chat attachments from the inbox (#373)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -216,7 +216,25 @@
       "interactiveReply": "[Interactive reply]",
       "unsupported": "[Unsupported message type]",
       "aiBadge": "AI",
-      "aiBadgeTitle": "Sent automatically by the AI assistant"
+      "aiBadgeTitle": "Sent automatically by the AI assistant",
+      "download": "Download",
+      "downloadFailed": "Couldn't download the attachment",
+      "viewImage": "View image",
+      "expandVideo": "Expand video",
+      "imageAlt": "Shared image"
+    },
+    "mediaViewer": {
+      "counter": "{index} of {total}",
+      "previous": "Previous",
+      "next": "Next",
+      "zoomIn": "Zoom to full size",
+      "zoomOut": "Fit to screen",
+      "openOriginal": "Open original",
+      "download": "Download",
+      "downloadFailed": "Couldn't download the attachment",
+      "failed": "This attachment is no longer available",
+      "imageAlt": "Shared image",
+      "you": "You"
     },
     "actions": {
       "reply": "Reply",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -216,7 +216,25 @@
       "interactiveReply": "[인터랙티브 응답]",
       "unsupported": "[지원되지 않는 메시지 형식]",
       "aiBadge": "AI",
-      "aiBadgeTitle": "AI 어시스턴트가 자동으로 전송함"
+      "aiBadgeTitle": "AI 어시스턴트가 자동으로 전송함",
+      "download": "다운로드",
+      "downloadFailed": "첨부파일을 다운로드할 수 없습니다",
+      "viewImage": "이미지 보기",
+      "expandVideo": "동영상 확대",
+      "imageAlt": "공유된 이미지"
+    },
+    "mediaViewer": {
+      "counter": "{total}개 중 {index}번째",
+      "previous": "이전",
+      "next": "다음",
+      "zoomIn": "실제 크기로 보기",
+      "zoomOut": "화면에 맞추기",
+      "openOriginal": "원본 열기",
+      "download": "다운로드",
+      "downloadFailed": "첨부파일을 다운로드할 수 없습니다",
+      "failed": "이 첨부파일은 더 이상 사용할 수 없습니다",
+      "imageAlt": "공유된 이미지",
+      "you": "나"
     },
     "actions": {
       "reply": "답장",

--- a/src/components/inbox/media-lightbox.tsx
+++ b/src/components/inbox/media-lightbox.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { format } from "date-fns";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ExternalLink,
+  ImageOff,
+  Loader2,
+  ZoomIn,
+  ZoomOut,
+  type LucideIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useMediaBlobUrl } from "@/hooks/use-media-blob-url";
+import { downloadMediaMessage } from "@/lib/media/download";
+import { galleryIndexOf, type MediaGalleryItem } from "@/lib/media/gallery";
+
+/**
+ * Full-size viewer for the images and videos in the open conversation
+ * (issue #373). One instance lives at the thread level rather than one per
+ * bubble, which is what lets ← / → page through the whole thread's media
+ * instead of just re-opening the one that was clicked.
+ *
+ * `activeId` is a `messages.id`, not an index: the thread's message list is
+ * live (realtime inserts, optimistic bubbles being swapped for their real
+ * rows), so an index would silently start pointing at a different photo.
+ */
+
+type Translator = ReturnType<typeof useTranslations>;
+
+/** Leaves room for the caption and the header inside a 100vh dialog. */
+const MEDIA_MAX_HEIGHT = "max-h-[75vh]";
+
+interface MediaLightboxProps {
+  items: MediaGalleryItem[];
+  /** `messages.id` of the item on screen; null closes the viewer. */
+  activeId: string | null;
+  onActiveIdChange: (id: string | null) => void;
+  /** Display name used for customer-sent media. */
+  contactLabel: string;
+}
+
+export function MediaLightbox({
+  items,
+  activeId,
+  onActiveIdChange,
+  contactLabel,
+}: MediaLightboxProps) {
+  const t = useTranslations("Inbox.mediaViewer");
+
+  const index = galleryIndexOf(items, activeId);
+  const item = index >= 0 ? items[index] : null;
+
+  // Zoom is tracked by id, not a boolean, so moving to the next photo shows
+  // it fit-to-screen without an effect resetting the flag after the fact.
+  const [zoomedId, setZoomedId] = useState<string | null>(null);
+  const zoomed = activeId !== null && zoomedId === activeId;
+  const [downloading, setDownloading] = useState(false);
+
+  const toggleZoom = useCallback(() => {
+    setZoomedId((current) => (current === activeId ? null : activeId));
+  }, [activeId]);
+
+  const goTo = useCallback(
+    (next: number) => {
+      const target = items[next];
+      if (target) onActiveIdChange(target.messageId);
+    },
+    [items, onActiveIdChange],
+  );
+
+  // Arrow keys page through the gallery. Bound on window so it works
+  // whichever control inside has focus, and in the CAPTURE phase because
+  // base-ui's popup stops arrow-key propagation for its own focus
+  // management — a bubble-phase listener here never fires. Esc is left
+  // alone; the dialog already closes on it.
+  useEffect(() => {
+    if (index < 0) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        goTo(index - 1);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        goTo(index + 1);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [index, goTo]);
+
+  const handleDownload = useCallback(async () => {
+    if (!item || downloading) return;
+    setDownloading(true);
+    try {
+      await downloadMediaMessage(item.message);
+    } catch {
+      toast.error(t("downloadFailed"));
+    } finally {
+      setDownloading(false);
+    }
+  }, [downloading, item, t]);
+
+  if (!item) return null;
+
+  const authorLabel = item.fromCustomer ? contactLabel : t("you");
+  const timestamp = format(new Date(item.createdAt), "MMM d, yyyy HH:mm");
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onActiveIdChange(null);
+      }}
+    >
+      <DialogContent className="flex w-auto max-w-[95vw] flex-col gap-3 p-3 sm:max-w-[min(95vw,72rem)]">
+        {/* pr-9 keeps the toolbar clear of the dialog's own close button. */}
+        <DialogHeader className="flex-row items-start gap-3 pr-9">
+          <div className="min-w-0 flex-1">
+            <DialogTitle className="truncate">{authorLabel}</DialogTitle>
+            <DialogDescription className="truncate text-xs">
+              {timestamp}
+            </DialogDescription>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {items.length > 1 && (
+              <span className="mr-1 text-xs tabular-nums text-muted-foreground">
+                {t("counter", { index: index + 1, total: items.length })}
+              </span>
+            )}
+            {item.kind === "image" && (
+              <ToolbarButton
+                icon={zoomed ? ZoomOut : ZoomIn}
+                label={zoomed ? t("zoomOut") : t("zoomIn")}
+                onClick={toggleZoom}
+              />
+            )}
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={t("openOriginal")}
+              title={t("openOriginal")}
+              className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ExternalLink className="h-4 w-4" />
+            </a>
+            <ToolbarButton
+              icon={Download}
+              label={t("download")}
+              onClick={handleDownload}
+              busy={downloading}
+            />
+          </div>
+        </DialogHeader>
+
+        <div className="relative flex items-center justify-center">
+          {item.kind === "image" ? (
+            <LightboxImage
+              item={item}
+              zoomed={zoomed}
+              onToggleZoom={toggleZoom}
+              t={t}
+            />
+          ) : (
+            <video
+              // Plain URL, never a blob — the player should stream.
+              src={item.url}
+              controls
+              preload="metadata"
+              className={cn(MEDIA_MAX_HEIGHT, "max-w-full rounded-lg")}
+            />
+          )}
+
+          {items.length > 1 && (
+            <>
+              <NavButton
+                side="left"
+                icon={ChevronLeft}
+                label={t("previous")}
+                disabled={index <= 0}
+                onClick={() => goTo(index - 1)}
+              />
+              <NavButton
+                side="right"
+                icon={ChevronRight}
+                label={t("next")}
+                disabled={index >= items.length - 1}
+                onClick={() => goTo(index + 1)}
+              />
+            </>
+          )}
+        </div>
+
+        {item.caption && (
+          <p className="max-h-24 overflow-y-auto whitespace-pre-wrap break-words text-sm">
+            {item.caption}
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LightboxImage({
+  item,
+  zoomed,
+  onToggleZoom,
+  t,
+}: {
+  item: MediaGalleryItem;
+  zoomed: boolean;
+  onToggleZoom: () => void;
+  t: Translator;
+}) {
+  // Hits the blob cache when the thumbnail already pulled these bytes, so
+  // opening the viewer is instant rather than a second trip through Meta.
+  const { src, status } = useMediaBlobUrl(item.url);
+  const [broken, setBroken] = useState(false);
+
+  if (status === "error" || broken) {
+    return (
+      <div className="flex h-64 w-full min-w-64 flex-col items-center justify-center gap-2 rounded-lg bg-muted text-sm text-muted-foreground">
+        <ImageOff className="h-8 w-8" />
+        <span>{t("failed")}</span>
+      </div>
+    );
+  }
+
+  if (status !== "ready" || !src) {
+    return (
+      <div className="flex h-64 w-full min-w-64 items-center justify-center rounded-lg bg-muted">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    // When zoomed the image renders at natural size and this box scrolls;
+    // otherwise it's capped to the viewport. Centring is `mx-auto` on the
+    // image rather than `justify-center` here on purpose: a flex-centred
+    // child that overflows its scroll container spills equally both ways and
+    // the left half becomes unreachable (scrollWidth stops at the right
+    // overflow). Auto margins on a block child collapse to 0 once it's
+    // wider, so the whole image stays scrollable.
+    <div className={cn("w-full", MEDIA_MAX_HEIGHT, zoomed && "overflow-auto")}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt={item.caption || t("imageAlt")}
+        onClick={onToggleZoom}
+        onError={() => setBroken(true)}
+        className={cn(
+          "mx-auto block rounded-lg",
+          zoomed
+            ? "max-w-none cursor-zoom-out"
+            : cn(MEDIA_MAX_HEIGHT, "max-w-full cursor-zoom-in object-contain"),
+        )}
+      />
+    </div>
+  );
+}
+
+function ToolbarButton({
+  icon: Icon,
+  label,
+  onClick,
+  busy = false,
+}: {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  busy?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      aria-label={label}
+      title={label}
+      className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-60"
+    >
+      {busy ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Icon className="h-4 w-4" />
+      )}
+    </button>
+  );
+}
+
+function NavButton({
+  side,
+  icon: Icon,
+  label,
+  disabled,
+  onClick,
+}: {
+  side: "left" | "right";
+  icon: LucideIcon;
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "absolute top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/85 text-foreground shadow-md backdrop-blur-sm transition-colors hover:bg-background disabled:pointer-events-none disabled:opacity-0",
+        side === "left" ? "left-1" : "right-1",
+      )}
+    >
+      <Icon className="h-5 w-5" />
+    </button>
+  );
+}

--- a/src/components/inbox/message-bubble.tsx
+++ b/src/components/inbox/message-bubble.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import type { Message, MessageReaction } from "@/types";
 import {
@@ -8,16 +7,21 @@ import {
   Check,
   CheckCheck,
   XCircle,
-  FileText,
   MapPin,
   LayoutTemplate,
-  ImageOff,
   CornerDownLeft,
   Sparkles,
 } from "lucide-react";
 import { format } from "date-fns";
 import { ReplyQuote } from "./reply-quote";
 import { MessageReactions } from "./message-reactions";
+import {
+  MediaAudioBubble,
+  MediaDocumentBubble,
+  MediaImageBubble,
+  MediaUnavailable,
+  MediaVideoBubble,
+} from "./message-media";
 import { InteractivePreview } from "@/components/interactive/interactive-preview";
 import { useTranslations } from "next-intl";
 
@@ -28,6 +32,12 @@ interface MessageBubbleProps {
   reactions?: MessageReaction[];
   currentUserId?: string;
   onToggleReaction?: (emoji: string) => void;
+  /**
+   * Opens the thread's media viewer on this message. Only images and videos
+   * call it; omitted when the parent renders no viewer, in which case media
+   * stays inline and non-clickable.
+   */
+  onOpenMedia?: (messageId: string) => void;
 }
 
 function StatusIcon({ status }: { status: Message["status"] }) {
@@ -47,79 +57,19 @@ function StatusIcon({ status }: { status: Message["status"] }) {
   }
 }
 
-function MediaUnavailable({ label, t }: { label: string, t: ReturnType<typeof useTranslations> }) {
-  return (
-    <div className="flex items-center gap-2 rounded-lg bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-      <ImageOff className="h-4 w-4 shrink-0 text-muted-foreground" />
-      <span>{t("unavailable", { label })}</span>
-    </div>
-  );
-}
+function MessageContent({
+  message,
+  t,
+  onOpenMedia,
+}: {
+  message: Message;
+  t: ReturnType<typeof useTranslations>;
+  onOpenMedia?: (messageId: string) => void;
+}) {
+  // Passed to the media bubbles as a no-arg callback; `undefined` when the
+  // parent wired up no viewer, which is what makes them non-clickable.
+  const openMedia = onOpenMedia ? () => onOpenMedia(message.id) : undefined;
 
-function MediaImage({ url, alt }: { url: string; alt: string }) {
-  const [src, setSrc] = useState<string | null>(null);
-  const [error, setError] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  const loadImage = useCallback(async () => {
-    if (!url) return;
-
-    // Proxy URLs need auth fetch to create blob URL
-    if (url.startsWith("/api/whatsapp/media/")) {
-      try {
-        const res = await fetch(url);
-        if (!res.ok) throw new Error("Failed to load media");
-        const blob = await res.blob();
-        const blobUrl = URL.createObjectURL(blob);
-        setSrc(blobUrl);
-      } catch {
-        setError(true);
-      } finally {
-        setLoading(false);
-      }
-    } else {
-      setSrc(url);
-      setLoading(false);
-    }
-  }, [url]);
-
-  useEffect(() => {
-    loadImage();
-    return () => {
-      if (src?.startsWith("blob:")) {
-        URL.revokeObjectURL(src);
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadImage]);
-
-  if (error) {
-    return (
-      <div className="flex h-40 w-60 items-center justify-center rounded-lg bg-muted">
-        <ImageOff className="h-8 w-8 text-muted-foreground" />
-      </div>
-    );
-  }
-
-  if (loading) {
-    return (
-      <div className="flex h-40 w-60 items-center justify-center rounded-lg bg-muted">
-        <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    );
-  }
-
-  return (
-    <img
-      src={src ?? ""}
-      alt={alt}
-      className="max-h-64 max-w-60 rounded-lg object-cover"
-      onError={() => setError(true)}
-    />
-  );
-}
-
-function MessageContent({ message, t }: { message: Message, t: ReturnType<typeof useTranslations> }) {
   switch (message.content_type) {
     case "text":
       return (
@@ -132,7 +82,7 @@ function MessageContent({ message, t }: { message: Message, t: ReturnType<typeof
       return (
         <div>
           {message.media_url ? (
-            <MediaImage url={message.media_url} alt="Shared image" />
+            <MediaImageBubble message={message} onOpen={openMedia} t={t} />
           ) : (
             <MediaUnavailable label={t("photo")} t={t} />
           )}
@@ -148,11 +98,7 @@ function MessageContent({ message, t }: { message: Message, t: ReturnType<typeof
       return (
         <div>
           {message.media_url ? (
-            <video
-              src={message.media_url}
-              controls
-              className="max-h-64 max-w-60 rounded-lg"
-            />
+            <MediaVideoBubble message={message} onOpen={openMedia} t={t} />
           ) : (
             <MediaUnavailable label={t("video")} t={t} />
           )}
@@ -168,7 +114,7 @@ function MessageContent({ message, t }: { message: Message, t: ReturnType<typeof
       return (
         <div>
           {message.media_url ? (
-            <audio src={message.media_url} controls className="max-w-60" />
+            <MediaAudioBubble message={message} t={t} />
           ) : (
             <MediaUnavailable label={t("audio")} t={t} />
           )}
@@ -179,19 +125,7 @@ function MessageContent({ message, t }: { message: Message, t: ReturnType<typeof
       if (!message.media_url) {
         return <MediaUnavailable label={message.content_text || t("document")} t={t} />;
       }
-      return (
-        <a
-          href={message.media_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm hover:bg-muted"
-        >
-          <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
-          <span className="truncate">
-            {message.content_text || t("document")}
-          </span>
-        </a>
-      );
+      return <MediaDocumentBubble message={message} t={t} />;
 
     case "template":
       return (
@@ -264,6 +198,7 @@ export function MessageBubble({
   reactions,
   currentUserId,
   onToggleReaction,
+  onOpenMedia,
 }: MessageBubbleProps) {
   const t = useTranslations("Inbox.bubble");
 
@@ -294,7 +229,7 @@ export function MessageBubble({
             onPrimary={isAgent}
           />
         )}
-        <MessageContent message={message} t={t} />
+        <MessageContent message={message} t={t} onOpenMedia={onOpenMedia} />
         <div
           className={cn(
             "mt-1 flex items-center gap-1",

--- a/src/components/inbox/message-media.tsx
+++ b/src/components/inbox/message-media.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  Download,
+  FileText,
+  ImageOff,
+  Loader2,
+  Maximize2,
+  type LucideIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import type { Message } from "@/types";
+import { downloadMediaMessage } from "@/lib/media/download";
+import { useMediaBlobUrl } from "@/hooks/use-media-blob-url";
+
+/**
+ * The media renderers behind `<MessageBubble>`'s image / video / audio /
+ * document cases. Split out of message-bubble.tsx so that file stays a
+ * thin content switch — everything here is about the two affordances
+ * issue #373 asked for: open it full-size, and save it.
+ *
+ * Both are less trivial than they look, because the two flavours of
+ * `media_url` behave differently in the browser. See
+ * `@/lib/media/blob-cache` for the proxy-vs-bucket split and
+ * `@/lib/media/download` for why `<a download>` alone isn't enough.
+ */
+
+type Translator = ReturnType<typeof useTranslations>;
+
+/** Inline media size cap, shared so the four bubbles can't drift apart. */
+const MEDIA_BOX = "max-h-64 max-w-60";
+
+export function MediaUnavailable({
+  label,
+  t,
+}: {
+  label: string;
+  t: Translator;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+      <ImageOff className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <span>{t("unavailable", { label })}</span>
+    </div>
+  );
+}
+
+/**
+ * Kicks off a download and reports failure as a toast. Kept as a hook so
+ * each bubble owns its own in-flight state — a slow 16 MB video shouldn't
+ * put a spinner on every other attachment in the thread.
+ */
+function useMediaDownload(message: Message, t: Translator) {
+  const [downloading, setDownloading] = useState(false);
+
+  const download = useCallback(async () => {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      await downloadMediaMessage(message);
+    } catch {
+      toast.error(t("downloadFailed"));
+    } finally {
+      setDownloading(false);
+    }
+  }, [downloading, message, t]);
+
+  return { downloading, download };
+}
+
+function MediaActionButton({
+  icon: Icon,
+  label,
+  onClick,
+  busy = false,
+}: {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  busy?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      aria-label={label}
+      title={label}
+      // Own surface rather than inheriting the bubble's, so the same button
+      // reads on the muted inbound fill, the primary outbound fill, and on
+      // top of an arbitrary photo.
+      className="flex h-7 w-7 items-center justify-center rounded-full border border-border/60 bg-background/85 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background disabled:opacity-60"
+    >
+      {busy ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <Icon className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}
+
+function MediaPlaceholder({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-40 w-60 items-center justify-center rounded-lg bg-muted">
+      {children}
+    </div>
+  );
+}
+
+export function MediaImageBubble({
+  message,
+  onOpen,
+  t,
+}: {
+  message: Message;
+  /** Opens the thread's lightbox on this message. Omitted ⇒ not clickable. */
+  onOpen?: () => void;
+  t: Translator;
+}) {
+  const { src, status } = useMediaBlobUrl(message.media_url);
+  // The fetch can succeed and the bytes still not be a decodable image.
+  const [broken, setBroken] = useState(false);
+  const { downloading, download } = useMediaDownload(message, t);
+
+  if (status === "error" || broken) {
+    return (
+      <MediaPlaceholder>
+        <ImageOff className="h-8 w-8 text-muted-foreground" />
+      </MediaPlaceholder>
+    );
+  }
+
+  if (status !== "ready" || !src) {
+    return (
+      <MediaPlaceholder>
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </MediaPlaceholder>
+    );
+  }
+
+  const image = (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt={t("imageAlt")}
+      className={cn(MEDIA_BOX, "rounded-lg object-contain")}
+      onError={() => setBroken(true)}
+    />
+  );
+
+  return (
+    <div className="group/media relative w-fit">
+      {onOpen ? (
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={t("viewImage")}
+          className="block cursor-zoom-in rounded-lg outline-none ring-offset-2 ring-offset-transparent focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {image}
+        </button>
+      ) : (
+        image
+      )}
+      {/* Hover-only: on touch there is no hover, but tapping the image opens
+          the viewer, which carries a full-size Download button. */}
+      <div className="absolute bottom-2 right-2 opacity-0 transition-opacity group-hover/media:opacity-100 group-focus-within/media:opacity-100">
+        <MediaActionButton
+          icon={Download}
+          label={t("download")}
+          onClick={download}
+          busy={downloading}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function MediaVideoBubble({
+  message,
+  onOpen,
+  t,
+}: {
+  message: Message;
+  onOpen?: () => void;
+  t: Translator;
+}) {
+  const { downloading, download } = useMediaDownload(message, t);
+
+  return (
+    <div className="relative w-fit">
+      {/* Plain URL, not a blob: the element should stream rather than wait
+          for up to 16 MB to land. */}
+      <video
+        src={message.media_url}
+        controls
+        preload="metadata"
+        className={cn(MEDIA_BOX, "rounded-lg")}
+      />
+      {/* Top-right, clear of the native controls — and always visible, since
+          expanding is the only way to watch a clip capped at 15rem wide and
+          a touch device gets no hover. */}
+      <div className="absolute right-2 top-2 flex gap-1">
+        {onOpen && (
+          <MediaActionButton
+            icon={Maximize2}
+            label={t("expandVideo")}
+            onClick={onOpen}
+          />
+        )}
+        <MediaActionButton
+          icon={Download}
+          label={t("download")}
+          onClick={download}
+          busy={downloading}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function MediaAudioBubble({
+  message,
+  t,
+}: {
+  message: Message;
+  t: Translator;
+}) {
+  const { downloading, download } = useMediaDownload(message, t);
+
+  return (
+    <div className="flex items-center gap-2">
+      <audio src={message.media_url} controls className="max-w-60" />
+      <MediaActionButton
+        icon={Download}
+        label={t("download")}
+        onClick={download}
+        busy={downloading}
+      />
+    </div>
+  );
+}
+
+export function MediaDocumentBubble({
+  message,
+  t,
+}: {
+  message: Message;
+  t: Translator;
+}) {
+  const { downloading, download } = useMediaDownload(message, t);
+
+  return (
+    <div className="flex items-center gap-2">
+      <a
+        href={message.media_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm hover:bg-muted"
+      >
+        <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
+        <span className="truncate">{message.content_text || t("document")}</span>
+      </a>
+      <MediaActionButton
+        icon={Download}
+        label={t("download")}
+        onClick={download}
+        busy={downloading}
+      />
+    </div>
+  );
+}

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -41,6 +41,8 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { MessageBubble } from "./message-bubble";
 import { MessageActions } from "./message-actions";
+import { MediaLightbox } from "./media-lightbox";
+import { collectMediaGallery } from "@/lib/media/gallery";
 import {
   MessageComposer,
   CHAT_MEDIA_BUCKET,
@@ -202,6 +204,15 @@ export function MessageThread({
     }, 700);
   }, [isRefreshing, onRefresh]);
   const [replyTo, setReplyTo] = useState<ReplyDraft | null>(null);
+  // Which attachment the media viewer is showing. Lives here rather than in
+  // the bubble so the viewer can page through every image/video in the
+  // thread (issue #373). Paired with the conversation it belongs to and read
+  // back through that check below, so switching threads closes the viewer
+  // without an effect racing the messages refetch.
+  const [openMedia, setOpenMedia] = useState<{
+    conversationId: string;
+    messageId: string;
+  } | null>(null);
 
   // Profiles are bounded by RLS to rows the current user is allowed to
   // see — today that's just the current user, but the dropdown keeps the
@@ -267,6 +278,19 @@ export function MessageThread({
 
   const conversationId = conversation?.id;
   const hasUnread = (conversation?.unread_count ?? 0) > 0;
+
+  const mediaMessageId =
+    openMedia && openMedia.conversationId === conversationId
+      ? openMedia.messageId
+      : null;
+  const handleMediaChange = useCallback(
+    (messageId: string | null) => {
+      setOpenMedia(
+        messageId && conversationId ? { conversationId, messageId } : null,
+      );
+    },
+    [conversationId],
+  );
 
   // Fetch messages whenever the selected conversation changes. Kept
   // separate from the unread-reset effect so that incoming messages
@@ -718,6 +742,10 @@ export function MessageThread({
     return map;
   }, [messages]);
 
+  // Images + videos in the thread, in order — the set the media viewer
+  // pages through with ← / →.
+  const mediaGallery = useMemo(() => collectMediaGallery(messages), [messages]);
+
   // Bucket reactions by their target message_id for O(1) per-bubble lookup.
   const reactionsByMessageId = useMemo(() => {
     const map = new Map<string, MessageReaction[]>();
@@ -1122,6 +1150,7 @@ export function MessageThread({
                           reactions={msgReactions}
                           currentUserId={user?.id}
                           onToggleReaction={handlePillToggle}
+                          onOpenMedia={handleMediaChange}
                         />
                       </MessageActions>
                     );
@@ -1165,6 +1194,15 @@ export function MessageThread({
         open={templateModalOpen}
         onOpenChange={setTemplateModalOpen}
         onSelect={handleSendTemplate}
+      />
+
+      {/* Full-size viewer for the thread's images/videos. Renders nothing
+          until a bubble opens it. */}
+      <MediaLightbox
+        items={mediaGallery}
+        activeId={mediaMessageId}
+        onActiveIdChange={handleMediaChange}
+        contactLabel={contactDisplayName}
       />
     </div>
   );

--- a/src/hooks/use-media-blob-url.ts
+++ b/src/hooks/use-media-blob-url.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isProxiedMediaUrl, loadMediaBlob } from "@/lib/media/blob-cache";
+
+export type MediaLoadStatus = "idle" | "loading" | "ready" | "error";
+
+interface MediaBlobUrlState {
+  /** Ready-to-render URL: the original for public media, an object URL for proxied. */
+  src: string | null;
+  status: MediaLoadStatus;
+}
+
+/** A settled load, tagged with the URL it belongs to. */
+interface ResolvedMedia {
+  url: string;
+  objectUrl: string | null;
+  failed: boolean;
+}
+
+/**
+ * Resolve a `messages.media_url` into something an `<img>` can render.
+ *
+ * Public `chat-media` URLs are handed straight back — the browser fetches
+ * and caches them itself. Inbound `/api/whatsapp/media/*` URLs are pulled
+ * through `loadMediaBlob` (credentialed, cached, de-duplicated) and turned
+ * into an object URL that is revoked when the URL changes or the component
+ * unmounts.
+ *
+ * Only use this for images. Video and audio must keep their plain URL so
+ * the element streams instead of buffering up to 16 MB before it plays.
+ */
+export function useMediaBlobUrl(url: string | undefined): MediaBlobUrlState {
+  const [resolved, setResolved] = useState<ResolvedMedia | null>(null);
+
+  useEffect(() => {
+    if (!url || !isProxiedMediaUrl(url)) return;
+
+    let cancelled = false;
+    // Held in a local rather than read back off state, because that is
+    // exactly the bug this replaces: the previous implementation's cleanup
+    // closed over a `src` that was still null when the effect ran, so no
+    // object URL was ever revoked.
+    let objectUrl: string | null = null;
+
+    loadMediaBlob(url)
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setResolved({ url, objectUrl, failed: false });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setResolved({ url, objectUrl: null, failed: true });
+      });
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [url]);
+
+  if (!url) return { src: null, status: "idle" };
+
+  // Nothing to load for a public URL — derived here rather than pushed
+  // through state so the first paint already has the image.
+  if (!isProxiedMediaUrl(url)) return { src: url, status: "ready" };
+
+  // A result for a *previous* URL is stale; the new URL's load is already
+  // in flight, so report loading rather than flashing the old image.
+  if (resolved?.url === url) {
+    return resolved.failed
+      ? { src: null, status: "error" }
+      : { src: resolved.objectUrl, status: "ready" };
+  }
+
+  return { src: null, status: "loading" };
+}

--- a/src/lib/media/blob-cache.test.ts
+++ b/src/lib/media/blob-cache.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  __resetMediaBlobCache,
+  isProxiedMediaUrl,
+  loadMediaBlob,
+  MediaResponseError,
+  type MediaFetch,
+} from "./blob-cache";
+
+const PROXY = "/api/whatsapp/media/";
+const BUCKET = "https://x.supabase.co/storage/v1/object/public/chat-media/a/1-p.png";
+
+function okResponse(body: string): Response {
+  return new Response(body, { status: 200 });
+}
+
+/** Records every URL requested so de-duplication is observable. */
+function trackingFetch(): MediaFetch & { calls: string[] } {
+  const calls: string[] = [];
+  const impl = vi.fn(async (url: string) => {
+    calls.push(url);
+    return okResponse(`bytes:${url}`);
+  }) as unknown as MediaFetch & { calls: string[] };
+  impl.calls = calls;
+  return impl;
+}
+
+beforeEach(() => {
+  __resetMediaBlobCache();
+});
+
+describe("isProxiedMediaUrl", () => {
+  it("recognises inbound media, not bucket URLs", () => {
+    expect(isProxiedMediaUrl(`${PROXY}123`)).toBe(true);
+    expect(isProxiedMediaUrl(BUCKET)).toBe(false);
+  });
+});
+
+describe("loadMediaBlob", () => {
+  it("caches proxied media so a second consumer costs nothing", async () => {
+    const fetchImpl = trackingFetch();
+    const first = await loadMediaBlob(`${PROXY}1`, fetchImpl);
+    const second = await loadMediaBlob(`${PROXY}1`, fetchImpl);
+
+    expect(fetchImpl.calls).toEqual([`${PROXY}1`]);
+    // Same Blob instance — the thumbnail, the viewer and a download all end
+    // up holding the bytes that were fetched once.
+    expect(second).toBe(first);
+  });
+
+  it("de-duplicates concurrent loads of the same URL", async () => {
+    const fetchImpl = trackingFetch();
+    const [a, b] = await Promise.all([
+      loadMediaBlob(`${PROXY}2`, fetchImpl),
+      loadMediaBlob(`${PROXY}2`, fetchImpl),
+    ]);
+
+    expect(fetchImpl.calls).toEqual([`${PROXY}2`]);
+    expect(a).toBe(b);
+  });
+
+  it("does not cache public bucket URLs", async () => {
+    // The browser's HTTP cache already covers these, and a 16 MB video has
+    // no business being pinned in JS memory.
+    const fetchImpl = trackingFetch();
+    await loadMediaBlob(BUCKET, fetchImpl);
+    await loadMediaBlob(BUCKET, fetchImpl);
+
+    expect(fetchImpl.calls).toEqual([BUCKET, BUCKET]);
+  });
+
+  it("evicts the least-recently-used entry past the cap", async () => {
+    const fetchImpl = trackingFetch();
+    for (let i = 0; i < 30; i++) {
+      await loadMediaBlob(`${PROXY}${i}`, fetchImpl);
+    }
+    // Touch the oldest so it is no longer the eviction candidate.
+    await loadMediaBlob(`${PROXY}0`, fetchImpl);
+    // One more entry pushes the cache over the cap.
+    await loadMediaBlob(`${PROXY}30`, fetchImpl);
+
+    const before = fetchImpl.calls.length;
+    await loadMediaBlob(`${PROXY}0`, fetchImpl); // still cached
+    expect(fetchImpl.calls.length).toBe(before);
+
+    await loadMediaBlob(`${PROXY}1`, fetchImpl); // evicted → refetched
+    expect(fetchImpl.calls.length).toBe(before + 1);
+  });
+
+  it("throws on a failed request and caches nothing", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 404 }));
+
+    await expect(
+      loadMediaBlob(`${PROXY}3`, fetchImpl as unknown as MediaFetch),
+    ).rejects.toThrow("404");
+
+    // A retry genuinely retries rather than replaying the failure.
+    await expect(
+      loadMediaBlob(`${PROXY}3`, fetchImpl as unknown as MediaFetch),
+    ).rejects.toThrow("404");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("distinguishes a refused response from a fetch that never completed", async () => {
+    // `downloadMediaMessage` branches on this: a refused response must
+    // surface as an error, while a blocked fetch falls back to a new tab.
+    // Getting the two confused made an expired attachment silently open a
+    // tab onto its own 401 instead of telling the agent.
+    const refuse = vi.fn(async () => new Response("no", { status: 401 }));
+    await expect(
+      loadMediaBlob(`${PROXY}5`, refuse as unknown as MediaFetch),
+    ).rejects.toBeInstanceOf(MediaResponseError);
+
+    const blocked = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    await expect(
+      loadMediaBlob(BUCKET, blocked as unknown as MediaFetch),
+    ).rejects.not.toBeInstanceOf(MediaResponseError);
+  });
+
+  it("carries the status on a refused response", async () => {
+    const refuse = vi.fn(async () => new Response("no", { status: 401 }));
+    await expect(
+      loadMediaBlob(`${PROXY}6`, refuse as unknown as MediaFetch),
+    ).rejects.toMatchObject({ status: 401, name: "MediaResponseError" });
+  });
+
+  it("lets a retry succeed after a failure", async () => {
+    let attempt = 0;
+    const fetchImpl = vi.fn(async () => {
+      attempt += 1;
+      return attempt === 1
+        ? new Response("nope", { status: 500 })
+        : okResponse("bytes");
+    });
+
+    await expect(
+      loadMediaBlob(`${PROXY}4`, fetchImpl as unknown as MediaFetch),
+    ).rejects.toThrow();
+    const blob = await loadMediaBlob(
+      `${PROXY}4`,
+      fetchImpl as unknown as MediaFetch,
+    );
+    expect(await blob.text()).toBe("bytes");
+  });
+});

--- a/src/lib/media/blob-cache.ts
+++ b/src/lib/media/blob-cache.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared loader for chat-media bytes.
+ *
+ * A `messages.media_url` is one of two very different things:
+ *
+ *   1. INBOUND — `/api/whatsapp/media/<mediaId>`, our own auth-gated proxy
+ *      (`src/app/api/whatsapp/media/[mediaId]/route.ts`). Meta only hands
+ *      the bytes to a request carrying the account's access token, so the
+ *      browser can't reach them on its own, and `next.config.ts` puts
+ *      `Cache-Control: no-store` on every `/api/*` response, so nothing
+ *      caches them at the HTTP layer either.
+ *
+ *   2. OUTBOUND — a public `chat-media` bucket URL (migration 023). Plain
+ *      https that the browser fetches and caches like any other image.
+ *
+ * The thumbnail, the lightbox and a download all want the same bytes. For
+ * (1) that would otherwise be three separate multi-MB round trips through
+ * Meta, so proxy responses are memoised here.
+ *
+ * `Blob`s are cached, NOT object URLs: every consumer mints its own object
+ * URL from the cached blob and revokes it on unmount. That way an LRU
+ * eviction can never yank a URL out from under a mounted `<img>` — an
+ * object URL keeps its blob's data alive by itself.
+ */
+
+/** Prefix of the auth-gated proxy — these need a credentialed fetch. */
+const PROXY_PREFIX = "/api/whatsapp/media/";
+
+/**
+ * How many blobs to hold. Worst case is a thread that's nothing but
+ * photos; 30 entries against the 5 MB image cap (`MEDIA_MAX_BYTES_BY_KIND`
+ * in `@/lib/storage/upload-media`) bounds the footprint while comfortably
+ * covering "scroll back, page through the last dozen photos".
+ */
+const MAX_CACHED = 30;
+
+/** Insertion-ordered, so Map iteration order gives us LRU for free. */
+const cache = new Map<string, Blob>();
+
+/** In-flight loads, so N consumers of one URL share a single request. */
+const inFlight = new Map<string, Promise<Blob>>();
+
+/** Minimal `fetch` shape — injectable so the cache is testable. */
+export type MediaFetch = (url: string) => Promise<Response>;
+
+const defaultFetch: MediaFetch = (url) => fetch(url);
+
+/**
+ * The request completed and the server refused it — a 401 on inbound media
+ * Meta has since expired, a 404, a 5xx. Distinct from a fetch that never
+ * completed at all (offline, CORS), because those two deserve different
+ * handling: see `downloadMediaMessage`.
+ */
+export class MediaResponseError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`Media request failed (${status})`);
+    this.name = "MediaResponseError";
+    this.status = status;
+  }
+}
+
+/** True for inbound media that has to be pulled through our proxy. */
+export function isProxiedMediaUrl(url: string): boolean {
+  return url.startsWith(PROXY_PREFIX);
+}
+
+function remember(url: string, blob: Blob): void {
+  cache.set(url, blob);
+  while (cache.size > MAX_CACHED) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+/**
+ * Fetch the bytes behind a `media_url`.
+ *
+ * Proxy URLs are cached (and concurrent callers de-duplicated); public
+ * bucket URLs are fetched straight through, since the browser's own HTTP
+ * cache already covers them and a 16 MB video has no business sitting in
+ * a JS-side cache.
+ *
+ * Throws on a failed request — nothing is cached on failure, so a retry
+ * genuinely retries.
+ */
+export async function loadMediaBlob(
+  url: string,
+  fetchImpl: MediaFetch = defaultFetch,
+): Promise<Blob> {
+  if (!isProxiedMediaUrl(url)) {
+    const res = await fetchImpl(url);
+    if (!res.ok) throw new MediaResponseError(res.status);
+    return res.blob();
+  }
+
+  const cached = cache.get(url);
+  if (cached) {
+    // Refresh recency — re-inserting moves it to the end of the Map.
+    cache.delete(url);
+    cache.set(url, cached);
+    return cached;
+  }
+
+  const pending = inFlight.get(url);
+  if (pending) return pending;
+
+  const load = (async () => {
+    const res = await fetchImpl(url);
+    if (!res.ok) throw new MediaResponseError(res.status);
+    const blob = await res.blob();
+    remember(url, blob);
+    return blob;
+  })();
+
+  inFlight.set(url, load);
+  try {
+    return await load;
+  } finally {
+    inFlight.delete(url);
+  }
+}
+
+/** Test seam — drops everything the cache is holding. */
+export function __resetMediaBlobCache(): void {
+  cache.clear();
+  inFlight.clear();
+}

--- a/src/lib/media/download.ts
+++ b/src/lib/media/download.ts
@@ -1,0 +1,79 @@
+import type { Message } from "@/types";
+import { loadMediaBlob, MediaResponseError } from "./blob-cache";
+import { mediaFilename } from "./filename";
+
+/**
+ * Save a chat attachment to the agent's machine.
+ *
+ * The obvious `<a href={media_url} download>` doesn't work for either kind
+ * of media we have: browsers ignore `download` on a cross-origin href (so
+ * a `chat-media` bucket URL would just navigate), and inbound media lives
+ * behind an auth-gated proxy with no filename in its path. Fetching the
+ * bytes ourselves solves both — we get a real `Blob` (already cached by
+ * `loadMediaBlob` if the thumbnail or lightbox pulled it) and full control
+ * over the filename.
+ *
+ * Throws so the caller can toast; the only silent path is the new-tab
+ * fallback below.
+ */
+export async function downloadMediaMessage(message: Message): Promise<void> {
+  const url = message.media_url;
+  if (!url) throw new Error("This message has no attachment.");
+
+  let blob: Blob;
+  try {
+    blob = await loadMediaBlob(url);
+  } catch (error) {
+    // A refused *response* is a real failure — inbound media Meta has
+    // expired 401s here, and quietly opening a tab onto that error would
+    // hide it. Let the caller toast instead.
+    if (error instanceof MediaResponseError) throw error;
+    // A fetch that never completed is the other case: a bucket with a
+    // stricter CORS policy than ours can block the XHR while the browser
+    // is still perfectly able to navigate to the object. Handing the URL
+    // to a new tab gets the agent to the file, visibly.
+    if (openInNewTab(url)) return;
+    throw error;
+  }
+
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    clickAnchor({
+      href: objectUrl,
+      download: mediaFilename(message, blob.type),
+    });
+  } finally {
+    // Revoking in the same tick can cancel the download in Safari; a beat
+    // later the browser has taken its own reference to the bytes.
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+  }
+}
+
+function openInNewTab(url: string): boolean {
+  if (typeof document === "undefined") return false;
+  clickAnchor({ href: url, target: "_blank" });
+  return true;
+}
+
+/**
+ * Programmatic anchor click. An anchor is used rather than `window.open`
+ * because it isn't subject to the popup blocker, and because `download`
+ * only exists on anchors.
+ */
+function clickAnchor(attrs: {
+  href: string;
+  download?: string;
+  target?: string;
+}): void {
+  const a = document.createElement("a");
+  a.href = attrs.href;
+  if (attrs.download) a.download = attrs.download;
+  if (attrs.target) {
+    a.target = attrs.target;
+    a.rel = "noopener noreferrer";
+  }
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}

--- a/src/lib/media/filename.test.ts
+++ b/src/lib/media/filename.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import {
+  basenameFromUrl,
+  extensionForMime,
+  mediaFilename,
+  sanitizeFilename,
+} from "./filename";
+
+const AT = "2026-08-04T14:15:30.000Z";
+
+/**
+ * A media message row carries no filename and no MIME type, so the name a
+ * download lands under is reconstructed. These pin the three sources and,
+ * more importantly, the sanitisation — the document filename comes straight
+ * from whatever the customer's phone sent.
+ */
+describe("extensionForMime", () => {
+  it("maps the bucket's allow-list and inbound-only types", () => {
+    expect(extensionForMime("image/jpeg")).toBe("jpg");
+    expect(extensionForMime("image/webp")).toBe("webp");
+    expect(extensionForMime("video/3gpp")).toBe("3gp");
+    expect(extensionForMime("audio/ogg")).toBe("ogg");
+    expect(extensionForMime("application/pdf")).toBe("pdf");
+    expect(
+      extensionForMime(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      ),
+    ).toBe("xlsx");
+  });
+
+  it("ignores parameters and case", () => {
+    expect(extensionForMime("IMAGE/JPEG; charset=binary")).toBe("jpg");
+  });
+
+  it("falls back to bin for unknown or missing types", () => {
+    expect(extensionForMime("application/x-nonsense")).toBe("bin");
+    expect(extensionForMime(undefined)).toBe("bin");
+    expect(extensionForMime(null)).toBe("bin");
+    expect(extensionForMime("")).toBe("bin");
+  });
+});
+
+describe("sanitizeFilename", () => {
+  it("keeps only the last path segment", () => {
+    expect(sanitizeFilename("../../etc/passwd.txt")).toBe("passwd.txt");
+    expect(sanitizeFilename("C:\\Users\\me\\report.pdf")).toBe("report.pdf");
+  });
+
+  it("strips control characters and replaces reserved ones", () => {
+    expect(sanitizeFilename("in\u0000voi\u001fce.pdf")).toBe("invoice.pdf");
+    expect(sanitizeFilename('quote:"final"?.pdf')).toBe("quote__final__.pdf");
+  });
+
+  it("refuses to produce a dotfile or a bare dot", () => {
+    expect(sanitizeFilename(".hidden")).toBe("hidden");
+    expect(sanitizeFilename("..")).toBe("");
+    expect(sanitizeFilename("   ")).toBe("");
+  });
+
+  it("truncates the stem but never the extension", () => {
+    const long = `${"a".repeat(200)}.pdf`;
+    const out = sanitizeFilename(long);
+    expect(out.length).toBe(80);
+    expect(out.endsWith(".pdf")).toBe(true);
+  });
+});
+
+describe("basenameFromUrl", () => {
+  it("drops the epoch-ms prefix buildMediaPath adds", () => {
+    expect(
+      basenameFromUrl(
+        "https://x.supabase.co/storage/v1/object/public/chat-media/account-abc/1770000000000-invoice.pdf",
+      ),
+    ).toBe("invoice.pdf");
+  });
+
+  it("ignores query strings and percent-decodes", () => {
+    expect(
+      basenameFromUrl(
+        "https://x.supabase.co/storage/v1/object/public/chat-media/account-abc/1770000000000-my%20photo.jpg?token=1",
+      ),
+    ).toBe("my photo.jpg");
+  });
+
+  it("returns nothing for a proxy URL, whose last segment is a Meta id", () => {
+    expect(basenameFromUrl("/api/whatsapp/media/1234567890123456")).toBe("");
+  });
+
+  it("returns nothing when the last segment has no extension", () => {
+    expect(basenameFromUrl("https://example.com/files/report")).toBe("");
+  });
+});
+
+describe("mediaFilename", () => {
+  it("uses a document's own filename when content_text is one", () => {
+    expect(
+      mediaFilename(
+        {
+          content_type: "document",
+          content_text: "Q3 statement.pdf",
+          media_url: "/api/whatsapp/media/999",
+          created_at: AT,
+        },
+        "application/pdf",
+      ),
+    ).toBe("Q3 statement.pdf");
+  });
+
+  it("sanitises a document filename that tries to escape the folder", () => {
+    expect(
+      mediaFilename(
+        {
+          content_type: "document",
+          content_text: "../../../.ssh/authorized_keys.txt",
+          created_at: AT,
+        },
+        "text/plain",
+      ),
+    ).toBe("authorized_keys.txt");
+  });
+
+  it("does not mistake a document caption for a filename", () => {
+    expect(
+      mediaFilename(
+        {
+          content_type: "document",
+          content_text: "here is the thing you asked for",
+          media_url:
+            "https://x.supabase.co/storage/v1/object/public/chat-media/account-a/1770000000000-contract.pdf",
+          created_at: AT,
+        },
+        "application/pdf",
+      ),
+    ).toBe("contract.pdf");
+  });
+
+  it("does not treat an image caption as a filename", () => {
+    // "cat.jpg" here is prose, and the URL has the real name.
+    expect(
+      mediaFilename(
+        {
+          content_type: "image",
+          content_text: "is this the right cat.jpg",
+          media_url:
+            "https://x.supabase.co/storage/v1/object/public/chat-media/account-a/1770000000000-tabby.png",
+          created_at: AT,
+        },
+        "image/png",
+      ),
+    ).toBe("tabby.png");
+  });
+
+  it("synthesises a timestamped name for inbound media", () => {
+    const name = mediaFilename(
+      {
+        content_type: "image",
+        media_url: "/api/whatsapp/media/1234567890123456",
+        created_at: AT,
+      },
+      "image/jpeg",
+    );
+    // Local time, so assert the shape rather than a fixed clock reading.
+    expect(name).toMatch(/^whatsapp-image-\d{8}-\d{6}\.jpg$/);
+  });
+
+  it("falls back to bin when the MIME type is unknown", () => {
+    expect(
+      mediaFilename(
+        {
+          content_type: "audio",
+          media_url: "/api/whatsapp/media/42",
+          created_at: AT,
+        },
+        undefined,
+      ),
+    ).toMatch(/^whatsapp-audio-\d{8}-\d{6}\.bin$/);
+  });
+
+  it("drops the timestamp rather than throwing on an unparseable created_at", () => {
+    expect(
+      mediaFilename(
+        {
+          content_type: "video",
+          media_url: "/api/whatsapp/media/42",
+          created_at: "not a date",
+        },
+        "video/mp4",
+      ),
+    ).toBe("whatsapp-video.mp4");
+  });
+});

--- a/src/lib/media/filename.ts
+++ b/src/lib/media/filename.ts
@@ -1,0 +1,174 @@
+import { format } from "date-fns";
+import type { ContentType } from "@/types";
+
+/**
+ * Works out the filename to save a chat attachment under.
+ *
+ * There is no `media_filename` column: the webhook drops the MIME type on
+ * the floor (`route.ts` — "the schema has no media_type") and inbound media
+ * is only ever a Meta media-id, so a name has to be reconstructed from what
+ * the message row *does* carry. Three sources, in order of trustworthiness:
+ *
+ *   1. A document's `content_text`. That's where the webhook puts
+ *      `document.filename`, and where the composer puts the uploaded file's
+ *      name — but only when the sender typed no caption, hence the
+ *      "does it look like a filename" guard.
+ *   2. The basename of a `chat-media` bucket URL, minus the epoch-ms prefix
+ *      `buildMediaPath` (`@/lib/storage/upload-media`) puts in front of it.
+ *   3. A synthesised `whatsapp-<kind>-<timestamp>.<ext>`, with the extension
+ *      taken from the MIME type the browser reports for the fetched bytes.
+ */
+
+/**
+ * Extension per MIME type. Covers the `chat-media` bucket's allow-list
+ * (migration 023) plus the inbound-only types Meta can hand us (notably
+ * `image/webp` stickers and `audio/ogg` voice notes).
+ */
+const EXTENSION_BY_MIME: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "video/mp4": "mp4",
+  "video/3gpp": "3gp",
+  "video/quicktime": "mov",
+  "audio/ogg": "ogg",
+  "audio/opus": "opus",
+  "audio/mpeg": "mp3",
+  "audio/mp4": "m4a",
+  "audio/aac": "aac",
+  "audio/amr": "amr",
+  "application/pdf": "pdf",
+  "application/msword": "doc",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "docx",
+  "application/vnd.ms-excel": "xls",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "application/vnd.ms-powerpoint": "ppt",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "pptx",
+  "text/plain": "txt",
+};
+
+/** Longest filename we'll produce, extension included. */
+const MAX_FILENAME_LENGTH = 80;
+
+/**
+ * Extension for a MIME type, `bin` when unknown. Parameters are stripped,
+ * so `image/jpeg; charset=binary` still resolves.
+ */
+export function extensionForMime(mimeType?: string | null): string {
+  if (!mimeType) return "bin";
+  const base = mimeType.split(";")[0].trim().toLowerCase();
+  return EXTENSION_BY_MIME[base] ?? "bin";
+}
+
+/**
+ * Strip anything that would make the name unsafe to hand to a download:
+ * path separators (a `../` in a Meta-supplied filename must not escape the
+ * downloads folder), control characters, and the characters Windows
+ * rejects outright. Returns "" when nothing usable survives, so callers
+ * can fall through to the next source.
+ */
+export function sanitizeFilename(raw: string): string {
+  const basename = raw.split(/[\\/]/).pop() ?? "";
+  const cleaned = basename
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .replace(/[<>:"|?*]/g, "_")
+    .trim()
+    // Leading dots would make the file hidden (and "." / ".." are not names).
+    .replace(/^\.+/, "");
+  if (!cleaned) return "";
+
+  if (cleaned.length <= MAX_FILENAME_LENGTH) return cleaned;
+
+  // Truncate the stem, never the extension — a shortened `.pdf` opens, a
+  // truncated one doesn't.
+  const dot = cleaned.lastIndexOf(".");
+  if (dot <= 0) return cleaned.slice(0, MAX_FILENAME_LENGTH);
+  const ext = cleaned.slice(dot);
+  const stem = cleaned.slice(0, dot);
+  return stem.slice(0, Math.max(1, MAX_FILENAME_LENGTH - ext.length)) + ext;
+}
+
+/** A trailing `.ext` of 1–8 alphanumerics — good enough to call it a file. */
+function hasExtension(name: string): boolean {
+  return /\.[A-Za-z0-9]{1,8}$/.test(name);
+}
+
+/**
+ * Basename of a URL's path, query and fragment dropped, percent-decoded,
+ * and with `buildMediaPath`'s `<epoch-ms>-` prefix removed. Returns "" when
+ * the URL has no filename-looking last segment (e.g. a proxy URL, whose
+ * last segment is a bare Meta media-id).
+ */
+export function basenameFromUrl(url: string): string {
+  let path = url;
+  try {
+    // Base only matters for the relative-URL case; it's discarded either way.
+    path = new URL(url, "http://media.invalid").pathname;
+  } catch {
+    // Not parseable — fall back to chopping the query off by hand.
+    path = url.split(/[?#]/)[0];
+  }
+
+  const last = path.split("/").filter(Boolean).pop() ?? "";
+  let decoded = last;
+  try {
+    decoded = decodeURIComponent(last);
+  } catch {
+    // Malformed escape sequence — keep the raw segment.
+  }
+
+  const withoutStamp = decoded.replace(/^\d{10,}-/, "");
+  return hasExtension(withoutStamp) ? sanitizeFilename(withoutStamp) : "";
+}
+
+export interface MediaFilenameInput {
+  content_type: ContentType;
+  content_text?: string;
+  media_url?: string;
+  created_at: string;
+}
+
+/**
+ * Filename for a media message. `mimeType` is what the browser reported
+ * for the downloaded bytes (`blob.type`) — pass it when available, since
+ * it's the only reliable extension source for inbound media.
+ */
+export function mediaFilename(
+  message: MediaFilenameInput,
+  mimeType?: string | null,
+): string {
+  // 1. A document's own filename, when the sender didn't replace it with a
+  //    caption. Restricted to documents on purpose: an image caption like
+  //    "is this the right invoice.pdf" is prose, not a filename.
+  if (message.content_type === "document" && message.content_text) {
+    const fromText = hasExtension(message.content_text)
+      ? sanitizeFilename(message.content_text)
+      : "";
+    if (fromText) return fromText;
+  }
+
+  // 2. The uploaded object's name, for anything we sent ourselves.
+  if (message.media_url) {
+    const fromUrl = basenameFromUrl(message.media_url);
+    if (fromUrl) return fromUrl;
+  }
+
+  // 3. Synthesise. Timestamped so saving two photos from one thread doesn't
+  //    collide, and prefixed so they're greppable in a downloads folder.
+  const stamp = formatStamp(message.created_at);
+  const kind = message.content_type || "file";
+  const ext = extensionForMime(mimeType);
+  return sanitizeFilename(
+    stamp ? `whatsapp-${kind}-${stamp}.${ext}` : `whatsapp-${kind}.${ext}`,
+  );
+}
+
+function formatStamp(createdAt: string): string {
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return "";
+  return format(date, "yyyyMMdd-HHmmss");
+}

--- a/src/lib/media/gallery.test.ts
+++ b/src/lib/media/gallery.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import type { ContentType, Message, SenderType } from "@/types";
+import { collectMediaGallery, galleryIndexOf } from "./gallery";
+
+function msg(
+  id: string,
+  content_type: ContentType,
+  overrides: Partial<Message> = {},
+): Message {
+  return {
+    id,
+    conversation_id: "conv-1",
+    sender_type: (overrides.sender_type ?? "customer") as SenderType,
+    content_type,
+    status: "delivered",
+    created_at: "2026-08-04T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("collectMediaGallery", () => {
+  it("keeps images and videos in thread order and nothing else", () => {
+    const items = collectMediaGallery([
+      msg("t1", "text", { content_text: "hi" }),
+      msg("i1", "image", { media_url: "/api/whatsapp/media/1" }),
+      msg("a1", "audio", { media_url: "/api/whatsapp/media/2" }),
+      msg("v1", "video", { media_url: "/api/whatsapp/media/3" }),
+      msg("d1", "document", { media_url: "/api/whatsapp/media/4" }),
+      msg("i2", "image", { media_url: "https://x.supabase.co/photo.png" }),
+    ]);
+
+    expect(items.map((i) => i.messageId)).toEqual(["i1", "v1", "i2"]);
+    expect(items.map((i) => i.kind)).toEqual(["image", "video", "image"]);
+  });
+
+  it("skips media whose bytes we have no URL for", () => {
+    // Meta refusing to verify the id (webhook's verifyAndBuildUrl → null) or
+    // expiring it later both land here — the bubble shows "unavailable", so
+    // the viewer must not offer a blank frame to page onto.
+    const items = collectMediaGallery([
+      msg("i1", "image"),
+      msg("i2", "image", { media_url: "" }),
+      msg("i3", "image", { media_url: "/api/whatsapp/media/9" }),
+    ]);
+    expect(items.map((i) => i.messageId)).toEqual(["i3"]);
+  });
+
+  it("carries the caption, direction and the row itself", () => {
+    const [item] = collectMediaGallery([
+      msg("i1", "image", {
+        media_url: "/api/whatsapp/media/1",
+        content_text: "the receipt",
+        sender_type: "agent",
+      }),
+    ]);
+
+    expect(item.caption).toBe("the receipt");
+    expect(item.fromCustomer).toBe(false);
+    expect(item.message.id).toBe("i1");
+  });
+
+  it("treats an empty caption as no caption", () => {
+    const [item] = collectMediaGallery([
+      msg("i1", "image", { media_url: "/api/whatsapp/media/1", content_text: "" }),
+    ]);
+    expect(item.caption).toBeUndefined();
+  });
+
+  it("counts a bot-sent image as ours, not the customer's", () => {
+    const [item] = collectMediaGallery([
+      msg("i1", "image", {
+        media_url: "/api/whatsapp/media/1",
+        sender_type: "bot",
+      }),
+    ]);
+    expect(item.fromCustomer).toBe(false);
+  });
+
+  it("returns nothing for a thread with no media", () => {
+    expect(collectMediaGallery([msg("t1", "text")])).toEqual([]);
+    expect(collectMediaGallery([])).toEqual([]);
+  });
+});
+
+describe("galleryIndexOf", () => {
+  const items = collectMediaGallery([
+    msg("i1", "image", { media_url: "/api/whatsapp/media/1" }),
+    msg("i2", "image", { media_url: "/api/whatsapp/media/2" }),
+  ]);
+
+  it("finds the open item", () => {
+    expect(galleryIndexOf(items, "i2")).toBe(1);
+  });
+
+  it("reports -1 for null, so a closed viewer stays closed", () => {
+    expect(galleryIndexOf(items, null)).toBe(-1);
+  });
+
+  it("reports -1 once the message is gone from the thread", () => {
+    // Happens when an optimistic `temp-…` bubble is swapped for its real row
+    // while the viewer is open — the viewer closes rather than mis-pointing.
+    expect(galleryIndexOf(items, "temp-123")).toBe(-1);
+  });
+});

--- a/src/lib/media/gallery.ts
+++ b/src/lib/media/gallery.ts
@@ -1,0 +1,65 @@
+import type { Message } from "@/types";
+
+/**
+ * The set of media in a thread that the lightbox can page through, built
+ * from the messages the thread already holds (no extra fetch).
+ *
+ * Only images and videos qualify: an audio bubble has nothing to look at,
+ * and a document is handed to the OS rather than rendered. Rows with no
+ * `media_url` are skipped — that's either media Meta refused to verify
+ * (`verifyAndBuildUrl` returns null in the webhook) or media whose bytes
+ * Meta has since expired, and both render as "unavailable" in the bubble.
+ */
+
+export type MediaGalleryKind = "image" | "video";
+
+export interface MediaGalleryItem {
+  /** `messages.id` — the lightbox's identity for "which one is open". */
+  messageId: string;
+  url: string;
+  kind: MediaGalleryKind;
+  /** Caption, when the sender attached one. */
+  caption?: string;
+  createdAt: string;
+  /** Drives the "You" vs contact-name label in the viewer header. */
+  fromCustomer: boolean;
+  /** The row itself, so a download can derive its filename. */
+  message: Message;
+}
+
+function galleryKind(message: Message): MediaGalleryKind | null {
+  if (message.content_type === "image") return "image";
+  if (message.content_type === "video") return "video";
+  return null;
+}
+
+/**
+ * Viewable media in thread order. Order matters — it's what ← / → walk,
+ * and the thread hands messages over already sorted by `created_at`.
+ */
+export function collectMediaGallery(messages: Message[]): MediaGalleryItem[] {
+  const items: MediaGalleryItem[] = [];
+  for (const message of messages) {
+    const kind = galleryKind(message);
+    if (!kind || !message.media_url) continue;
+    items.push({
+      messageId: message.id,
+      url: message.media_url,
+      kind,
+      caption: message.content_text || undefined,
+      createdAt: message.created_at,
+      fromCustomer: message.sender_type === "customer",
+      message,
+    });
+  }
+  return items;
+}
+
+/** Index of a message in the gallery, or -1 when it isn't in it. */
+export function galleryIndexOf(
+  items: MediaGalleryItem[],
+  messageId: string | null,
+): number {
+  if (!messageId) return -1;
+  return items.findIndex((item) => item.messageId === messageId);
+}


### PR DESCRIPTION
## Summary

Adds a full-size media viewer and a download affordance to the inbox thread, so an agent can actually look at and keep an attachment a customer sent. Closes #373.

## What changed

**Viewer** — [`media-lightbox.tsx`](src/components/inbox/media-lightbox.tsx). Clicking an image (or focus + Enter) opens a dialog that pages through every image *and* video in the open conversation: ← / → keys, edge chevrons, a `3 of 12` counter, a fit ↔ 100% zoom toggle with scroll-to-pan, download, open-original, sender + timestamp, and the caption. One instance lives at thread level, keyed by `messages.id` rather than an index — the message list is live (realtime inserts, optimistic rows being swapped for real ones), so an index would quietly start pointing at a different photo.

**Downloads on every media kind** — [`message-media.tsx`](src/components/inbox/message-media.tsx), extracted from `message-bubble.tsx` so that file stays a content switch. Hover overlay on images; always-visible on video (plus an expand button, since the inline player is capped at `max-w-60` and a touch device gets no hover); beside the existing audio player and document link.

Neither affordance is a one-liner, because a `media_url` is one of two different things — inbound is `/api/whatsapp/media/<id>`, the auth-gated Meta proxy the browser can't reach on its own; outbound is a cross-origin bucket URL, where browsers ignore the `download` attribute. Both are handled by fetching the bytes:

- [`lib/media/blob-cache.ts`](src/lib/media/blob-cache.ts) — memoises proxy responses as `Blob`s (LRU 30, concurrent loads de-duplicated) so the thumbnail, the viewer and a download share one trip through Meta instead of three. Blobs are cached rather than object URLs, so an eviction can't revoke a URL a mounted `<img>` is still using.
- [`lib/media/filename.ts`](src/lib/media/filename.ts) — reconstructs a filename (there is no `media_filename` column) from a document's own name, a bucket URL's basename minus `buildMediaPath`'s epoch prefix, or a synthesised `whatsapp-image-<timestamp>.<ext>`. Strips path traversal and control characters — the document name comes straight off the customer's phone.
- [`lib/media/download.ts`](src/lib/media/download.ts) — turns that into an `<a download>` click. Only a fetch that *never completed* (CORS) falls back to a new tab; a refused response throws so the caller can toast, otherwise expired media would silently open a tab onto its own 401.

**Drive-by fix:** the `MediaImage` this replaces revoked a `src` captured from a render where it was still `null`, so no thumbnail object URL was ever revoked and every remount refetched the whole image.

**i18n:** new `Inbox.mediaViewer.*` block plus five `Inbox.bubble` keys, in both `en.json` and `ko.json`.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 38 warnings / 0 errors, one *fewer* than `main`'s 39.
- [x] `npm test` — 690 passing, up from 654. 36 new tests: filename derivation (incl. `../` and control-char sanitisation), gallery collection, blob-cache de-duplication / LRU eviction / refused-vs-blocked error typing.
- [x] `npm run build` succeeds (with CI's dummy env).
- [x] Manually exercised in the browser against a throwaway harness route — a live thread needs a configured WABA, so the harness stood in with fixture messages covering both URL flavours, a caption, an outbound bubble, and the expired-media case.

Two bugs that pass caught and this PR fixes:

1. **Arrow keys did nothing.** base-ui's popup stops arrow-key propagation for its own focus management, so a bubble-phase `window` listener never fires — the handler is registered in the capture phase. Worth knowing for anything similar: a synthetic keydown dispatched *on `window`* passes and proves nothing; dispatch from `document.activeElement` inside the dialog to reproduce the real path.
2. **A zoomed image couldn't pan left.** A flex-centred child overflowing a scroll container spills both ways and the left half is unreachable — measured `scrollWidth` 1764 against a natural 2400. Centring with `mx-auto` on a block child instead gives the full 2400.

Reviewer check: open a conversation with a photo, click it, arrow through the thread's media, toggle zoom, hit Download; then try Download on a video, a voice note and a document.

## Related

Closes #373. Follow-up in #466 — inbound media is stored as a Meta media-id only, and Meta deletes the bytes ~30 days after receipt, so attachments older than that still render "no longer available". Mirroring them into `chat-media` needs a migration + webhook changes and was deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)