### PR TITLE
fix(automations): whole-word keyword mode + re-open closed threads on customer reply (#409)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -990,6 +990,8 @@
         "placeholderBody": "{\"id\": \"{{ contact.id }}\"}",
         "matchType": "Match type",
         "matchContains": "Contains",
+        "matchWord": "Whole word",
+        "matchWordHint": "Matches the keyword only as a standalone word, so \"k\" no longer fires on \"thanks\". Best for short keywords in space-separated languages; use Contains for languages written without spaces.",
         "matchExact": "Exact",
         "closeConversationHint": "Sets the conversation status to \"closed\". No configuration needed."
       }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -990,6 +990,8 @@
         "placeholderBody": "{\"id\": \"{{ contact.id }}\"}",
         "matchType": "일치 유형",
         "matchContains": "포함",
+        "matchWord": "단어 단위 일치",
+        "matchWordHint": "키워드가 독립된 단어일 때만 일치하므로 \"k\"가 \"thanks\"에서 실행되지 않습니다. 공백으로 단어를 구분하는 언어의 짧은 키워드에 적합하며, 공백 없이 표기하는 언어에는 \"포함\"을 사용하세요.",
         "matchExact": "정확히 일치",
         "closeConversationHint": "대화 상태를 \"닫힘\"으로 설정합니다. 추가 설정이 필요 없습니다."
       }

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -4,6 +4,7 @@ import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption'
 import { getMediaUrl, downloadMedia } from '@/lib/whatsapp/meta-api'
 import { normalizePhone } from '@/lib/whatsapp/phone-utils'
 import { findExistingContact, isUniqueViolation } from '@/lib/contacts/dedupe'
+import { reopenClosedConversation } from '@/lib/conversations/reopen'
 import { verifyMetaWebhookSignature } from '@/lib/whatsapp/webhook-signature'
 import { runAutomationsForTrigger } from '@/lib/automations/engine'
 import { dispatchInboundToFlows } from '@/lib/flows/engine'
@@ -701,6 +702,12 @@ async function processMessage(
   if (convError) {
     console.error('Error updating conversation:', convError)
   }
+
+  // A customer writing again re-opens the thread (issue #409). Kept as a
+  // separate conditional statement rather than a `status` field on the
+  // update above so the write can be gated on the row's CURRENT status in
+  // SQL — see the helper for why that matters.
+  await reopenClosedConversation(supabaseAdmin(), conversation)
 
   // If this contact was a recent broadcast recipient, flag the reply
   // so the broadcast's `replied_count` advances (via the aggregate

--- a/src/components/automations/automation-builder.tsx
+++ b/src/components/automations/automation-builder.tsx
@@ -950,12 +950,26 @@ function KeywordMatchConfig({
         </label>
         <select
           value={config?.match_type ?? "contains"}
-          onChange={(e) => onChange({ ...config, match_type: e.target.value as "exact" | "contains" })}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              match_type: e.target.value as "exact" | "contains" | "word",
+            })
+          }
           className="w-full rounded-md border border-border bg-muted px-2 py-1.5 text-sm text-foreground focus:outline-none"
         >
           <option value="contains">{t("config.matchContains")}</option>
+          <option value="word">{t("config.matchWord")}</option>
           <option value="exact">{t("config.matchExact")}</option>
         </select>
+        {/* Only worth explaining for `word` — "contains" and "exact" read
+            for themselves, and this is the one that changes which messages
+            fire an automation in a way that isn't obvious. */}
+        {config?.match_type === "word" && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t("config.matchWordHint")}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/src/lib/automations/engine.test.ts
+++ b/src/lib/automations/engine.test.ts
@@ -105,7 +105,7 @@ vi.mock("./meta-send", () => ({
 }));
 
 import { runAutomationsForTrigger, triggerMatches } from "./engine";
-import type { Automation } from "@/types";
+import type { Automation, KeywordMatchTriggerConfig } from "@/types";
 
 const ACCOUNT = "acct-1";
 
