### PR TITLE
fix(i18n): read ICU-unparseable strings with t.raw() instead of t()

### DIFF
--- a/src/components/automations/automation-builder.tsx
+++ b/src/components/automations/automation-builder.tsx
@@ -1376,7 +1376,7 @@ function StepEditor({
             <Input
               value={(cfg.value as string) ?? ""}
               onChange={(e) => set({ value: e.target.value })}
-              placeholder={t("config.placeholderValue")}
+              placeholder={t.raw("config.placeholderValue")}
               className="bg-muted text-foreground"
             />
           </FieldBlock>

--- a/src/components/settings/template-manager.tsx
+++ b/src/components/settings/template-manager.tsx
@@ -776,7 +776,7 @@ export function TemplateManager() {
                   <Input
                     id="template-header-text"
                     aria-label="Header text"
-                    placeholder={t('headerTextPlaceholder')}
+                    placeholder={t.raw('headerTextPlaceholder')}
                     value={form.header_content}
                     onChange={(e) =>
                       setForm({ ...form, header_content: e.target.value })
@@ -788,7 +788,7 @@ export function TemplateManager() {
                     <Input
                       id="template-header-sample"
                       aria-label={t('headerSampleAria')}
-                      placeholder={t('headerSamplePlaceholder')}
+                      placeholder={t.raw('headerSamplePlaceholder')}
                       value={form.header_sample}
                       onChange={(e) =>
                         setForm({ ...form, header_sample: e.target.value })
@@ -865,7 +865,7 @@ export function TemplateManager() {
             <div className="space-y-2">
               <Label className="text-muted-foreground">{t('bodyText')}</Label>
               <Textarea
-                placeholder={t('bodyPlaceholder')}
+                placeholder={t.raw('bodyPlaceholder')}
                 value={form.body_text}
                 onChange={(e) =>
                   setForm({ ...form, body_text: e.target.value })
@@ -875,7 +875,7 @@ export function TemplateManager() {
                 className="bg-muted border-border text-foreground placeholder:text-muted-foreground resize-none"
               />
               <p className="text-[11px] text-muted-foreground">
-                {t('bodyHint')}
+                {t.raw('bodyHint')}
               </p>
 
               {bodyVarCount > 0 && (
@@ -1007,7 +1007,7 @@ export function TemplateManager() {
                       {btn.type === 'URL' && (
                         <div className="space-y-1 pl-1">
                           <Input
-                            placeholder={t('urlPlaceholder')}
+                            placeholder={t.raw('urlPlaceholder')}
                             value={btn.url}
                             onChange={(e) =>
                               updateButton(i, { url: e.target.value })
@@ -1016,7 +1016,7 @@ export function TemplateManager() {
                           />
                           {extractVariableIndices(btn.url).length > 0 && (
                             <Input
-                              placeholder={t('urlSamplePlaceholder')}
+                              placeholder={t.raw('urlSamplePlaceholder')}
                               value={btn.example ?? ''}
                               onChange={(e) =>
                                 updateButton(i, { example: e.target.value })

--- a/src/components/settings/whatsapp-config.tsx
+++ b/src/components/settings/whatsapp-config.tsx
@@ -794,9 +794,9 @@ export function WhatsAppConfig() {
                 <AccordionContent className="text-muted-foreground">
                   <ol className="list-decimal list-inside space-y-1 text-sm">
                     <li>{t('step3_1')}</li>
-                    <li dangerouslySetInnerHTML={{ __html: t('step3_2') }} />
-                    <li dangerouslySetInnerHTML={{ __html: t('step3_3') }} />
-                    <li dangerouslySetInnerHTML={{ __html: t('step3_4') }} />
+                    <li dangerouslySetInnerHTML={{ __html: t.raw('step3_2') }} />
+                    <li dangerouslySetInnerHTML={{ __html: t.raw('step3_3') }} />
+                    <li dangerouslySetInnerHTML={{ __html: t.raw('step3_4') }} />
                   </ol>
                 </AccordionContent>
               </AccordionItem>
@@ -812,8 +812,8 @@ export function WhatsAppConfig() {
                   <ol className="list-decimal list-inside space-y-1 text-sm">
                     <li>{t('step4_1')}</li>
                     <li>{t('step4_2')}</li>
-                    <li dangerouslySetInnerHTML={{ __html: t('step4_3') }} />
-                    <li dangerouslySetInnerHTML={{ __html: t('step4_4') }} />
+                    <li dangerouslySetInnerHTML={{ __html: t.raw('step4_3') }} />
+                    <li dangerouslySetInnerHTML={{ __html: t.raw('step4_4') }} />
                     <li>{t('step4_5')}</li>
                   </ol>
                 </AccordionContent>

--- a/src/i18n/icu-safety.test.ts
+++ b/src/i18n/icu-safety.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createTranslator } from 'next-intl';
+
+// Some catalogue strings are deliberately not ICU messages: template
+// placeholders show the literal WhatsApp `{{1}}` syntax to the user, and
+// a few setup steps carry raw HTML destined for dangerouslySetInnerHTML.
+// next-intl's ICU parser rejects both.
+//
+// It rejects them *quietly*: `t()` reports INVALID_MESSAGE / FORMATTING_ERROR
+// to onError and then renders the keypath itself, so the field shows
+// "Settings.templates.bodyPlaceholder" instead of the placeholder. Nothing
+// throws, no build fails, and dev looks the same as prod — which is how
+// twelve of these shipped unnoticed.
+//
+// Such strings must be read with `t.raw()` (bypasses the parser) or
+// `t.rich()` (tag handlers). This test fails when one is wired to plain
+// `t()`. Reported by @Arifuzzamanjoy in #421.
+
+const MESSAGES = join(process.cwd(), 'messages', 'en.json');
+const SRC = join(process.cwd(), 'src');
+
+/** Leaf keypaths whose value next-intl cannot parse as an ICU message. */
+function icuHostileKeys(): string[] {
+  const catalogue = JSON.parse(readFileSync(MESSAGES, 'utf8'));
+  const leaves: string[] = [];
+  const walk = (node: unknown, path: string) => {
+    if (node && typeof node === 'object' && !Array.isArray(node)) {
+      for (const [k, v] of Object.entries(node)) walk(v, path ? `${path}.${k}` : k);
+      return;
+    }
+    if (typeof node === 'string') leaves.push(path);
+  };
+  walk(catalogue, '');
+
+  return leaves.filter((key) => {
+    let code = '';
+    const t = createTranslator({
+      locale: 'en',
+      messages: catalogue,
+      onError: (err) => {
+        code = err.code;
+      },
+    });
+    t(key as never);
+    // INVALID_MESSAGE only — the parser could not read the string at all,
+    // so no call site can rescue it. Deliberately excludes FORMATTING_ERROR,
+    // which a well-formed message raises merely because this probe passes no
+    // values and no tag handlers; those are `t.rich()` / interpolation sites
+    // and are correct as written.
+    return code === 'INVALID_MESSAGE';
+  });
+}
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return tsxFiles(full);
+    return full.endsWith('.tsx') ? [full] : [];
+  });
+}
+
+describe('ICU-hostile strings are not read with plain t()', () => {
+  it('every {{…}} / raw-HTML message is consumed via t.raw() or t.rich()', () => {
+    const hostile = icuHostileKeys();
+    // Guard the guard: if this ever hits zero the walk or the parser probe
+    // has broken, and the test would pass vacuously.
+    expect(hostile.length).toBeGreaterThan(0);
+
+    const sources = tsxFiles(SRC).map((path) => ({
+      path,
+      text: readFileSync(path, 'utf8'),
+    }));
+
+    const offenders: string[] = [];
+
+    for (const key of hostile) {
+      const namespace = key.slice(0, key.lastIndexOf('.'));
+      const leaf = key.slice(key.lastIndexOf('.') + 1);
+
+      for (const { path, text } of sources) {
+        // Leaf names repeat across namespaces ('delete', 'desc', …), so only
+        // consider a file that actually opens this key's namespace. The call
+        // may use a trailing sub-path (useTranslations('Settings.templates')
+        // + t('config.foo')), so match on any namespace prefix.
+        const opensNamespace = [...text.matchAll(/useTranslations\(\s*['"]([^'"]+)['"]/g)].some(
+          (m) => namespace === m[1] || namespace.startsWith(`${m[1]}.`),
+        );
+        if (!opensNamespace) continue;
+
+        // A plain call: `t('leaf')` or `t("a.leaf")`, but not `.raw(` / `.rich(`.
+        const plainCall = new RegExp(
+          String.raw`(?<![.\w])t\(\s*['"](?:[\w.]+\.)?${leaf}['"]`,
+        );
+        if (plainCall.test(text)) {
+          offenders.push(`${key} — plain t() in ${path.replace(process.cwd() + '/', '')}`);
+        }
+      }
+    }
+
+    expect(
+      offenders.sort(),
+      'these render as their own keypath at runtime; use t.raw() (or t.rich() with tag handlers)',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Twelve UI strings have been rendering as their own keypath — the template body field literally showed `Settings.templates.bodyPlaceholder`, and the Meta setup checklist showed five keypaths where its instructions should be.

## What changed

Some catalogue strings are deliberately not ICU messages: template placeholders show the user WhatsApp's literal `{{1}}` syntax, and the setup steps carry raw `<strong class="…">` markup for `dangerouslySetInnerHTML`. next-intl's parser rejects both — and does it *quietly*. `t()` reports `INVALID_MESSAGE` to `onError` and falls back to rendering the keypath. Nothing throws, no build fails, and dev looks identical to prod:

```
Settings.templates.bodyPlaceholder
  onError -> INVALID_MESSAGE
  t()     = "Settings.templates.bodyPlaceholder"
  t.raw() = "Hello {{1}}, your order {{2}} is confirmed."
```

All twelve call sites move to `t.raw()`:

| file | n | keys |
|---|---|---|
| `template-manager.tsx` | 6 | `bodyPlaceholder`, `bodyHint`, `headerTextPlaceholder`, `headerSamplePlaceholder`, `urlPlaceholder`, `urlSamplePlaceholder` |
| `whatsapp-config.tsx` | 5 | `step3_2`, `step3_3`, `step3_4`, `step4_3`, `step4_4` |
| `automation-builder.tsx` | 1 | `config.placeholderValue` |

I audited all 25 strings in `en.json` containing `{{` or a tag. The other 13 (`authWarning`, `langHint`, `scopesHint`, `noPendingDesc`, …) already use `t.rich()` with tag handlers and are correct — no change.

`src/i18n/icu-safety.test.ts` keeps it that way: it walks `en.json`, collects every value next-intl reports `INVALID_MESSAGE` for, and fails if one is consumed by a plain `t()` in a component that opens its namespace. Filtering on `INVALID_MESSAGE` specifically — rather than any `onError` — is what keeps the well-formed `t.rich()` and interpolation sites out of the result.

## Test plan

- [x] `npm run lint` — 0 errors, 38 warnings (unchanged from `main`).
- [x] `npm run typecheck` clean.
- [x] `npm test` — 73 files, 713 passed.
- [x] `npm run build` succeeds.
- [x] New test **fails with 12 offenders** when the fixes are reverted, passes with them applied — verified both directions rather than assuming.
- [ ] Not exercised in a browser: both surfaces sit behind Supabase auth, and the assertion lives at the next-intl layer where the bug actually is.

## Related

Reported by @Arifuzzamanjoy in #421, which found 7 of the 12 alongside an unrelated Groq provider. That PR is closed for scope; this lands the correctness half in full.