### PR TITLE
Fix blank inbox bubble for template messages sent via API

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -212,6 +212,8 @@
       "document": "Document",
       "locationShared": "Location shared",
       "template": "Template",
+      "templateNamed": "Sent template \"{name}\"",
+      "templateNoPreview": "Template sent",
       "buttonReply": "Button reply",
       "interactiveReply": "[Interactive reply]",
       "unsupported": "[Unsupported message type]",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -212,6 +212,8 @@
       "document": "문서",
       "locationShared": "위치 공유됨",
       "template": "템플릿",
+      "templateNamed": "\"{name}\" 템플릿을 보냈습니다",
+      "templateNoPreview": "템플릿을 보냈습니다",
       "buttonReply": "버튼 응답",
       "interactiveReply": "[인터랙티브 응답]",
       "unsupported": "[지원되지 않는 메시지 형식]",

--- a/src/components/inbox/message-bubble.tsx
+++ b/src/components/inbox/message-bubble.tsx
@@ -61,10 +61,13 @@ function MessageContent({
   message,
   t,
   onOpenMedia,
+  onPrimary,
 }: {
   message: Message;
   t: ReturnType<typeof useTranslations>;
   onOpenMedia?: (messageId: string) => void;
+  /** True inside an outbound bubble, which is filled with `bg-primary`. */
+  onPrimary?: boolean;
 }) {
   // Passed to the media bubbles as a no-arg callback; `undefined` when the
   // parent wired up no viewer, which is what makes them non-clickable.
@@ -130,15 +133,32 @@ function MessageContent({
     case "template":
       return (
         <div>
-          <span className="mb-1 inline-flex items-center gap-1 rounded bg-primary/20 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+          <span
+            className={cn(
+              "mb-1 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium",
+              // Outbound bubbles are `bg-primary`, so a primary-on-primary
+              // chip is invisible against them.
+              onPrimary
+                ? "bg-primary-foreground/20 text-primary-foreground"
+                : "bg-primary/20 text-primary",
+            )}
+          >
             <LayoutTemplate className="h-3 w-3" />
             {t("template")}
           </span>
-          {message.content_text && (
-            <p className="mt-1 whitespace-pre-wrap break-words text-sm">
-              {message.content_text}
-            </p>
-          )}
+          {/* A template whose body we couldn't resolve locally persists
+              no content_text. Naming it beats rendering an empty bubble. */}
+          <p
+            className={cn(
+              "mt-1 whitespace-pre-wrap break-words text-sm",
+              !message.content_text && "italic opacity-80",
+            )}
+          >
+            {message.content_text ||
+              (message.template_name
+                ? t("templateNamed", { name: message.template_name })
+                : t("templateNoPreview"))}
+          </p>
         </div>
       );
 
@@ -229,7 +249,12 @@ export function MessageBubble({
             onPrimary={isAgent}
           />
         )}
-        <MessageContent message={message} t={t} onOpenMedia={onOpenMedia} />
+        <MessageContent
+          message={message}
+          t={t}
+          onOpenMedia={onOpenMedia}
+          onPrimary={isAgent}
+        />
         <div
           className={cn(
             "mt-1 flex items-center gap-1",

--- a/src/components/inbox/message-thread.tsx
+++ b/src/components/inbox/message-thread.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { usePresence } from "@/hooks/use-presence";
 import { PresenceDot } from "@/components/presence/presence-dot";
 import { presenceLabel } from "@/lib/presence";
+import { renderTemplateBody } from "@/lib/whatsapp/template-render";
 import { cn } from "@/lib/utils";
 import type {
   Conversation,
@@ -58,13 +59,6 @@ interface ReplyDraft {
   id: string;
   authorLabel: string;
   preview: string;
-}
-
-function renderTemplateBody(body: string, params: string[]): string {
-  return body.replace(/\{\{(\d+)\}\}/g, (_, raw) => {
-    const idx = Number(raw) - 1;
-    return params[idx] ?? `{{${raw}}}`;
-  });
 }
 
 interface MessageThreadProps {

--- a/src/lib/automations/meta-send.ts
+++ b/src/lib/automations/meta-send.ts
@@ -4,6 +4,7 @@ import {
   engineSendInteractiveButtons,
   engineSendInteractiveList,
 } from '@/lib/flows/meta-send'
+import { renderTemplateBody } from '@/lib/whatsapp/template-render'
 import { decrypt } from '@/lib/whatsapp/encryption'
 import {
   sanitizePhoneForMeta,
@@ -188,11 +189,34 @@ async function sendViaMeta(input: SendInput): Promise<{ whatsapp_message_id: str
     await db.from('contacts').update({ phone: workingPhone }).eq('id', contact.id)
   }
 
+  // Template sends carry no body text of their own — Meta receives the
+  // template name plus params, and the body lives in the approved
+  // template. Substitute it from the local row so the inbox shows the
+  // message instead of an empty bubble. A template we can't resolve
+  // (never synced, or a language mismatch) leaves this null and the
+  // thread falls back to the template name.
+  let renderedTemplateBody: string | null = null
+  if (input.kind === 'template') {
+    const { data: templateRow } = await db
+      .from('message_templates')
+      .select('body_text')
+      .eq('account_id', input.accountId)
+      .eq('name', input.templateName)
+      .eq('language', input.language || 'en_US')
+      .maybeSingle()
+    if (templateRow?.body_text) {
+      renderedTemplateBody = renderTemplateBody(
+        templateRow.body_text,
+        input.params ?? [],
+      )
+    }
+  }
+
   // Persist the sent message so it appears in the inbox with a real
   // Meta message id. sender_type='bot' distinguishes automation sends
   // from manual agent sends.
   const content_type = input.kind === 'template' ? 'template' : 'text'
-  const content_text = input.kind === 'text' ? input.text : null
+  const content_text = input.kind === 'text' ? input.text : renderedTemplateBody
   const template_name = input.kind === 'template' ? input.templateName : null
 
   const { error: msgErr } = await db.from('messages').insert({
@@ -214,7 +238,9 @@ async function sendViaMeta(input: SendInput): Promise<{ whatsapp_message_id: str
     .from('conversations')
     .update({
       last_message_text:
-        input.kind === 'template' ? `[template:${input.templateName}]` : input.text,
+        input.kind === 'template'
+          ? (renderedTemplateBody ?? `[template:${input.templateName}]`)
+          : input.text,
       last_message_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     })

--- a/src/lib/whatsapp/send-message.test.ts
+++ b/src/lib/whatsapp/send-message.test.ts
@@ -7,6 +7,40 @@ import {
   type SendMessageParams,
 } from './send-message';
 
+// The persistence tests below drive the full send path, so the three
+// side-effecting collaborators are stubbed: Meta (network), the token
+// crypto (needs a real key), and the service-role client the flow-run
+// pause uses. The validation tests above never reach any of them.
+// Spread the real module so non-network exports (INTERACTIVE_LIMITS,
+// consumed by the payload validator) keep working; only the senders
+// are replaced.
+vi.mock('./meta-api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./meta-api')>()),
+  sendTextMessage: vi.fn(async () => ({ messageId: 'wamid.TEXT' })),
+  sendTemplateMessage: vi.fn(async () => ({ messageId: 'wamid.TEMPLATE' })),
+  sendMediaMessage: vi.fn(async () => ({ messageId: 'wamid.MEDIA' })),
+  sendInteractiveButtons: vi.fn(async () => ({ messageId: 'wamid.BUTTONS' })),
+  sendInteractiveList: vi.fn(async () => ({ messageId: 'wamid.LIST' })),
+}));
+
+vi.mock('./encryption', () => ({
+  decrypt: (v: string) => v,
+  encrypt: (v: string) => v,
+  isLegacyFormat: () => false,
+}));
+
+vi.mock('@/lib/flows/admin-client', () => ({
+  supabaseAdmin: () => {
+    const chain: Record<string, unknown> = {
+      update: () => chain,
+      eq: () => chain,
+      then: (resolve: (v: { error: null }) => unknown) =>
+        Promise.resolve({ error: null }).then(resolve),
+    };
+    return { from: () => chain };
+  },
+}));
+
 // A db that explodes if touched — these tests cover the param
 // validation that MUST short-circuit before any query runs.
 function noDb(): SupabaseClient {
@@ -146,6 +180,173 @@ describe('sendMessageToConversation — param validation (pre-DB)', () => {
       })
     ).rejects.toThrow('reached DB');
     expect(spy).toHaveBeenCalledWith('conversations');
+  });
+});
+
+// ------------------------------------------------------------
+// Chainable Supabase stub for the full send path, scripted per table.
+// Captures the `messages` insert and the `conversations` update so a
+// test can assert on what actually gets persisted.
+// ------------------------------------------------------------
+interface Captured {
+  message?: Record<string, unknown>;
+  conversationUpdate?: Record<string, unknown>;
+}
+
+const TEMPLATE_ROW = {
+  id: 'tpl-1',
+  user_id: 'usr-1',
+  name: 'order_update',
+  language: 'en',
+  body_text: 'Hi {{1}}, your order {{2}} ships on {{3}}.',
+};
+
+function makeSendDb(
+  templateRow: Record<string, unknown> | null,
+  captured: Captured
+): SupabaseClient {
+  let table = '';
+  let mode: 'select' | 'insert' | 'update' = 'select';
+
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    insert: (payload: Record<string, unknown>) => {
+      mode = 'insert';
+      if (table === 'messages') captured.message = payload;
+      return builder;
+    },
+    update: (payload: Record<string, unknown>) => {
+      mode = 'update';
+      if (table === 'conversations') captured.conversationUpdate = payload;
+      return builder;
+    },
+    eq: () => builder,
+    maybeSingle: () =>
+      Promise.resolve({
+        data: table === 'message_templates' ? templateRow : null,
+        error: null,
+      }),
+    single: () => {
+      if (table === 'conversations' && mode === 'select') {
+        return Promise.resolve({
+          data: {
+            id: 'cv-1',
+            account_id: 'acct-1',
+            contact: { id: 'ct-1', phone: '+14155550123' },
+          },
+          error: null,
+        });
+      }
+      if (table === 'whatsapp_config') {
+        return Promise.resolve({
+          data: { id: 'cfg-1', phone_number_id: 'pn-1', access_token: 'tok' },
+          error: null,
+        });
+      }
+      if (table === 'messages') {
+        return Promise.resolve({ data: { id: 'msg-1' }, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+    // Awaited chains that don't end in single/maybeSingle (the
+    // conversations update) resolve through here.
+    then: (resolve: (v: { data: null; error: null }) => unknown) =>
+      Promise.resolve({ data: null, error: null }).then(resolve),
+  };
+
+  return {
+    from: (t: string) => {
+      table = t;
+      mode = 'select';
+      return builder;
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe('sendMessageToConversation — template body persistence', () => {
+  const templateSend: SendMessageParams = {
+    conversationId: 'cv-1',
+    messageType: 'template',
+    templateName: 'order_update',
+    templateLanguage: 'en',
+    templateParams: ['Jane', 'A123', 'Friday'],
+  };
+
+  it('renders the template body when the caller sends no text', async () => {
+    // The regression: an API caller passes only `template`, so
+    // content_text used to persist as null and the Inbox rendered an
+    // empty bubble even though Meta delivered the message.
+    const captured: Captured = {};
+    const db = makeSendDb(TEMPLATE_ROW, captured);
+
+    const result = await sendMessageToConversation(db, 'acct-1', templateSend);
+
+    expect(result.whatsappMessageId).toBe('wamid.TEMPLATE');
+    expect(captured.message?.content_text).toBe(
+      'Hi Jane, your order A123 ships on Friday.'
+    );
+    expect(captured.message?.template_name).toBe('order_update');
+    expect(captured.conversationUpdate?.last_message_text).toBe(
+      'Hi Jane, your order A123 ships on Friday.'
+    );
+  });
+
+  it('reads body values from structured template_message_params', async () => {
+    const captured: Captured = {};
+    const db = makeSendDb(TEMPLATE_ROW, captured);
+
+    await sendMessageToConversation(db, 'acct-1', {
+      ...templateSend,
+      templateParams: undefined,
+      templateMessageParams: { body: ['Sam', 'B456', 'Monday'] },
+    });
+
+    expect(captured.message?.content_text).toBe(
+      'Hi Sam, your order B456 ships on Monday.'
+    );
+  });
+
+  it('keeps caller-supplied text — the dashboard pre-renders its own', async () => {
+    const captured: Captured = {};
+    const db = makeSendDb(TEMPLATE_ROW, captured);
+
+    await sendMessageToConversation(db, 'acct-1', {
+      ...templateSend,
+      contentText: 'Composer-rendered copy',
+    });
+
+    expect(captured.message?.content_text).toBe('Composer-rendered copy');
+    expect(captured.conversationUpdate?.last_message_text).toBe(
+      'Composer-rendered copy'
+    );
+  });
+
+  it('still sends when the template row is missing locally', async () => {
+    // Never synced, or a language mismatch. We can't render a body, so
+    // content_text stays null and the thread falls back to the template
+    // name — but the send itself must not fail.
+    const captured: Captured = {};
+    const db = makeSendDb(null, captured);
+
+    const result = await sendMessageToConversation(db, 'acct-1', templateSend);
+
+    expect(result.messageId).toBe('msg-1');
+    expect(captured.message?.content_text).toBeNull();
+    expect(captured.conversationUpdate?.last_message_text).toBe('[template]');
+  });
+
+  it('leaves a plain text send untouched', async () => {
+    const captured: Captured = {};
+    const db = makeSendDb(null, captured);
+
+    await sendMessageToConversation(db, 'acct-1', {
+      conversationId: 'cv-1',
+      messageType: 'text',
+      contentText: 'Hello there',
+    });
+
+    expect(captured.message?.content_text).toBe('Hello there');
+    expect(captured.message?.template_name).toBeNull();
   });
 });
 

--- a/src/lib/whatsapp/send-message.ts
+++ b/src/lib/whatsapp/send-message.ts
@@ -34,6 +34,10 @@ import {
   interactivePayloadPreviewText,
   type InteractiveMessagePayload,
 } from '@/lib/whatsapp/interactive';
+import {
+  renderTemplateBody,
+  resolveTemplateBodyParams,
+} from '@/lib/whatsapp/template-render';
 import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption';
 import { supabaseAdmin } from '@/lib/flows/admin-client';
 import {
@@ -448,13 +452,32 @@ export async function sendMessageToConversation(
   const interactiveBody =
     messageType === 'interactive' ? interactivePayload!.body : null;
 
+  // Template sends carry no body text of their own — Meta gets the
+  // template *name* plus params, and the body lives in the approved
+  // template. Substitute it here so the Inbox has something to show.
+  // The dashboard composer pre-renders and passes `contentText`, so it
+  // wins; an API caller that sends only `template` gets this instead of
+  // the blank bubble it used to produce. A template we can't resolve
+  // locally (never synced, or a language mismatch) still yields null —
+  // the thread falls back to the template name.
+  const renderedTemplateBody =
+    messageType === 'template' && templateRow?.body_text
+      ? renderTemplateBody(
+          templateRow.body_text,
+          resolveTemplateBodyParams(templateMessageParams, templateParams)
+        )
+      : null;
+
+  const persistedText =
+    interactiveBody ?? contentText ?? renderedTemplateBody ?? null;
+
   const { data: messageRecord, error: msgError } = await db
     .from('messages')
     .insert({
       conversation_id: conversationId,
       sender_type: 'agent',
       content_type: messageType,
-      content_text: interactiveBody ?? contentText ?? null,
+      content_text: persistedText,
       media_url: mediaUrl || null,
       template_name: templateName || null,
       interactive_payload:
@@ -478,7 +501,7 @@ export async function sendMessageToConversation(
   const lastMessageText =
     messageType === 'interactive'
       ? interactivePayloadPreviewText(interactivePayload!)
-      : contentText || `[${messageType}]`;
+      : contentText || renderedTemplateBody || `[${messageType}]`;
 
   await db
     .from('conversations')

--- a/src/lib/whatsapp/template-render.test.ts
+++ b/src/lib/whatsapp/template-render.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  renderTemplateBody,
+  resolveTemplateBodyParams,
+} from './template-render';
+
+describe('renderTemplateBody', () => {
+  it('substitutes positional {{N}} placeholders', () => {
+    expect(
+      renderTemplateBody('Hi {{1}}, your order {{2}} shipped.', [
+        'Jane',
+        'A123',
+      ])
+    ).toBe('Hi Jane, your order A123 shipped.');
+  });
+
+  it('leaves a placeholder intact when no value was supplied', () => {
+    // Blanking it would silently drop text and read as a truncated
+    // message; leaving it makes the missing value obvious.
+    expect(renderTemplateBody('Date: {{3}} Time: {{7}}', ['a', 'b', 'c'])).toBe(
+      'Date: c Time: {{7}}'
+    );
+  });
+
+  it('reuses a value when the same placeholder repeats', () => {
+    expect(renderTemplateBody('{{1}} and {{1}} again', ['x'])).toBe(
+      'x and x again'
+    );
+  });
+
+  it('returns a body with no placeholders unchanged', () => {
+    expect(renderTemplateBody('No variables here.', [])).toBe(
+      'No variables here.'
+    );
+  });
+});
+
+describe('resolveTemplateBodyParams', () => {
+  it('prefers structured messageParams.body', () => {
+    expect(resolveTemplateBodyParams({ body: ['a', 'b'] }, ['legacy'])).toEqual(
+      ['a', 'b']
+    );
+  });
+
+  it('falls back to the legacy positional array', () => {
+    expect(resolveTemplateBodyParams(undefined, ['legacy'])).toEqual([
+      'legacy',
+    ]);
+    expect(resolveTemplateBodyParams({ headerText: 'h' }, ['legacy'])).toEqual([
+      'legacy',
+    ]);
+  });
+
+  it('returns an empty array when neither shape carries values', () => {
+    expect(resolveTemplateBodyParams(null, undefined)).toEqual([]);
+    expect(resolveTemplateBodyParams('not-an-object', undefined)).toEqual([]);
+  });
+});

--- a/src/lib/whatsapp/template-render.ts
+++ b/src/lib/whatsapp/template-render.ts
@@ -1,0 +1,47 @@
+// ============================================================
+// Render a template's stored body into the plain text we persist on
+// `messages.content_text` (and preview on `conversations.last_message_text`).
+//
+// Meta only ever receives the template *name* plus its parameters — the
+// body text lives in the approved template, not in the send payload. So
+// unless we substitute the params ourselves at send time, the Inbox has
+// nothing to show and the thread renders an empty bubble.
+//
+// Shared by every outbound template path: the send core behind both
+// `/api/whatsapp/send` and `/api/v1/messages`, the automation engine,
+// and the dashboard composer (which pre-renders client-side so the
+// optimistic bubble reads correctly before the insert round-trips).
+// ============================================================
+
+import type { SendTimeParams } from '@/lib/whatsapp/template-send-builder';
+
+/**
+ * Substitute `{{1}}`, `{{2}}`, … in a template body with positional
+ * `params`. A placeholder with no corresponding value is left intact
+ * rather than blanked, so a partially-filled body still reads as a
+ * template with a missing value instead of silently losing text.
+ */
+export function renderTemplateBody(body: string, params: string[]): string {
+  return body.replace(/\{\{(\d+)\}\}/g, (_, raw) => {
+    const idx = Number(raw) - 1;
+    return params[idx] ?? `{{${raw}}}`;
+  });
+}
+
+/**
+ * Pick the body values out of the two shapes callers may supply:
+ * structured `messageParams.body` (the current send-builder path) or a
+ * bare positional array (the legacy path). Mirrors how
+ * `sendTemplateMessage` resolves the same pair, so what we persist can't
+ * drift from what Meta was actually sent.
+ */
+export function resolveTemplateBodyParams(
+  messageParams: unknown,
+  legacyParams?: string[]
+): string[] {
+  const structured =
+    messageParams && typeof messageParams === 'object'
+      ? (messageParams as SendTimeParams).body
+      : undefined;
+  return structured ?? legacyParams ?? [];
+}


### PR DESCRIPTION

## Summary

Template messages persisted `content_text = null` unless the caller happened to
pass pre-rendered text, so they rendered in the Inbox as a completely empty
bubble. This renders the body server-side in the shared send core, so every
caller — public API, dashboard, automations — stores readable text.

## What changed

- **`src/lib/whatsapp/template-render.ts`** (new) — `renderTemplateBody()` does the
  `{{N}}` substitution, leaving unmatched placeholders intact rather than blanking
  them. `resolveTemplateBodyParams()` picks body values out of either shape a
  caller may use (structured `messageParams.body` or the legacy positional array),
  mirroring how `sendTemplateMessage` resolves the same pair so the persisted copy
  can't drift from what Meta was actually sent.
- **`src/lib/whatsapp/send-message.ts`** — when the message is a template and the
  caller supplied no `contentText`, derive it from the `message_templates` row the
  function already loads for the send-builder. Caller-supplied text still wins, so
  the dashboard path is unchanged. Same value feeds `last_message_text`, replacing
  the `[template]` placeholder in the conversation list.
- **`src/lib/automations/meta-send.ts`** — had the same defect unconditionally
  (`content_text = input.kind === 'text' ? input.text : null`), so *every*
  automation template send was blank. Now loads the template row and renders it.
- **`src/components/inbox/message-bubble.tsx`** — a template with no resolvable body
  now falls back to naming the template instead of rendering nothing. Also fixes
  the "Template" chip, which was `bg-primary/20 text-primary` inside an outbound
  bubble that is `bg-primary text-primary-foreground` — primary-on-primary, so it
  was invisible and the bubble appeared entirely empty. It now follows the same
  `onPrimary` pattern `ReplyQuote` already uses.
- **`src/components/inbox/message-thread.tsx`** — drops its local copy of the
  substitution helper in favour of the shared one; behaviour unchanged.
- **`messages/en.json`, `messages/ko.json`** — two keys for the fallback label.

Tests: 12 new cases — 7 for the helper (substitution, unmatched placeholder,
repeated placeholder, both param shapes) and 5 driving the send core against a
stubbed client, asserting the persisted row. Those cover the regression itself,
that caller-supplied text still wins, that a missing template row doesn't fail
the send, and that plain text sends are untouched.

## Screenshots
Before
<img width="2008" height="1126" alt="wacrm-bug-before-redacted" src="https://github.com/user-attachments/assets/69c1926f-9814-43ab-a09d-ac005220e989" />

After
<img width="2333" height="1333" alt="wacrm-bug-after-redacted" src="https://github.com/user-attachments/assets/6e297687-f0d0-4d66-9a38-703b86cc38bd" />



Same template, sent through `POST /api/v1/messages` with no `text` field.

| Before | After |
| --- | --- |
| _drag the empty-bubble image here_ | _drag the rendered-body image here_ |

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — no new errors (0 errors; the 38 pre-existing warnings are
      unchanged).
- [x] `npm run build` succeeds.
- [x] `npm test` — 725 passing, including the 12 new cases.
- [x] Feature / fix manually exercised in the browser — verified on a live
      deployment: a template sent via `POST /api/v1/messages` with no `text`
      field now renders the substituted body in the Inbox, and the
      conversation-list preview shows it instead of `[template]`. See the
      screenshots above.

The bug was also confirmed against a real occurrence before the fix: a row with
`content_type='template'`, `template_name` set, `content_text=NULL` and
`status='read'` — Meta had delivered it — which rendered as the empty bubble on
the left. After deploying, an identical request (same template, same shape, no
`text`) persisted the fully substituted body; that message is the one on the
right. The pre-existing NULL row is untouched, since the change only affects what
is written at send time — it now falls back to naming the template rather than
rendering nothing.

## Note on formatting

I did not run `npm run format`, deliberately. It's `prettier --write .`, and five
of the files this PR touches were already non-conforming on `main`, so running it
would have buried the change under whole-file reformatting. The two files added
here are Prettier-clean; everything else is left exactly as it was. Happy to
follow up with a separate formatting-only PR if that's wanted.

## Related

```
Closes #483
```