### PR TITLE
fix(broadcasts): stop throttling a campaign's own fan-out (#472)

### DIFF
--- a/src/hooks/use-broadcast-sending.ts
+++ b/src/hooks/use-broadcast-sending.ts
@@ -3,6 +3,10 @@
 import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { useAuth } from '@/hooks/use-auth';
+import {
+  BATCH_SEND_ATTEMPTS,
+  batchRetryDelayMs,
+} from '@/lib/broadcast-retry';
 import { Contact, MessageTemplate } from '@/types';
 
 export type CustomFieldOperator = 'is' | 'is_not' | 'contains';
@@ -58,6 +62,11 @@ interface UseBroadcastSendingReturn {
  * Meta rate-limit buffer. 10 per batch + 1 s pause matches the spec
  * and keeps us comfortably under Meta's per-phone-number messaging
  * rate so a large broadcast never trips the upstream limiter.
+ *
+ * Note this shape when touching `RATE_LIMITS.broadcast`: a campaign is
+ * many calls to `/api/whatsapp/broadcast`, not one. A 1 000-recipient
+ * send is ~100 calls over several minutes, and a bucket sized for
+ * "one call per campaign" throttles most of it away (issue #472).
  */
 const SEND_BATCH_SIZE = 10;
 const SEND_BATCH_DELAY_MS = 1000;
@@ -474,20 +483,32 @@ export function useBroadcastSending(): UseBroadcastSendingReturn {
         if (apiRecipients.length === 0) continue;
 
         try {
-          const res = await fetch('/api/whatsapp/broadcast', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              recipients: apiRecipients,
-              template_name: payload.template.name,
-              template_language: payload.template.language ?? 'en_US',
-            }),
-          });
+          // Send the batch, waiting out a 429 rather than writing the
+          // whole batch off as failed. Only 429 is replayed — see
+          // batchRetryDelayMs for why nothing else can be.
+          let data: { error?: string; results?: BroadcastApiResult[] } = {};
+          for (let attempt = 1; ; attempt++) {
+            const res = await fetch('/api/whatsapp/broadcast', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                recipients: apiRecipients,
+                template_name: payload.template.name,
+                template_language: payload.template.language ?? 'en_US',
+              }),
+            });
 
-          const data = await res.json();
+            data = await res.json();
+            if (res.ok) break;
 
-          if (!res.ok) {
-            throw new Error(data.error || 'Broadcast API request failed');
+            const retryIn =
+              attempt < BATCH_SEND_ATTEMPTS
+                ? batchRetryDelayMs(res.status, res.headers.get('Retry-After'))
+                : null;
+            if (retryIn === null) {
+              throw new Error(data.error || 'Broadcast API request failed');
+            }
+            await sleep(retryIn);
           }
 
           const resultsByPhone = new Map<string, BroadcastApiResult>();

--- a/src/lib/broadcast-retry.test.ts
+++ b/src/lib/broadcast-retry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { BATCH_SEND_ATTEMPTS, batchRetryDelayMs } from "./broadcast-retry";
+
+describe("batchRetryDelayMs", () => {
+  it("waits out a 429 for the advertised Retry-After", () => {
+    expect(batchRetryDelayMs(429, "12")).toBe(12_000);
+  });
+
+  it("falls back to a fixed wait when Retry-After is missing or junk", () => {
+    expect(batchRetryDelayMs(429, null)).toBe(5_000);
+    expect(batchRetryDelayMs(429, "soon")).toBe(5_000);
+    expect(batchRetryDelayMs(429, "0")).toBe(5_000);
+    expect(batchRetryDelayMs(429, "-3")).toBe(5_000);
+  });
+
+  it("clamps an absurd Retry-After", () => {
+    expect(batchRetryDelayMs(429, "86400")).toBe(120_000);
+  });
+
+  it.each([400, 401, 403, 404, 422, 500, 502, 503, 504])(
+    "does not replay a %i — the batch may already have reached Meta",
+    (status) => {
+      expect(batchRetryDelayMs(status, "1")).toBeNull();
+    },
+  );
+
+  it("allows a few attempts, not an unbounded loop", () => {
+    expect(BATCH_SEND_ATTEMPTS).toBeGreaterThan(1);
+    expect(BATCH_SEND_ATTEMPTS).toBeLessThan(10);
+  });
+});

