### PR TITLE
fix(webhook): handle template quick-reply button taps (#478)

### DIFF
--- a/src/app/api/whatsapp/webhook/route.test.ts
+++ b/src/app/api/whatsapp/webhook/route.test.ts
@@ -11,6 +11,8 @@ const h = vi.hoisted(() => ({
     // returns the row; a replayed delivery conflicts and returns [].
     messageUpsertResult: [{ id: 'msg-1' }] as { id: string }[],
     priorCustomerMsgCount: 0,
+    /** Row `lookupInternalIdByMetaId` resolves for a `context.id`. */
+    replyContextParent: null as { id: string } | null,
     conversation: { id: 'conv-1', unread_count: 0, account_id: 'acc-1' },
     upsertCalls: [] as { row: Record<string, unknown>; options: unknown }[],
     rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
@@ -84,16 +86,33 @@ vi.mock('@supabase/supabase-js', () => ({
           }
         case 'messages':
           return {
-            // priorCustomerMsgCount: select('id',{count,head}).eq().eq()
-            select: () => ({
-              eq: () => ({
-                eq: () =>
-                  Promise.resolve({
-                    count: h.state.priorCustomerMsgCount,
-                    error: null,
-                  }),
-              }),
-            }),
+            // Two different chains land here, told apart by the count
+            // option: the prior-message count (head request) and the
+            // reply-context parent lookup.
+            select: (_columns: string, options?: { head?: boolean }) =>
+              options?.head
+                ? // priorCustomerMsgCount: select('id',{count,head}).eq().eq()
+                  {
+                    eq: () => ({
+                      eq: () =>
+                        Promise.resolve({
+                          count: h.state.priorCustomerMsgCount,
+                          error: null,
+                        }),
+                    }),
+                  }
+                : // lookupInternalIdByMetaId: select('id').eq().eq().maybeSingle()
+                  {
+                    eq: () => ({
+                      eq: () => ({
+                        maybeSingle: () =>
+                          Promise.resolve({
+                            data: h.state.replyContextParent,
+                            error: null,
+                          }),
+                      }),
+                    }),
+                  },
             // Idempotent insert: upsert(...).select('id')
             upsert: (row: Record<string, unknown>, options: unknown) => {
               h.state.upsertCalls.push({ row, options })
@@ -156,7 +175,15 @@ vi.mock('@/lib/webhooks/deliver', () => ({
 
 import { POST } from './route'
 
-function inboundRequest() {
+const TEXT_MESSAGE = {
+  id: 'wamid.TEST1',
+  from: '15551230000',
+  timestamp: '1700000000',
+  type: 'text',
+  text: { body: 'hello' },
+}
+
+function inboundRequest(message: Record<string, unknown> = TEXT_MESSAGE) {
   const body = {
     entry: [
       {
@@ -166,15 +193,7 @@ function inboundRequest() {
             value: {
               metadata: { phone_number_id: 'pn-1' },
               contacts: [{ wa_id: '15551230000', profile: { name: 'Ada' } }],
-              messages: [
-                {
-                  id: 'wamid.TEST1',
-                  from: '15551230000',
-                  timestamp: '1700000000',
-                  type: 'text',
-                  text: { body: 'hello' },
-                },
-              ],
+              messages: [message],
             },
           },
         ],
@@ -187,8 +206,8 @@ function inboundRequest() {
   } as unknown as Request
 }
 
-async function runWebhook() {
-  const res = await POST(inboundRequest())
+async function runWebhook(message?: Record<string, unknown>) {
+  const res = await POST(inboundRequest(message))
   // Drain the after() callback exactly as the runtime would.
   for (const cb of h.state.afterCallbacks) await cb()
   return res
@@ -198,6 +217,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   h.state.messageUpsertResult = [{ id: 'msg-1' }]
   h.state.priorCustomerMsgCount = 0
+  h.state.replyContextParent = null
   h.state.conversation = { id: 'conv-1', unread_count: 0, account_id: 'acc-1' }
   h.state.upsertCalls = []
   h.state.rpcCalls = []
@@ -259,6 +279,68 @@ describe('inbound webhook: atomic unread bump (#369)', () => {
     expect(h.state.rpcCalls[0]).toMatchObject({
       name: 'bump_conversation_on_inbound',
       args: { p_conversation_id: 'conv-1' },
+    })
+  })
+})
+
+describe('inbound webhook: template quick-reply buttons (#478)', () => {
+  // A customer tapping a QUICK_REPLY button on a broadcast template.
+  // `context.id` points at the template message we sent — which the
+  // broadcast path never wrote to `messages`, so the parent lookup
+  // legitimately misses and the reply is stored unquoted.
+  const templateButtonTap = {
+    id: 'wamid.BTN1',
+    from: '15551230000',
+    timestamp: '1700000000',
+    type: 'button',
+    button: { text: 'Yes, interested', payload: 'YES_INTERESTED' },
+    context: { id: 'wamid.BROADCAST1' },
+  }
+
+  it('stores the tap as an interactive reply, not an unsupported message', async () => {
+    await runWebhook(templateButtonTap)
+
+    expect(h.state.upsertCalls).toHaveLength(1)
+    expect(h.state.upsertCalls[0].row).toMatchObject({
+      content_type: 'interactive',
+      content_text: 'Yes, interested',
+      interactive_reply_id: 'YES_INTERESTED',
+      reply_to_message_id: null,
+    })
+  })
+
+  it('routes the tap to flows and fires the interactive_reply trigger', async () => {
+    await runWebhook(templateButtonTap)
+
+    expect(h.dispatchInboundToFlows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: {
+          kind: 'interactive_reply',
+          reply_id: 'YES_INTERESTED',
+          reply_title: 'Yes, interested',
+          meta_message_id: 'wamid.BTN1',
+        },
+      }),
+    )
+    const triggers = h.runAutomationsForTrigger.mock.calls.map(
+      (call) => (call[0] as { triggerType: string }).triggerType,
+    )
+    expect(triggers).toContain('interactive_reply')
+    // The AI auto-reply must stay out of it — a button tap is not a
+    // free-text question.
+    expect(h.dispatchInboundToAiReply).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the label when the template button carries no payload', async () => {
+    await runWebhook({
+      ...templateButtonTap,
+      button: { text: 'Track my order' },
+    })
+
+    expect(h.state.upsertCalls[0].row).toMatchObject({
+      content_type: 'interactive',
+      content_text: 'Track my order',
+      interactive_reply_id: 'Track my order',
     })
   })
 })

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -58,6 +58,15 @@ interface WhatsAppMessage {
     button_reply?: { id: string; title: string }
     list_reply?: { id: string; title: string; description?: string }
   }
+  /**
+   * Set when the customer taps a QUICK_REPLY button on a *template*
+   * message — a broadcast, or any template send. Meta uses a different
+   * envelope from `interactive` above: `type: 'button'`, the label in
+   * `button.text`, and the payload configured on the template's button
+   * in `button.payload` (Meta's own template editor doesn't ask for a
+   * payload and mirrors the label into it).
+   */
+  button?: { text?: string; payload?: string }
   /** Present when the customer swipe-replies to one of our messages. */
   context?: { id: string }
 }
@@ -653,8 +662,10 @@ async function processMessage(
   const contentType = ALLOWED_CONTENT_TYPES.has(message.type)
     ? message.type
     : message.type === 'sticker'
-      ? 'image'   // stickers are images
-      : 'text'    // reaction, unknown → text fallback
+      ? 'image'         // stickers are images
+      : message.type === 'button'
+        ? 'interactive' // template quick-reply tap (issue #478)
+        : 'text'        // reaction, unknown → text fallback
 
   // Determine whether this is the contact's very first inbound message
   // BEFORE we insert, so the count is accurate. Covers the case where
@@ -1006,6 +1017,28 @@ async function parseMessageContent(
         }
       }
       return { ...empty, contentText: '[Interactive reply]' }
+    }
+
+    case 'button': {
+      // Quick-reply tap on a TEMPLATE message. Meta delivers these under
+      // their own `button` envelope rather than `interactive` above, so
+      // without this case they fell through to `default` and landed in
+      // the inbox as "[Unsupported message type: button]" with a null
+      // interactiveReplyId — which also meant the Flows engine and the
+      // `interactive_reply` automation trigger never saw the tap, so
+      // nothing chained off a broadcast reply (issue #478).
+      //
+      // `payload` is the stable value (the analogue of
+      // `button_reply.id`); `text` is the visible label. Prefer the
+      // payload for routing and the label for display, each falling
+      // back to the other since a template may carry only one.
+      const payload = message.button?.payload || null
+      const label = message.button?.text || null
+      return {
+        ...empty,
+        contentText: label || payload,
+        interactiveReplyId: payload || label,
+      }
     }
 
     default:


### PR DESCRIPTION
## Summary

A customer tapping a QUICK_REPLY button on a template message — the reply path for every broadcast — landed in the inbox as `[Unsupported message type: button]`, and no automation could chain off it.

## What changed

- [`src/app/api/whatsapp/webhook/route.ts`](src/app/api/whatsapp/webhook/route.ts) — `parseMessageContent` gains a `case 'button'`. Meta delivers template button taps under their own envelope (`type: 'button'`, label in `button.text`, configured value in `button.payload`), not the `interactive.button_reply` shape used by session messages, so they fell through to `default`. That left `interactiveReplyId` null — which is exactly what `dispatchInboundToFlows` and the `interactive_reply` automation trigger route on.
- `payload` becomes the reply id (the analogue of `button_reply.id`), `text` the display text, each falling back to the other since a template may carry only one.
- `content_type` maps `button` → `interactive`, so the stored `interactive_reply_id` is meaningful. Migration 010 already widened the CHECK constraint for these taps.

The `[webhook] reply context parent not found` warning in the report is separate and cosmetic: the dashboard broadcast path never writes its outbound template sends to `messages`, so the quoted parent genuinely isn't there and the reply is stored unquoted.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 38 warnings, 0 errors (unchanged from `main`).
- [x] `npm run build` succeeds.
- [x] `npm test` — 747 passing.
- [x] Three new tests in [`route.test.ts`](src/app/api/whatsapp/webhook/route.test.ts) drive a real `type: 'button'` payload through `POST`. Verified they fail on `main` with the reported string (`content_text: "[Unsupported message type: button]"`) and pass here.
- [ ] Not exercised against live Meta traffic — needs a real WABA and a broadcast to a real number.

The test harness also gained a `messages` mock for the reply-context lookup, which nothing covered before.

## Related

Closes #478