@@ -448,5 +448,105 @@ describe("tag_added — conversation policy", () => {
       status: "failed",
       error_message: "tag_added automation cannot send: contact has no existing conversation",
     }));
+  });
+});
+
+describe("triggerMatches — keyword_match", () => {
+  function automation(
+    cfg: Partial<KeywordMatchTriggerConfig> & { keywords: string[] },
+  ): Automation {
+    return {
+      id: "a1",
+      account_id: ACCOUNT,
+      user_id: "u1",
+      name: "kw",
+      trigger_type: "keyword_match",
+      trigger_config: { match_type: "contains", ...cfg },
+      is_active: true,
+    } as unknown as Automation;
+  }
+
+  const on = (a: Automation, text: string) =>
+    triggerMatches(a, { message_text: text });
+
+  it("keeps `contains` as a raw substring test", () => {
+    // Issue #409 asked for this to become word-boundary matching. It
+    // deliberately did NOT change: existing automations relying on
+    // substring behaviour ("cat" firing on "category") must keep working,
+    // and `contains` is the builder's default. `word` is the opt-in fix.
+    expect(on(automation({ keywords: ["k"] }), "thanks")).toBe(true);
+    expect(on(automation({ keywords: ["cat"] }), "category")).toBe(true);
+  });
+
+  it("`word` matches only standalone words", () => {
+    const a = automation({ keywords: ["k"], match_type: "word" });
+    expect(on(a, "thanks")).toBe(false);
+    expect(on(a, "k")).toBe(true);
+    expect(on(a, "press k to continue")).toBe(true);
+    expect(on(a, "press K!")).toBe(true);
+  });
+
+  it("`word` respects punctuation and line edges around the keyword", () => {
+    const a = automation({ keywords: ["hi"], match_type: "word" });
+    expect(on(a, "hi")).toBe(true);
+    expect(on(a, "hi!")).toBe(true);
+    expect(on(a, "(hi)")).toBe(true);
+    expect(on(a, "say hi.")).toBe(true);
+    expect(on(a, "this")).toBe(false);
+    expect(on(a, "hiya")).toBe(false);
+  });
+
+  it("`word` handles a keyword that itself carries punctuation", () => {
+    // `\b` can't do this: /\bhi!\b/ demands a word char after the "!",
+    // so it never matches. Hence the lookaround implementation.
+    const a = automation({ keywords: ["hi!"], match_type: "word" });
+    expect(on(a, "say hi!")).toBe(true);
+    expect(on(a, "hi! there")).toBe(true);
+  });
+
+  it("`word` treats regex metacharacters in a keyword as literal", () => {
+    // Account-supplied free text — an unescaped "(" would throw.
+    const a = automation({ keywords: ["c++ (beginner)"], match_type: "word" });
+    expect(on(a, "I want the c++ (beginner) course")).toBe(true);
+    expect(on(a, "I want the cxx beginner course")).toBe(false);
+    expect(() => on(automation({ keywords: ["("], match_type: "word" }), "(")).not.toThrow();
+  });
+
+  it("`word` is case-insensitive unless case_sensitive is set", () => {
+    expect(on(automation({ keywords: ["Hi"], match_type: "word" }), "hi")).toBe(true);
+    expect(
+      on(
+        automation({ keywords: ["Hi"], match_type: "word", case_sensitive: true }),
+        "hi",
+      ),
+    ).toBe(false);
+    expect(
+      on(
+        automation({ keywords: ["Hi"], match_type: "word", case_sensitive: true }),
+        "Hi",
+      ),
+    ).toBe(true);
+  });
+
+  it("`word` finds a space-delimited keyword in a non-Latin script", () => {
+    // ASCII `\b` fails outright here — every character of "안녕" is a
+    // non-word character to it, so /\b안녕\b/ matches nothing.
+    const a = automation({ keywords: ["안녕"], match_type: "word" });
+    expect(on(a, "안녕")).toBe(true);
+    expect(on(a, "저기 안녕 하세요")).toBe(true);
+    // Documented limitation, not an accident: a language written without
+    // spaces has no word edge inside a run of characters.
+    expect(on(a, "안녕하세요")).toBe(false);
+  });
+
+  it("`exact` still requires the whole message to be the keyword", () => {
+    const a = automation({ keywords: ["hi"], match_type: "exact" });
+    expect(on(a, "hi")).toBe(true);
+    expect(on(a, "hi there")).toBe(false);
+  });
+
+  it("ignores empty keywords and empty messages in `word` mode", () => {
+    expect(on(automation({ keywords: [""], match_type: "word" }), "anything")).toBe(false);
+    expect(on(automation({ keywords: ["hi"], match_type: "word" }), "")).toBe(false);
   });
 });