--- a/src/lib/broadcast-retry.ts
+++ b/src/lib/broadcast-retry.ts
@@ -1,0 +1,38 @@
+/**
+ * Retry policy for one batch of a broadcast fan-out.
+ *
+ * Deliberately narrow: a batch is retried ONLY on 429. That is the one
+ * status where the route is known to have rejected the request before
+ * calling Meta — `checkRateLimit` runs before any send — so replaying
+ * the batch cannot double-message a customer. A 500, a timeout, or a
+ * dropped connection may all have sent some or all of the batch
+ * already; those recipients are recorded as failed for the operator to
+ * review rather than silently messaged twice.
+ */
+
+/** Attempts per batch, including the first. */
+export const BATCH_SEND_ATTEMPTS = 4;
+
+/** Fallback wait when a 429 arrives without a usable Retry-After. */
+const DEFAULT_RETRY_MS = 5_000;
+
+/** Never sleep longer than this on one retry, whatever the header says. */
+const MAX_RETRY_MS = 120_000;
+
+/**
+ * How long to wait before replaying a batch, or null if it must not be
+ * replayed.
+ *
+ * @param status HTTP status of the failed attempt.
+ * @param retryAfter Raw `Retry-After` header, if the response had one.
+ */
+export function batchRetryDelayMs(
+  status: number,
+  retryAfter: string | null,
+): number | null {
+  if (status !== 429) return null;
+
+  const seconds = Number(retryAfter);
+  if (!Number.isFinite(seconds) || seconds <= 0) return DEFAULT_RETRY_MS;
+  return Math.min(seconds * 1_000, MAX_RETRY_MS);
+}

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -94,13 +94,22 @@ describe("rateLimitResponse", () => {
 });
 
 describe("RATE_LIMITS presets", () => {
-  it("send and broadcast budgets are independent", async () => {
+  it("send and broadcast are budgeted per minute", async () => {
     __resetRateLimitForTests();
     // Importing here so the presets stay close to their assertions.
     const { RATE_LIMITS } = await import("./rate-limit");
-    expect(RATE_LIMITS.send.limit).toBeGreaterThan(RATE_LIMITS.broadcast.limit);
     expect(RATE_LIMITS.send.windowMs).toBe(60_000);
     expect(RATE_LIMITS.broadcast.windowMs).toBe(60_000);
+  });
+
+  it("the broadcast budget carries a campaign's per-batch call pattern", async () => {
+    __resetRateLimitForTests();
+    const { RATE_LIMITS } = await import("./rate-limit");
+    // A campaign is NOT one call: the wizard posts a batch of 10
+    // recipients roughly every 1–2 s, so it needs ~45+ calls of headroom
+    // per minute. Sized below that, every batch past the cap comes back
+    // 429 and its recipients are written off as failed (issue #472).
+    expect(RATE_LIMITS.broadcast.limit).toBeGreaterThanOrEqual(45);
   });
 });
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -117,10 +117,16 @@ export const RATE_LIMITS = {
   /** Individual message send. 60/min per user = one per second
    *  sustained, comfortable for a live human typing. */
   send: { limit: 60, windowMs: 60_000 },
-  /** Broadcast dispatch. 5/min per user — even a 1 000-recipient
-   *  broadcast is one call; this caps the rate at which a single user
-   *  can launch campaigns, not the messages inside one. */
-  broadcast: { limit: 5, windowMs: 60_000 },
+  /** Broadcast dispatch. NOT one call per campaign: the wizard fans a
+   *  campaign out over `/api/whatsapp/broadcast` in batches of 10
+   *  recipients, roughly one call every 1–2 s, so a 1 000-recipient
+   *  send is ~100 calls over several minutes. This bucket was 5/min on
+   *  the assumption of one call per campaign, which meant everything
+   *  past the first ~50 recipients came back 429 and was recorded as a
+   *  failed recipient (issue #472). 60/min per user carries the wizard's
+   *  pacing with headroom while still bounding a script in a loop;
+   *  Meta's own per-number limits remain the real throughput ceiling. */
+  broadcast: { limit: 60, windowMs: 60_000 },
   /** Reaction add/swap/remove. More permissive than send — users
    *  fidget with reactions and a single "swap" is actually two calls
    *  (remove + add) under the hood. */


### PR DESCRIPTION
## Summary

A 1,000-recipient campaign stopped making progress a couple of hundred recipients in. The app was rate-limiting its own fan-out.

## What changed

`RATE_LIMITS.broadcast` was 5/min per user, and its comment stated the reasoning: *"even a 1 000-recipient broadcast is one call; this caps the rate at which a single user can launch campaigns, not the messages inside one."* That isn't how the dashboard sends. [`use-broadcast-sending.ts`](src/hooks/use-broadcast-sending.ts) fans a campaign out over `/api/whatsapp/broadcast` in batches of 10 recipients with a 1s pause — so a 1,000-recipient send is ~100 calls over several minutes. Five cleared the bucket per window; the rest came back 429, and the wizard recorded all ten of each rejected batch as failed recipients. Effective ceiling ~50 recipients/minute, everything else written off.

- [`src/lib/rate-limit.ts`](src/lib/rate-limit.ts) — bucket is 60/min, sized for the call pattern that actually exists. Documented at both ends (limiter and wizard) so it doesn't get re-tightened on the old assumption. Meta's per-number limits remain the real ceiling.
- New [`src/lib/broadcast-retry.ts`](src/lib/broadcast-retry.ts) — a 429 no longer fails ten recipients: the wizard waits out `Retry-After` and replays the batch, up to 4 attempts. **Only 429 is replayed.** `checkRateLimit` runs before the route touches Meta, so a rejected batch provably sent nothing; a 500 or a dropped connection may have sent part of the batch already, and those stay failed rather than risk messaging a customer twice.
- [`src/lib/rate-limit.test.ts`](src/lib/rate-limit.test.ts) — the preset assertion `send.limit > broadcast.limit` encoded the old one-call-per-campaign assumption, so it's replaced with one that asserts the budget can carry a campaign's call pattern.

## Not addressed here

Delivery still runs in the browser tab that started it, so closing that tab abandons the campaign with recipients left `pending` and the broadcast stuck in `sending` — the "no campaign status is updated" half of the report. That, and the reprocess-pending / reprocess-failed controls the issue asks for, need a resumable server-side sender (the public-API path already has the shape for it in [`broadcast-core.ts`](src/lib/whatsapp/broadcast-core.ts)). Worth its own issue.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — 38 warnings, 0 errors (unchanged from `main`).
- [x] `npm run build` succeeds.
- [x] `npm test` — 747 passing, 6 new for the retry policy including "never replays a non-429".
- [ ] Not exercised end-to-end: needs a live WABA and ~1,000 contacts. The arithmetic above is from the code, not a reproduction.

## Related

Part of #472