### PR TITLE
fix(deps): patch all open Dependabot alerts in one pass (brace-expansion, fast-uri, hono, ip-address)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -466,9 +466,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.28",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
-      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -654,9 +654,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3754,9 +3754,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4711,9 +4711,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6489,9 +6489,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7054,9 +7054,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7236,9 +7236,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -78,11 +78,13 @@
   },
   "overrides": {
     "postcss": "^8.5.10",
-    "ip-address": "^10.1.1",
-    "fast-uri": "^3.1.2",
-    "hono": "^4.12.25",
+    "ip-address": "^10.3.1",
+    "fast-uri": "^3.1.5",
+    "hono": "^4.12.34",
     "js-yaml": "^4.2.0",
     "@babel/core": "^7.29.6",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "brace-expansion@^1.0.0": "^1.1.18",
+    "brace-expansion@^5.0.0": "^5.0.9"
   }
 }


### PR DESCRIPTION
## Summary

Clears **every open Dependabot alert** on the repo. There were 11 alerts, but they reduce to four packages across the two lockfiles — all transitive, none requiring a source change — so they belong in one PR rather than 11 bot PRs each needing the usual lockfile rescue.

| Package | Change | Advisories | Alerts |
| --- | --- | --- | --- |
| `brace-expansion` | 5.0.8 → 5.0.9, 1.1.16 → 1.1.18 | GHSA-rgw5-rvv9-x895 | #76 (+ #75/#67, see below) |
| `fast-uri` | 3.1.4 → 3.1.5 | GHSA-7p8r-x3mc-p8w7 | #72, #77 |
| `hono` | 4.12.28/4.12.32 → 4.13.0 | GHSA-8j4g-w8fx-2239 | #74, #79 |
| `ip-address` | 10.2.0 → 10.4.0 | GHSA-mwp4-54f8-5fhr, GHSA-22jq-vg5j-6vgg, GHSA-4xrf-jv44-h6hh | #73, #78, #69, #68, #71, #70 |

The alert count is inflated because `ip-address` has three separate advisories and `brace-expansion` two vulnerable ranges — one bump each satisfies them all. 11 alerts, 8 version changes.

## What changed

Every existing spec **already permitted** the patched version; the committed lockfiles were just resolved lower. So rather than leave that to drift, the `overrides` floors move up to the patched versions — which is how that block is already used here (`postcss`, `js-yaml`, `sharp` are all security floors from earlier PRs). This stops a future resolve dropping back below a patched release.

**`brace-expansion` uses npm's version-scoped override keys**, which is the one unusual bit:

```json
"brace-expansion@^1.0.0": "^1.1.18",
"brace-expansion@^5.0.0": "^5.0.9"
```

GHSA-rgw5-rvv9-x895 patches each major line separately, and the tree holds two of them: `1.1.16` under the dev `minimatch@^1.1.7` chain (patched by 1.1.18) and two `5.0.8` copies under the `minimatch@^5.0.5` chains inside `@ts-morph/common` and `@typescript-eslint/typescript-estree` (patched by 5.0.9). A plain `"brace-expansion": "^5.0.9"` would have closed the alert while dragging the 1.x consumer up four majors; scoping keeps each line on its own patch. Verified in the resulting lockfile: the 1.x entry is at 1.1.18 and still 1.x, the 5.x entries at 5.0.9.

Note on scope: only **#76** (the 5.x range) was open. **#75** and **#67**, covering the 1.x range, were auto-dismissed by Dependabot as `development` scope earlier today. They're fixed here incidentally because it's a patch bump within the same major and it makes `npm audit` clean on a fresh clone — not because they were outstanding.

**`mcp-server/` needs no overrides.** The SDK's own ranges already allow the patched versions (`hono ^4.11.4` from `@modelcontextprotocol/sdk`, `fast-uri ^3.0.1` via `ajv`, `ip-address ^10.2.0` via `express-rate-limit`), so a targeted `npm update --package-lock-only` was sufficient.

## Test plan

Both lockfiles regenerated with **npm 10** — what CI's Node 20 ships — so the nested `next-intl/node_modules/@swc/helpers@0.5.23` entry survives and `npm ci` doesn't fail the way bot-generated lockfiles do (still 7 `@swc/helpers` occurrences).

- [x] `npm ci` under npm 10 — 696 packages, no lockfile-sync error.
- [x] `npm run lint` — 38 warnings / 0 errors, unchanged from `main`.
- [x] `npm run typecheck` clean.
- [x] `npm test` — 706 passing, unchanged.
- [x] `npm run build` succeeds.
- [x] `npm audit` — **0 vulnerabilities**, root and `mcp-server/`.
- [x] `mcp-server/` verified separately, since CI does not cover it at all: `npm ci`, `npm run typecheck`, `npm run build` all pass.

Diffed both lockfiles against their pre-change state programmatically rather than eyeballing:

- exactly the 8 intended version changes;
- **zero** packages added or removed;
- **`@supabase/*` still pinned at 2.108.2.** Worth stating explicitly: its `^2.107.0` spec permits the 2.112 line, which declares `engines.node >= 22.0.0` against this repo's Node 20 target — the reason #458/#433/#412/#379 were all closed. A careless `npm update` here would have pulled it in silently and gone green in CI anyway.
- `next` 16.2.12, `sharp` 0.35.3, `recharts` 3.10.1 untouched.

## Related

Supersedes the open bot PRs for these packages, if any are raised. Does not touch the two known-blocked bumps: `eslint 9→10` (bundled `eslint-plugin-react@7.37.5` still calls the removed `context.getFilename()`, and it's the latest published version, so there's nothing to override our way out of) and the `@supabase/*` 2.112 family (Node 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)