--- a/src/lib/automations/engine.ts
+++ b/src/lib/automations/engine.ts
@@ -655,12 +655,56 @@ async function resolveConversationId(args: ExecuteArgs): Promise<string> {
   return data.id as string
 }
 
+/** Letter, digit or underscore in any script — the "inside a word" test. */
+const WORD_CHAR = '[\\p{L}\\p{N}_]'
+
+/**
+ * Whole-word keyword test, behind `match_type: 'word'` (issue #409 — a
+ * one-letter keyword under `contains` fires on every message containing
+ * that letter, e.g. "k" on "thanks").
+ *
+ * Deliberately NOT `\b`, which is defined against `[A-Za-z0-9_]` and so
+ * breaks two cases that matter for WhatsApp traffic:
+ *
+ *   - A keyword carrying punctuation: `/\bhi!\b/` demands a word character
+ *     after the "!", so it never matches "say hi!".
+ *   - Any non-Latin script: every character of "안녕" is a non-word
+ *     character to `\b`, so `/\b안녕\b/` matches nothing at all.
+ *
+ * Unicode-aware lookarounds handle both. Note this really is word-based:
+ * it won't find "안녕" inside "안녕하세요", because a language that doesn't
+ * delimit words with spaces has no word edge there. That's what `contains`
+ * is for, and it stays the default.
+ *
+ * Exported for direct unit testing of the escaping / boundary edges.
+ */
+export function matchesWholeWord(
+  text: string,
+  keyword: string,
+  caseSensitive = false,
+): boolean {
+  if (!keyword) return false
+  // The keyword is account-supplied free text, so metacharacters have to
+  // be literal — otherwise "(" is an unterminated group and RegExp throws.
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(
+    `(?<!${WORD_CHAR})${escaped}(?!${WORD_CHAR})`,
+    caseSensitive ? 'u' : 'iu',
+  )
+  return pattern.test(text)
+}
+
 export function triggerMatches(automation: Automation, ctx: AutomationContext | undefined): boolean {
   if (automation.trigger_type === 'keyword_match') {
     const cfg = automation.trigger_config as KeywordMatchTriggerConfig
     if (!cfg?.keywords || cfg.keywords.length === 0) return false
     const text = (ctx?.message_text ?? '').toString()
     if (!text) return false
+    if (cfg.match_type === 'word') {
+      return cfg.keywords.some((raw) =>
+        matchesWholeWord(text, raw, cfg.case_sensitive),
+      )
+    }
     const haystack = cfg.case_sensitive ? text : text.toLowerCase()
     return cfg.keywords.some((raw) => {
       const k = cfg.case_sensitive ? raw : raw.toLowerCase()

--- a/src/lib/automations/validate.test.ts
+++ b/src/lib/automations/validate.test.ts
@@ -249,6 +249,18 @@ describe("validateTriggerForActivation", () => {
     ).toEqual([]);
   });
 
+  it("accepts the word match_type (issue #409)", () => {
+    // Activation validation has to stay in step with the engine and the
+    // builder's dropdown — an automation the UI can save must not be
+    // rejected on activation.
+    expect(
+      validateTriggerForActivation("keyword_match", {
+        keywords: ["hi"],
+        match_type: "word",
+      }),
+    ).toEqual([]);
+  });
+
   it("requires schedule on time_based triggers", () => {
     expect(validateTriggerForActivation("time_based", {})).toEqual([
       { path: "trigger.schedule", message: "schedule is required" },

--- a/src/lib/automations/validate.ts
+++ b/src/lib/automations/validate.ts
@@ -171,10 +171,15 @@ export function validateTriggerForActivation(
     // value is invalid here. This keeps activation validation in step
     // with the engine and with the builder's "Contains" default — an
     // automation that shows the default in the UI must not be rejected.
-    if (cfg.match_type != null && cfg.match_type !== 'exact' && cfg.match_type !== 'contains') {
+    if (
+      cfg.match_type != null &&
+      cfg.match_type !== 'exact' &&
+      cfg.match_type !== 'contains' &&
+      cfg.match_type !== 'word'
+    ) {
       issues.push({
         path: 'trigger.match_type',
-        message: 'match type must be "exact" or "contains"',
+        message: 'match type must be "exact", "contains" or "word"',
       })
     }
   } else if (triggerType === 'time_based') {

--- a/src/lib/conversations/reopen.test.ts
+++ b/src/lib/conversations/reopen.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { reopenClosedConversation } from './reopen'
+
+/**
+ * Regression cover for issue #409's "closed conversation lockout": an
+ * inbound message bumped `unread_count` but never touched `status`, so a
+ * closed thread accumulated unread customer messages while still reading
+ * as resolved and staying out of the inbox's Open filter.
+ */
+
+interface Recorded {
+  table: string
+  payload: Record<string, unknown> | null
+  filters: [string, unknown][]
+}
+
+/** Chainable stub shaped like the bit of postgrest this touches. */
+function stubClient(error: { message: string } | null = null) {
+  const calls: Recorded[] = []
+
+  const client = {
+    from(table: string) {
+      const rec: Recorded = { table, payload: null, filters: [] }
+      calls.push(rec)
+      const builder = {
+        update(payload: Record<string, unknown>) {
+          rec.payload = payload
+          return builder
+        },
+        eq(column: string, value: unknown) {
+          rec.filters.push([column, value])
+          return builder
+        },
+        then(onFulfilled: (v: { error: unknown }) => unknown) {
+          return Promise.resolve({ error }).then(onFulfilled)
+        },
+      }
+      return builder
+    },
+  }
+
+  return { client: client as unknown as SupabaseClient, calls }
+}
+
+describe('reopenClosedConversation', () => {
+  it('flips a closed conversation back to open', async () => {
+    const { client, calls } = stubClient()
+
+    const reopened = await reopenClosedConversation(client, {
+      id: 'conv-1',
+      status: 'closed',
+    })
+
+    expect(reopened).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].table).toBe('conversations')
+    expect(calls[0].payload).toMatchObject({ status: 'open' })
+    expect(calls[0].payload).toHaveProperty('updated_at')
+  })
+
+  it('guards the write on the row still being closed', async () => {
+    // The caller read the row earlier in the request. Without this filter,
+    // two concurrent inbound deliveries both holding a stale
+    // `status: 'closed'` could write 'open' over an agent's re-close.
+    const { client, calls } = stubClient()
+
+    await reopenClosedConversation(client, { id: 'conv-1', status: 'closed' })
+
+    expect(calls[0].filters).toEqual([
+      ['id', 'conv-1'],
+      ['status', 'closed'],
+    ])
+  })
+
+  it.each(['open', 'pending'])(
+    'issues no query for a %s conversation',
+    async (status) => {
+      const { client, calls } = stubClient()
+
+      const reopened = await reopenClosedConversation(client, {
+        id: 'conv-1',
+        status,
+      })
+
+      expect(reopened).toBe(false)
+      expect(calls).toEqual([])
+    },
+  )
+
+  it('issues no query when status is missing', async () => {
+    const { client, calls } = stubClient()
+
+    expect(await reopenClosedConversation(client, { id: 'conv-1' })).toBe(false)
+    expect(calls).toEqual([])
+  })
+
+  it('swallows a failed update so inbound processing continues', async () => {
+    // Throwing here would abort the webhook and make Meta redeliver the
+    // message — a worse outcome than a thread that stays closed.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = stubClient({ message: 'permission denied' })
+
+    await expect(
+      reopenClosedConversation(client, { id: 'conv-1', status: 'closed' }),
+    ).resolves.toBe(false)
+
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})

--- a/src/lib/conversations/reopen.ts
+++ b/src/lib/conversations/reopen.ts
@@ -1,0 +1,45 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Re-open a closed conversation because the customer wrote again
+ * (issue #409).
+ *
+ * Inbound processing bumps `unread_count` but used to leave `status`
+ * alone, so a thread an agent closed — or that a `close_conversation`
+ * automation step closed — stayed `closed` while accumulating unread
+ * customer messages. It read as resolved, and it dropped out of the
+ * inbox's Open filter, so an agent working that filter never saw the
+ * reply. (Automation dispatch is unaffected either way: it keys on
+ * account + trigger + contact, never conversation status.)
+ *
+ * Lives here rather than inline in the webhook so it can be tested
+ * without standing up the whole route, and so any future inbound path
+ * gets the same behaviour for free.
+ */
+export async function reopenClosedConversation(
+  db: SupabaseClient,
+  conversation: { id: string; status?: string | null },
+): Promise<boolean> {
+  // Nothing to do for open/pending threads, which is the common case —
+  // skipping the round trip keeps inbound processing as cheap as it was.
+  if (conversation.status !== 'closed') return false
+
+  const { error } = await db
+    .from('conversations')
+    .update({ status: 'open', updated_at: new Date().toISOString() })
+    .eq('id', conversation.id)
+    // Re-checked in SQL, not just in the `if` above: the caller's row was
+    // read earlier in the request, so two concurrent inbound deliveries
+    // both holding a stale `status: 'closed'` must not be able to write
+    // 'open' back over an agent who re-closed the thread in between.
+    .eq('status', 'closed')
+
+  if (error) {
+    // Best-effort, same as the conversation update this follows: a failed
+    // re-open must not abort inbound processing (and make Meta redeliver).
+    console.error('Error re-opening conversation:', error)
+    return false
+  }
+
+  return true
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -460,7 +460,15 @@ export type AutomationLogStatus = 'success' | 'partial' | 'failed';
 
 export interface KeywordMatchTriggerConfig {
   keywords: string[];
-  match_type: 'exact' | 'contains';
+  /**
+   * `contains` (the default) is a raw substring test, so a short keyword
+   * matches inside longer words — "k" fires on "thanks". `word` is the
+   * boundary-aware alternative added for issue #409; see
+   * `matchesWholeWord` in `@/lib/automations/engine` for its exact
+   * semantics. Flows carry their own keyword config and stay
+   * substring-only (`@/lib/flows/types`).
+   */
+  match_type: 'exact' | 'contains' | 'word';
   case_sensitive?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Closes the two remaining defects in #409. The other two were already fixed by #444, and the title's "double-fire on concurrent webhooks" is inbound replay dedup — that's #449's job and this PR stays clear of it.

Where #409's four claims actually stand on `main`:

| Claim | Status |
| --- | --- |
| 1. `0 steps logged` (log seeded `success` before running) | Already fixed — #444, regression test at `engine.test.ts:178` |
| 2. `runAutomationsForTrigger` not awaited inside `after()` | Already fixed — #444 |
| 3. `contains` over-matches on short keywords | Fixed here, **additively** — see below |
| 4. Closed conversation not re-opened on reply | Fixed here |

One correction to the issue: a closed conversation **never blocked automations**. Dispatch filters on `account_id`, `trigger_type`, `is_active` and contact ownership only (`engine.ts:95-100`) — conversation status is never consulted. The real harm was inbox-side.

## What changed

**Whole-word keyword matching** — `match_type` gains a third value, `word`, shown as "Whole word" in the builder next to Contains/Exact.

The issue asked for `contains` itself to become word-boundary matching. I didn't do that: it silently changes behaviour for anyone whose automation relies on substring matching (keyword "cat" firing on "category") with no way to opt back out. `contains` is untouched and remains the default, so **no existing automation changes behaviour** — this is purely a new option. Test `keeps \`contains\` as a raw substring test` pins that.

`matchesWholeWord` ([engine.ts](src/lib/automations/engine.ts)) deliberately does not use `\b`, which is defined against `[A-Za-z0-9_]` and breaks two cases that matter for WhatsApp traffic:

- a keyword carrying punctuation — `/\bhi!\b/` demands a word character after the `!`, so it never matches "say hi!";
- any non-Latin script — every character of "안녕" is a non-word character to `\b`, so `/\b안녕\b/` matches nothing at all.

Unicode-aware lookarounds (`(?<![\p{L}\p{N}_])…(?![\p{L}\p{N}_])`) handle both. Keywords are account-supplied free text, so regex metacharacters are escaped — `"c++ (beginner)"` is matched literally rather than throwing.

The mode is genuinely word-based, so it won't find "안녕" inside "안녕하세요". That's a property of languages written without word delimiters, not a bug, and it's called out in the type, the helper docstring and the builder hint, which points those users at Contains.

Also touched: `validate.ts` accepts `word` on activation (otherwise the builder could save an automation that activation then rejects), the `match_type` union in `types/index.ts`, and `matchWord` / `matchWordHint` in both `en.json` and `ko.json`.

**Re-open closed threads** — [`lib/conversations/reopen.ts`](src/lib/conversations/reopen.ts), called from the inbound path. Previously the conversation update bumped `unread_count` but never touched `status`, so a thread an agent (or a `close_conversation` step) closed kept collecting unread customer messages while still reading as resolved, and stayed out of the inbox's Open filter — an agent working that filter never saw the reply.

Two deliberate choices there, both about not fighting #449:

- The write is gated on the row's **current** status in SQL (`.eq('status', 'closed')`), not just on the value this request read earlier, so two concurrent inbound deliveries can't write `open` back over an agent who re-closed the thread in between.
- It's a separate statement rather than a field on the existing conversation update, and it lives in `lib/` rather than inline in the route, because #449 rewrites that update into an RPC and adds the route's first test harness. Keeping this out of that block keeps both diffs readable; if #449 lands first, this is a one-line move into the RPC.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 38 warnings / 0 errors, unchanged from `main`.
- [x] `npm test` — 706 passing, up from 690. 16 new tests: 9 on keyword matching (substring behaviour preserved, standalone-word matching, punctuation in the message and in the keyword, metacharacter escaping, case sensitivity, Korean, empty inputs), 6 on the re-open (flips only when closed, SQL guard present, no query for open/pending/missing status, failure swallowed), 1 on activation validation.
- [x] `npm run build` succeeds (CI dummy env).
- [ ] Not exercised against live WhatsApp traffic — the re-open needs an inbound webhook against a configured WABA, which I can't drive here. It's covered by unit tests over the query it issues; worth one manual check on a staging number before release: close a thread, reply from the customer, confirm it returns to Open with the unread badge.

Reviewer check for the keyword mode: create a `keyword_match` automation with keyword `k`, set Match type to **Whole word**, send "thanks" (should not fire) then "k" (should fire); switch it back to **Contains** and confirm "thanks" fires again.

## Related

Closes #409. Deliberately disjoint from #449 (inbound replay dedup + the conversation-update RPC) — see the note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)