### PR TITLE
fix(automations): make steps nested under a condition editable (#474)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -951,6 +951,7 @@
         "no": "No"
       },
       "addStep": "Add step",
+      "delete": "Delete",
       "config": {
         "messageText": "Message text",
         "placeholderMessageText": "Hi! Thanks for reaching out…",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -951,6 +951,7 @@
         "no": "아니요"
       },
       "addStep": "단계 추가",
+      "delete": "삭제",
       "config": {
         "messageText": "메시지 텍스트",
         "placeholderMessageText": "안녕하세요! 문의해주셔서 감사합니다…",

--- a/src/components/automations/automation-builder.tsx
+++ b/src/components/automations/automation-builder.tsx
@@ -62,6 +62,15 @@ import {
 } from "@/components/interactive/interactive-builder"
 import { interactivePayloadPreviewText } from "@/lib/whatsapp/interactive"
 import { createClient } from "@/lib/supabase/client"
+import {
+  childPath,
+  insertAt,
+  mapAtPath,
+  moveAt,
+  removeAt,
+  type ParentScope,
+  type StepPath,
+} from "@/lib/automations/builder-tree"
 import { cn } from "@/lib/utils"
 
 // ------------------------------------------------------------
@@ -761,7 +770,8 @@ export function AutomationBuilder({ initial }: { initial: BuilderInitial }) {
             />
             <StepList
               steps={state.steps}
-              parentPath={[]}
+              basePath={[]}
+              scope={{ kind: "root" }}
               expandedId={expandedId}
               setExpandedId={setExpandedId}
               updateStep={updateStep}
@@ -1025,18 +1035,16 @@ function InteractiveReplyConfig({
 // Step list + card + connectors
 // ------------------------------------------------------------
 
-type ParentScope =
-  | { kind: "root" }
-  | { kind: "branch"; parentCid: string; branch: "yes" | "no" }
-
-type StepPath = (
-  | { kind: "root"; index: number }
-  | { kind: "branch"; parentCid: string; branch: "yes" | "no"; index: number }
-)[]
-
 interface StepListProps {
   steps: BuilderStep[]
-  parentPath: StepPath
+  /**
+   * Path of the step that owns this list — `[]` for the root canvas,
+   * the condition's own path for a branch column. Combined with
+   * `scope` by `childPath` to address each child.
+   */
+  basePath: StepPath
+  /** Which bucket this list reads and writes. */
+  scope: ParentScope
   expandedId: string | null
   setExpandedId: (id: string | null) => void
   updateStep: (path: StepPath, updater: (s: BuilderStep) => BuilderStep) => void
@@ -1046,27 +1054,19 @@ interface StepListProps {
 }
 
 function StepList(props: StepListProps) {
-  const { steps, parentPath, ...rest } = props
-  const parentScope: ParentScope =
-    parentPath.length === 0
-      ? { kind: "root" }
-      : (() => {
-          const last = parentPath[parentPath.length - 1]
-          if (last.kind !== "branch") return { kind: "root" } as const
-          return { kind: "branch", parentCid: last.parentCid, branch: last.branch } as const
-        })()
+  const { steps, basePath, scope, ...rest } = props
 
   return (
-    <div className="flex flex-col items-center">
-      <AddButton onPick={(t) => props.addStepAt(parentScope, 0, t)} />
+    <div className="flex w-full flex-col items-center">
+      <AddButton onPick={(t) => props.addStepAt(scope, 0, t)} />
       {steps.map((step, idx) => (
         <StepRenderer
           key={step.cid}
           step={step}
           index={idx}
           total={steps.length}
-          parentScope={parentScope}
-          parentPath={parentPath}
+          basePath={basePath}
+          scope={scope}
           {...rest}
         />
       ))}
@@ -1078,37 +1078,44 @@ function StepRenderer({
   step,
   index,
   total,
-  parentScope,
-  parentPath,
+  scope,
+  basePath,
   ...props
 }: {
   step: BuilderStep
   index: number
   total: number
-  parentScope: ParentScope
-  parentPath: StepPath
-} & Omit<StepListProps, "steps" | "parentPath">) {
+  scope: ParentScope
+  basePath: StepPath
+} & Omit<StepListProps, "steps" | "basePath" | "scope">) {
   const t = useTranslations("Automations.builder")
-  const path: StepPath = [
-    ...parentPath,
-    parentScope.kind === "root"
-      ? { kind: "root", index }
-      : { kind: "branch", parentCid: parentScope.parentCid, branch: parentScope.branch, index },
-  ]
+  const path = childPath(basePath, scope, index)
   const meta = STEP_META[step.step_type]
   const Icon = meta.icon
   const expanded = props.expandedId === step.cid
   const isCondition = step.step_type === "condition"
+  const nested = basePath.length > 0
   // Card widths on mobile fill the full canvas column (max-w-2xl px-4
-  // still keeps them reasonable). On sm+ the original fixed widths
-  // come back so the flow visual stays recognisable.
-  const width = isCondition
-    ? "w-full max-w-[400px] sm:w-[400px]"
-    : "w-full max-w-[320px] sm:w-80"
+  // still keeps them reasonable). On sm+ fixed widths come back so the
+  // flow visual stays recognisable — but only at the top level: a
+  // branch column is a fraction of its condition's width, so a 320px
+  // card inside one overflowed its own column and dragged the editor's
+  // controls out of reach (issue #474). Nested cards fill the column
+  // they were given instead.
+  //
+  // A condition is wider than a plain step because it has to hold two
+  // branch columns side by side; 600px (the canvas is max-w-2xl, i.e.
+  // 640px of content) leaves each branch ~294px — near enough to the
+  // 320px a step gets at the top level for the same editors to fit.
+  const width = nested
+    ? "w-full"
+    : isCondition
+      ? "w-full max-w-[600px] sm:w-[600px]"
+      : "w-full max-w-[320px] sm:w-80"
 
   return (
     <>
-      <div className={cn("z-10 flex flex-col", width)}>
+      <div className={cn("z-10 flex min-w-0 flex-col", width)}>
         <div
           className={cn(
             "rounded-lg border border-border border-l-4 bg-card shadow-lg",
@@ -1168,7 +1175,7 @@ function StepRenderer({
                   onClick={() => props.deleteStepAt(path)}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
-                  {t("delete", { defaultValue: "Delete" })}
+                  {t("delete")}
                 </Button>
               </div>
             </div>
@@ -1176,7 +1183,7 @@ function StepRenderer({
         </div>
 
         {isCondition && (
-          <ConditionBranches step={step} parentPath={path} {...props} />
+          <ConditionBranches step={step} path={path} {...props} />
         )}
       </div>
 
@@ -1184,9 +1191,7 @@ function StepRenderer({
           ConditionBranches), so it has no linear "continue" path — adding
           the trailing connector here would produce a spurious third output. */}
       {!isCondition && (
-        <AddButton
-          onPick={(t) => props.addStepAt(parentScope, index + 1, t)}
-        />
+        <AddButton onPick={(t) => props.addStepAt(scope, index + 1, t)} />
       )}
     </>
   )
@@ -1194,37 +1199,40 @@ function StepRenderer({
 
 function ConditionBranches({
   step,
-  parentPath,
+  path,
   ...props
 }: {
   step: BuilderStep
-  parentPath: StepPath
-} & Omit<StepListProps, "steps" | "parentPath">) {
+  /** The condition's OWN path. Children hang off it, one marker each. */
+  path: StepPath
+} & Omit<StepListProps, "steps" | "basePath" | "scope">) {
   const t = useTranslations("Automations.builder")
   const yes = step.branches?.yes ?? []
   const no = step.branches?.no ?? []
-  // Build the child scope by appending a branch marker. The scope the
-  // StepList uses is driven by the LAST element of parentPath, so the
-  // tail's `index` doesn't matter — it's replaced per child during walks.
-  const yesPath: StepPath = [
-    ...parentPath,
-    { kind: "branch", parentCid: step.cid, branch: "yes", index: 0 },
-  ]
-  const noPath: StepPath = [
-    ...parentPath,
-    { kind: "branch", parentCid: step.cid, branch: "no", index: 0 },
-  ]
   return (
-    // Stack Yes/No vertically on mobile — two columns at 375px would
-    // cram each branch to ~170px which is too narrow for the nested
-    // cards. Two-column grid returns on sm+.
-    <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-      <BranchColumn label={t("branches.yes")} color="text-primary">
-        <StepList {...props} steps={yes} parentPath={yesPath} />
-      </BranchColumn>
-      <BranchColumn label={t("branches.no")} color="text-rose-400">
-        <StepList {...props} steps={no} parentPath={noPath} />
-      </BranchColumn>
+    // Stack Yes/No vertically until THIS CARD is wide enough for two
+    // columns. A viewport breakpoint can't tell: a condition nested in
+    // a branch is a fraction of the screen, and `sm:grid-cols-2` split
+    // it anyway, leaving two columns too narrow to render a step in.
+    <div className="@container mt-3 w-full">
+      <div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
+        <BranchColumn label={t("branches.yes")} color="text-primary">
+          <StepList
+            {...props}
+            steps={yes}
+            basePath={path}
+            scope={{ kind: "branch", parentCid: step.cid, branch: "yes" }}
+          />
+        </BranchColumn>
+        <BranchColumn label={t("branches.no")} color="text-rose-400">
+          <StepList
+            {...props}
+            steps={no}
+            basePath={path}
+            scope={{ kind: "branch", parentCid: step.cid, branch: "no" }}
+          />
+        </BranchColumn>
+      </div>
     </div>
   )
 }
@@ -1239,7 +1247,7 @@ function BranchColumn({
   children: React.ReactNode
 }) {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex min-w-0 flex-col items-center">
       <div className={cn("mb-2 text-[11px] font-semibold uppercase", color)}>{label}</div>
       {children}
     </div>
@@ -1538,173 +1546,6 @@ function previewFor(step: BuilderStep): string {
     default:
       return ""
   }
-}
-
-// ------------------------------------------------------------
-// Tree mutation helpers
-// ------------------------------------------------------------
-
-function insertAt(
-  steps: BuilderStep[],
-  parent: ParentScope,
-  index: number,
-  node: BuilderStep,
-): BuilderStep[] {
-  if (parent.kind === "root") {
-    const copy = [...steps]
-    copy.splice(index, 0, node)
-    return copy
-  }
-  return steps.map((s) => {
-    if (s.cid !== parent.parentCid || !s.branches) return s
-    const list = [...s.branches[parent.branch]]
-    list.splice(index, 0, node)
-    return { ...s, branches: { ...s.branches, [parent.branch]: list } }
-  })
-}
-
-function mapAtPath(
-  steps: BuilderStep[],
-  path: StepPath,
-  updater: (s: BuilderStep) => BuilderStep,
-): BuilderStep[] {
-  if (path.length === 0) return steps
-  const head = path[0]
-  const rest = path.slice(1)
-
-  if (head.kind === "root") {
-    return steps.map((s, i) => {
-      if (i !== head.index) return s
-      return rest.length === 0
-        ? updater(s)
-        : { ...s, branches: walkBranches(s.branches, rest, updater) }
-    })
-  }
-  return steps.map((s) => {
-    if (s.cid !== head.parentCid || !s.branches) return s
-    const bucket = s.branches[head.branch]
-    const updated = bucket.map((child, i) => {
-      if (i !== head.index) return child
-      return rest.length === 0
-        ? updater(child)
-        : { ...child, branches: walkBranches(child.branches, rest, updater) }
-    })
-    return { ...s, branches: { ...s.branches, [head.branch]: updated } }
-  })
-}
-
-function walkBranches(
-  branches: BuilderStep["branches"],
-  path: StepPath,
-  updater: (s: BuilderStep) => BuilderStep,
-): BuilderStep["branches"] {
-  if (!branches) return branches
-  const head = path[0]
-  if (head.kind !== "branch") return branches
-  const bucket = branches[head.branch]
-  const rest = path.slice(1)
-  const updated = bucket.map((child, i) => {
-    if (i !== head.index) return child
-    return rest.length === 0
-      ? updater(child)
-      : { ...child, branches: walkBranches(child.branches, rest, updater) }
-  })
-  return { ...branches, [head.branch]: updated }
-}
-
-function removeAt(steps: BuilderStep[], path: StepPath): BuilderStep[] {
-  if (path.length === 0) return steps
-  const head = path[0]
-  const rest = path.slice(1)
-  if (head.kind === "root") {
-    if (rest.length === 0) return steps.filter((_, i) => i !== head.index)
-    return steps.map((s, i) =>
-      i !== head.index ? s : { ...s, branches: removeFromBranches(s.branches, rest) },
-    )
-  }
-  return steps.map((s) => {
-    if (s.cid !== head.parentCid || !s.branches) return s
-    const bucket = s.branches[head.branch]
-    const next =
-      rest.length === 0
-        ? bucket.filter((_, i) => i !== head.index)
-        : bucket.map((child, i) =>
-            i !== head.index
-              ? child
-              : { ...child, branches: removeFromBranches(child.branches, rest) },
-          )
-    return { ...s, branches: { ...s.branches, [head.branch]: next } }
-  })
-}
-
-function removeFromBranches(
-  branches: BuilderStep["branches"],
-  path: StepPath,
-): BuilderStep["branches"] {
-  if (!branches) return branches
-  const head = path[0]
-  if (head.kind !== "branch") return branches
-  const rest = path.slice(1)
-  const bucket = branches[head.branch]
-  const next =
-    rest.length === 0
-      ? bucket.filter((_, i) => i !== head.index)
-      : bucket.map((child, i) =>
-          i !== head.index
-            ? child
-            : { ...child, branches: removeFromBranches(child.branches, rest) },
-        )
-  return { ...branches, [head.branch]: next }
-}
-
-function moveAt(
-  steps: BuilderStep[],
-  path: StepPath,
-  direction: -1 | 1,
-): BuilderStep[] {
-  if (path.length === 0) return steps
-  const head = path[0]
-  const rest = path.slice(1)
-  const swap = <T,>(arr: T[], i: number) => {
-    const j = i + direction
-    if (j < 0 || j >= arr.length) return arr
-    const copy = [...arr]
-    ;[copy[i], copy[j]] = [copy[j], copy[i]]
-    return copy
-  }
-  if (head.kind === "root") {
-    if (rest.length === 0) return swap(steps, head.index)
-    return steps.map((s, i) =>
-      i !== head.index ? s : { ...s, branches: moveInBranches(s.branches, rest, direction) },
-    )
-  }
-  return steps.map((s) => {
-    if (s.cid !== head.parentCid || !s.branches) return s
-    const bucket = s.branches[head.branch]
-    const next = rest.length === 0 ? swap(bucket, head.index) : bucket
-    return { ...s, branches: { ...s.branches, [head.branch]: next } }
-  })
-}
-
-function moveInBranches(
-  branches: BuilderStep["branches"],
-  path: StepPath,
-  direction: -1 | 1,
-): BuilderStep["branches"] {
-  if (!branches) return branches
-  const head = path[0]
-  if (head.kind !== "branch") return branches
-  const rest = path.slice(1)
-  const bucket = branches[head.branch]
-  const swap = <T,>(arr: T[], i: number) => {
-    const j = i + direction
-    if (j < 0 || j >= arr.length) return arr
-    const copy = [...arr]
-    ;[copy[i], copy[j]] = [copy[j], copy[i]]
-    return copy
-  }
-  const next = rest.length === 0 ? swap(bucket, head.index) : bucket
-  return { ...branches, [head.branch]: next }
 }
 
 // ------------------------------------------------------------

--- a/src/components/interactive/interactive-builder.tsx
+++ b/src/components/interactive/interactive-builder.tsx
@@ -88,88 +88,97 @@ export function InteractiveBuilder({
   };
 
   return (
-    <div className="flex flex-col gap-4 md:flex-row">
-      <div className="flex min-w-0 flex-1 flex-col gap-3">
-        {/* Kind toggle */}
-        <div className="flex gap-2">
-          <KindButton
-            active={value.kind === "buttons"}
-            label="Reply buttons"
-            onClick={() => switchKind("buttons")}
-          />
-          <KindButton
-            active={value.kind === "list"}
-            label="List"
-            onClick={() => switchKind("list")}
-          />
-        </div>
+    // Editor and preview sit side by side only when the SPACE WE WERE
+    // GIVEN can hold both — a container query, not a viewport one. This
+    // builder is embedded in places far narrower than the screen (an
+    // automation step card, and a step nested in a condition branch is
+    // narrower still); keying the split to `md:` meant a desktop
+    // viewport forced a 280px preview column into a ~190px card and the
+    // whole editor overflowed (issue #474).
+    <div className="@container">
+      <div className="flex flex-col gap-4 @2xl:flex-row">
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
+          {/* Kind toggle */}
+          <div className="flex gap-2">
+            <KindButton
+              active={value.kind === "buttons"}
+              label="Reply buttons"
+              onClick={() => switchKind("buttons")}
+            />
+            <KindButton
+              active={value.kind === "list"}
+              label="List"
+              onClick={() => switchKind("list")}
+            />
+          </div>
 
-        <Field label="Body" counter={`${value.body.length}/${INTERACTIVE_LIMITS.bodyMaxLength}`}>
-          <Textarea
-            value={value.body}
-            maxLength={INTERACTIVE_LIMITS.bodyMaxLength}
-            onChange={(e) => setField({ body: e.target.value })}
-            placeholder="What the customer reads above the options"
-            className="min-h-20 bg-muted text-foreground"
-          />
-        </Field>
-
-        <div className="grid grid-cols-2 gap-2">
-          <Field
-            label="Header (optional)"
-            counter={`${(value.header ?? "").length}/${INTERACTIVE_LIMITS.headerTextMaxLength}`}
-          >
-            <Input
-              value={value.header ?? ""}
-              maxLength={INTERACTIVE_LIMITS.headerTextMaxLength}
-              onChange={(e) => setField({ header: e.target.value })}
-              className="bg-muted text-foreground"
+          <Field label="Body" counter={`${value.body.length}/${INTERACTIVE_LIMITS.bodyMaxLength}`}>
+            <Textarea
+              value={value.body}
+              maxLength={INTERACTIVE_LIMITS.bodyMaxLength}
+              onChange={(e) => setField({ body: e.target.value })}
+              placeholder="What the customer reads above the options"
+              className="min-h-20 bg-muted text-foreground"
             />
           </Field>
-          <Field
-            label="Footer (optional)"
-            counter={`${(value.footer ?? "").length}/${INTERACTIVE_LIMITS.footerMaxLength}`}
-          >
-            <Input
-              value={value.footer ?? ""}
-              maxLength={INTERACTIVE_LIMITS.footerMaxLength}
-              onChange={(e) => setField({ footer: e.target.value })}
-              className="bg-muted text-foreground"
+
+          <div className="grid grid-cols-2 gap-2">
+            <Field
+              label="Header (optional)"
+              counter={`${(value.header ?? "").length}/${INTERACTIVE_LIMITS.headerTextMaxLength}`}
+            >
+              <Input
+                value={value.header ?? ""}
+                maxLength={INTERACTIVE_LIMITS.headerTextMaxLength}
+                onChange={(e) => setField({ header: e.target.value })}
+                className="bg-muted text-foreground"
+              />
+            </Field>
+            <Field
+              label="Footer (optional)"
+              counter={`${(value.footer ?? "").length}/${INTERACTIVE_LIMITS.footerMaxLength}`}
+            >
+              <Input
+                value={value.footer ?? ""}
+                maxLength={INTERACTIVE_LIMITS.footerMaxLength}
+                onChange={(e) => setField({ footer: e.target.value })}
+                className="bg-muted text-foreground"
+              />
+            </Field>
+          </div>
+
+          {value.kind === "buttons" ? (
+            <ButtonsEditor value={value} onChange={onChange} advanced={advanced} />
+          ) : (
+            <ListEditor value={value} onChange={onChange} advanced={advanced} />
+          )}
+
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={advanced}
+              onChange={(e) => setAdvanced(e.target.checked)}
+              className="h-3.5 w-3.5 accent-primary"
             />
-          </Field>
+            Show reply IDs (advanced)
+          </label>
+
+          {!validation.ok && (
+            <p className="text-xs text-red-400">{validation.error}</p>
+          )}
         </div>
 
-        {value.kind === "buttons" ? (
-          <ButtonsEditor value={value} onChange={onChange} advanced={advanced} />
-        ) : (
-          <ListEditor value={value} onChange={onChange} advanced={advanced} />
-        )}
-
-        <label className="flex items-center gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={advanced}
-            onChange={(e) => setAdvanced(e.target.checked)}
-            className="h-3.5 w-3.5 accent-primary"
-          />
-          Show reply IDs (advanced)
-        </label>
-
-        {!validation.ok && (
-          <p className="text-xs text-red-400">{validation.error}</p>
+        {showPreview && (
+          <div className="flex shrink-0 flex-col gap-1.5 @2xl:w-[280px]">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Preview
+            </span>
+            <div className="rounded-lg bg-muted/40 p-3">
+              <InteractivePreview payload={value} />
+            </div>
+          </div>
         )}
       </div>
-
-      {showPreview && (
-        <div className="flex shrink-0 flex-col gap-1.5 md:w-[280px]">
-          <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-            Preview
-          </span>
-          <div className="rounded-lg bg-muted/40 p-3">
-            <InteractivePreview payload={value} />
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/lib/automations/builder-tree.test.ts
+++ b/src/lib/automations/builder-tree.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  childPath,
+  insertAt,
+  mapAtPath,
+  moveAt,
+  removeAt,
+  type ParentScope,
+  type StepPath,
+} from "./builder-tree"
+
+// Minimal stand-in for BuilderStep: a cid, some config to mutate, and
+// the optional branches a condition carries.
+interface Step {
+  cid: string
+  text?: string
+  branches?: { yes: Step[]; no: Step[] }
+}
+
+const step = (cid: string, text = ""): Step => ({ cid, text })
+const condition = (cid: string, yes: Step[] = [], no: Step[] = []): Step => ({
+  cid,
+  branches: { yes, no },
+})
+
+/** Path the builder renders for a root-level step. */
+const rootPath = (index: number): StepPath => childPath([], { kind: "root" }, index)
+
+/** Path the builder renders for a step inside `cid`'s branch. */
+const branchPath = (
+  conditionPath: StepPath,
+  cid: string,
+  branch: "yes" | "no",
+  index: number,
+): StepPath => childPath(conditionPath, { kind: "branch", parentCid: cid, branch }, index)
+
+const setText = (text: string) => (s: Step): Step => ({ ...s, text })
+
+describe("childPath", () => {
+  it("addresses a root step by its index", () => {
+    expect(rootPath(2)).toEqual([{ kind: "root", index: 2 }])
+  })
+
+  it("appends exactly one marker per level of nesting", () => {
+    const c1 = rootPath(0)
+    const inner = branchPath(c1, "c1", "yes", 1)
+    expect(inner).toEqual([
+      { kind: "root", index: 0 },
+      { kind: "branch", branch: "yes", index: 1 },
+    ])
+    // Two levels deep: still one marker each, never a duplicate.
+    expect(branchPath(inner, "c2", "no", 0)).toHaveLength(3)
+  })
+})
+
+describe("editing a step nested under a condition (#474)", () => {
+  // condition c1 → yes: [a, b], no: [n]
+  const tree = (): Step[] => [
+    condition("c1", [step("a"), step("b")], [step("n")]),
+    step("tail"),
+  ]
+  const c1 = rootPath(0)
+
+  it("updates the addressed step, not the first one in the bucket", () => {
+    const next = mapAtPath(tree(), branchPath(c1, "c1", "yes", 1), setText("typed"))
+
+    expect(next[0].branches!.yes.map((s) => s.text)).toEqual(["", "typed"])
+    // Nothing else moved or changed.
+    expect(next[0].branches!.no.map((s) => s.cid)).toEqual(["n"])
+    expect(next[1].cid).toBe("tail")
+  })
+
+  it("updates a step in the NO branch", () => {
+    const next = mapAtPath(tree(), branchPath(c1, "c1", "no", 0), setText("typed"))
+
+    expect(next[0].branches!.no[0].text).toBe("typed")
+    expect(next[0].branches!.yes.every((s) => s.text === "")).toBe(true)
+  })
+
+  it("keeps a nested step's own shape intact — no stray branches key", () => {
+    const next = mapAtPath(tree(), branchPath(c1, "c1", "yes", 0), setText("typed"))
+
+    expect(next[0].branches!.yes[0]).toEqual({ cid: "a", text: "typed" })
+  })
+
+  it("deletes the addressed nested step", () => {
+    const next = removeAt(tree(), branchPath(c1, "c1", "yes", 0))
+
+    expect(next[0].branches!.yes.map((s) => s.cid)).toEqual(["b"])
+  })
+
+  it("reorders within a branch", () => {
+    const next = moveAt(tree(), branchPath(c1, "c1", "yes", 1), -1)
+
+    expect(next[0].branches!.yes.map((s) => s.cid)).toEqual(["b", "a"])
+  })
+
+  it("leaves the tree alone when a move would run off the end", () => {
+    const next = moveAt(tree(), branchPath(c1, "c1", "yes", 1), 1)
+
+    expect(next[0].branches!.yes.map((s) => s.cid)).toEqual(["a", "b"])
+  })
+})
+
+describe("conditions nested inside conditions", () => {
+  // c1 → yes: [ c2 → yes: [deep] ]
+  const tree = (): Step[] => [condition("c1", [condition("c2", [step("deep")])])]
+  const c1 = rootPath(0)
+  const c2 = branchPath(c1, "c1", "yes", 0)
+
+  it("edits a step two levels down", () => {
+    const next = mapAtPath(tree(), branchPath(c2, "c2", "yes", 0), setText("typed"))
+
+    expect(next[0].branches!.yes[0].branches!.yes[0].text).toBe("typed")
+  })
+
+  it("reorders two levels down", () => {
+    const deep = (): Step[] => [
+      condition("c1", [condition("c2", [step("x"), step("y")])]),
+    ]
+    const next = moveAt(deep(), branchPath(c2, "c2", "yes", 1), -1)
+
+    expect(
+      next[0].branches!.yes[0].branches!.yes.map((s) => s.cid),
+    ).toEqual(["y", "x"])
+  })
+
+  it("adds into a nested condition's branch", () => {
+    const scope: ParentScope = { kind: "branch", parentCid: "c2", branch: "no" }
+    const next = insertAt(tree(), scope, 0, step("fresh"))
+
+    expect(next[0].branches!.yes[0].branches!.no.map((s) => s.cid)).toEqual([
+      "fresh",
+    ])
+    // The outer condition's own buckets are untouched.
+    expect(next[0].branches!.no).toEqual([])
+  })
+})
+
+describe("insertAt", () => {
+  it("splices into the root list at the given index", () => {
+    const next = insertAt([step("a"), step("b")], { kind: "root" }, 1, step("mid"))
+
+    expect(next.map((s) => s.cid)).toEqual(["a", "mid", "b"])
+  })
+
+  it("splices into a top-level condition's branch", () => {
+    const next = insertAt(
+      [condition("c1", [step("a")])],
+      { kind: "branch", parentCid: "c1", branch: "yes" },
+      1,
+      step("after"),
+    )
+
+    expect(next[0].branches!.yes.map((s) => s.cid)).toEqual(["a", "after"])
+  })
+
+  it("is a no-op when the scope's condition is gone", () => {
+    const before = [condition("c1", [step("a")])]
+    const next = insertAt(
+      before,
+      { kind: "branch", parentCid: "missing", branch: "yes" },
+      0,
+      step("fresh"),
+    )
+
+    expect(next).toEqual(before)
+  })
+})
+
+describe("unresolvable paths", () => {
+  const tree = (): Step[] => [condition("c1", [step("a")]), step("tail")]
+
+  it("an empty path changes nothing", () => {
+    expect(mapAtPath(tree(), [], setText("x"))).toEqual(tree())
+  })
+
+  it("descending into a step that has no branches changes nothing", () => {
+    // Marker chain says "root index 1, then its yes branch" — but
+    // `tail` is a plain step.
+    const path: StepPath = [
+      { kind: "root", index: 1 },
+      { kind: "branch", branch: "yes", index: 0 },
+    ]
+    expect(mapAtPath(tree(), path, setText("x"))).toEqual(tree())
+  })
+
+  it("a stale index changes nothing", () => {
+    expect(removeAt(tree(), rootPath(9))).toEqual(tree())
+  })
+})

--- a/src/lib/automations/builder-tree.ts
+++ b/src/lib/automations/builder-tree.ts
@@ -1,0 +1,182 @@
+// ------------------------------------------------------------
+// Automation builder step tree: addressing + immutable mutation.
+//
+// The builder edits a tree, not a list: root steps run in order, and a
+// `condition` step nests its children under `branches.yes` /
+// `branches.no`. Every mutation is addressed by a StepPath — one
+// element per level, each naming the bucket it descends into and the
+// index within that bucket.
+//
+// The addressing rule is: a step's path is its parent's path plus its
+// own marker. `childPath` is the only place that rule is written down;
+// build paths with it rather than by hand. Getting it wrong doesn't
+// throw — the walkers below simply find nothing and return the tree
+// unchanged, so the UI silently drops the edit. That is how issue #474
+// hid: every keystroke in a step nested under a condition was a no-op.
+//
+// Lives here rather than in the component so the rules are unit-
+// testable in the node test environment (there is no jsdom / DOM
+// testing setup in this repo).
+// ------------------------------------------------------------
+
+/**
+ * Structural minimum the walkers need. Generic in the concrete node
+ * type so callers keep their own richer step type end-to-end —
+ * `BuilderStep` in the builder satisfies `TreeStep<BuilderStep>`.
+ */
+export interface TreeStep<T> {
+  cid: string
+  branches?: { yes: T[]; no: T[] }
+}
+
+/** Which bucket new children go into, for insertion. */
+export type ParentScope =
+  | { kind: "root" }
+  | { kind: "branch"; parentCid: string; branch: "yes" | "no" }
+
+/**
+ * One level of addressing: which bucket, and the index within it. The
+ * first marker of a path is always `root`; every later one names the
+ * branch of the step the previous marker resolved to.
+ */
+export type StepMarker =
+  | { kind: "root"; index: number }
+  | { kind: "branch"; branch: "yes" | "no"; index: number }
+
+export type StepPath = StepMarker[]
+
+/**
+ * Path of the step at `index` within `scope`, where `basePath` is the
+ * path of the step that OWNS that scope (`[]` for the root list, the
+ * condition's own path for a branch).
+ *
+ * Callers used to append a branch marker when descending into a
+ * condition and then append a second one per child, on the assumption
+ * that the first one's index would be "replaced during the walk".
+ * Nothing replaced it: the walkers consumed both markers, so an edit
+ * addressed the first child of the branch and then looked for the real
+ * target inside *that* child's branches — which a `send_buttons` step
+ * doesn't have, so the update was dropped (issue #474).
+ */
+export function childPath(
+  basePath: StepPath,
+  scope: ParentScope,
+  index: number,
+): StepPath {
+  return [
+    ...basePath,
+    scope.kind === "root"
+      ? { kind: "root", index }
+      : { kind: "branch", branch: scope.branch, index },
+  ]
+}
+
+/**
+ * Insert `node` at `index` within `scope`. Searches the whole tree for
+ * the scope's owning condition, not just the root list — a condition
+ * nested inside another condition's branch is a normal thing to build,
+ * and only matching at the top level meant the Add button under it did
+ * nothing at all.
+ */
+export function insertAt<T extends TreeStep<T>>(
+  steps: T[],
+  scope: ParentScope,
+  index: number,
+  node: T,
+): T[] {
+  if (scope.kind === "root") {
+    const copy = [...steps]
+    copy.splice(index, 0, node)
+    return copy
+  }
+  return steps.map((step) => {
+    if (!step.branches) return step
+    if (step.cid === scope.parentCid) {
+      const bucket = [...step.branches[scope.branch]]
+      bucket.splice(index, 0, node)
+      return {
+        ...step,
+        branches: { ...step.branches, [scope.branch]: bucket },
+      }
+    }
+    // Not this condition — keep looking inside both of its branches.
+    return {
+      ...step,
+      branches: {
+        yes: insertAt(step.branches.yes, scope, index, node),
+        no: insertAt(step.branches.no, scope, index, node),
+      },
+    }
+  })
+}
+
+/** Replace the step at `path` with `updater`'s result. */
+export function mapAtPath<T extends TreeStep<T>>(
+  steps: T[],
+  path: StepPath,
+  updater: (step: T) => T,
+): T[] {
+  return atPath(steps, path, (bucket, index) =>
+    bucket.map((step, i) => (i === index ? updater(step) : step)),
+  )
+}
+
+/** Drop the step at `path`. */
+export function removeAt<T extends TreeStep<T>>(
+  steps: T[],
+  path: StepPath,
+): T[] {
+  return atPath(steps, path, (bucket, index) =>
+    bucket.filter((_, i) => i !== index),
+  )
+}
+
+/** Swap the step at `path` with its neighbour in `direction`. */
+export function moveAt<T extends TreeStep<T>>(
+  steps: T[],
+  path: StepPath,
+  direction: -1 | 1,
+): T[] {
+  return atPath(steps, path, (bucket, index) => {
+    const target = index + direction
+    if (target < 0 || target >= bucket.length) return bucket
+    const copy = [...bucket]
+    ;[copy[index], copy[target]] = [copy[target], copy[index]]
+    return copy
+  })
+}
+
+/**
+ * Walk to the bucket the last marker of `path` addresses and hand it,
+ * plus the target index, to `edit`. One traversal shared by every
+ * mutation above so they cannot drift apart on how a path resolves.
+ *
+ * A path that doesn't resolve (stale index, unknown branch, a marker
+ * pointing into a step with no branches) returns the tree untouched.
+ */
+function atPath<T extends TreeStep<T>>(
+  steps: T[],
+  path: StepPath,
+  edit: (bucket: T[], index: number) => T[],
+): T[] {
+  if (path.length === 0) return steps
+  const [head, ...rest] = path
+
+  // Last marker: `steps` is the bucket that holds the target.
+  if (rest.length === 0) return edit(steps, head.index)
+
+  // Otherwise descend through the step this marker names, into the
+  // branch the NEXT marker names.
+  const next = rest[0]
+  if (next.kind !== "branch") return steps
+  return steps.map((step, i) => {
+    if (i !== head.index || !step.branches) return step
+    return {
+      ...step,
+      branches: {
+        ...step.branches,
+        [next.branch]: atPath(step.branches[next.branch], rest, edit),
+      },
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Any step added under a condition's Yes/No branch rendered as a broken card you couldn't type into, whose Delete and reorder buttons did nothing. Root cause is step addressing, not the editor.

## What changed

**The functional bug.** Every mutation is addressed by a `StepPath`. `ConditionBranches` appended a branch marker to build the child list's path, then `StepRenderer` appended a second one per child — on the assumption, written in the comment there, that the first marker's index would be "replaced per child during walks". Nothing replaced it. The walkers consumed both: the first sent them into branch child 0, the second looked for the target inside *that* child's own `branches`, and a `send_buttons` step has none — so the walk fell off the tree and returned it unchanged. Every keystroke was silently dropped.

- New [`src/lib/automations/builder-tree.ts`](src/lib/automations/builder-tree.ts) owns the addressing rule in one function (`childPath`) plus the walkers, so it can be unit-tested — the vitest environment is `node`, with no jsdom, so component tests aren't an option.
- Extracting them surfaced two more holes in the same layer, both fixed and covered: `insertAt` only matched the scope's condition among *root* steps, so the Add button inside a condition nested in another condition's branch did nothing at all; and `moveInBranches` stopped recursing at depth 2, so reordering inside a nested condition was a no-op. That matches the reporter's follow-up ("none of the node works after being added to conditions node NO").
- The four walkers now share one traversal (`atPath`) so they can't drift on how a path resolves.

**The display bugs, same report.**

- `t("delete", { defaultValue: "Delete" })` — next-intl has no `defaultValue` option and the key was missing, so the button rendered the raw keypath and logged `MISSING_MESSAGE: Automations.builder.delete` on every open (the console error in the report). Key added to `en` + `ko`.
- A nested card kept the top-level fixed 320px width inside a branch column of ~190px, and `InteractiveBuilder` split editor/preview on a **viewport** breakpoint, forcing a 280px preview pane into that same column. Both now size to the space they're given: nested cards are fluid, and the branch grid and the interactive editor split on container queries. A condition card is 600px so its two branches get ~294px each — near enough to the 320px a top-level step gets for the same editors to fit.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 38 warnings, 0 errors (unchanged from `main`).
- [x] `npm run build` succeeds.
- [x] `npm test` — 747 passing, 17 of them new in [`builder-tree.test.ts`](src/lib/automations/builder-tree.test.ts): editing/deleting/reordering inside a branch, two levels of nesting, adding into a nested condition, and paths that shouldn't resolve.
- [x] Confirmed the container queries actually compile — the build emits `@container (min-width:24rem){.@sm\:grid-cols-2{…}}` and `@container (min-width:42rem){.@2xl\:flex-row{…}}`.
- [ ] **Not verified in a browser.** The builder is behind auth and I have no credentials for a live Supabase project, so the layout claims rest on the compiled CSS above rather than a screenshot. Worth a look at `/automations/new` → add a condition → add a Send buttons node under both branches, at desktop and at 375px, before merging.

## Related

Closes #474