### PR TITLE
fix(flows): let a button tap start a keyword flow (#490)

### DIFF
--- a/src/lib/flows/dispatch.test.ts
+++ b/src/lib/flows/dispatch.test.ts
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ============================================================
+// Entry-trigger dispatch (issue #490).
+//
+// Drives the real `dispatchInboundToFlows` against a fake Supabase so
+// the assertion is "a run was actually started", not "a helper returned
+// true". The bug was that a button tap never reached the keyword
+// matcher at all, so a helper-level test would have missed it.
+// ============================================================
+
+const h = vi.hoisted(() => ({
+  state: {
+    /** Rows loadActiveRunForContact sees. Empty = no run in progress. */
+    activeRuns: [] as unknown[],
+    flows: [] as unknown[],
+    nodes: [] as unknown[],
+    inserted: [] as { table: string; row: Record<string, unknown> }[],
+    /** Set by the flow_runs INSERT; what its .maybeSingle() returns. */
+    insertedRun: null as Record<string, unknown> | null,
+    rpcCalls: [] as string[],
+  },
+}));
+
+vi.mock("./admin-client", () => {
+  function rows(table: string): unknown[] {
+    if (table === "flow_runs") return h.state.activeRuns;
+    if (table === "flows") return h.state.flows;
+    if (table === "flow_nodes") return h.state.nodes;
+    return [];
+  }
+
+  function builder(table: string) {
+    const b: Record<string, unknown> = {
+      select: () => b,
+      eq: () => b,
+      in: () => b,
+      filter: () => b,
+      order: () => b,
+      limit: () => b,
+      update: () => b,
+      insert: (row: Record<string, unknown>) => {
+        h.state.inserted.push({ table, row });
+        if (table === "flow_runs") {
+          h.state.insertedRun = {
+            id: "run-1",
+            vars: {},
+            reprompt_count: 0,
+            ...row,
+          };
+        }
+        return b;
+      },
+      // Only reached on the INSERT ... SELECT for a new run, and on
+      // loadFlow's flows lookup.
+      maybeSingle: async () => ({
+        data:
+          table === "flow_runs" ? h.state.insertedRun : (rows(table)[0] ?? null),
+        error: null,
+      }),
+      single: async () => ({ data: rows(table)[0] ?? null, error: null }),
+      then: (
+        resolve: (r: {
+          data: unknown[];
+          error: null;
+          count: number;
+        }) => unknown,
+      ) => resolve({ data: rows(table), error: null, count: 0 }),
+    };
+    return b;
+  }
+
+  return {
+    supabaseAdmin: () => ({
+      from: (t: string) => builder(t),
+      rpc: (name: string) => {
+        h.state.rpcCalls.push(name);
+        return Promise.resolve({ error: null });
+      },
+    }),
+  };
+});
+
+const engineSendText = vi.fn(async () => ({ whatsapp_message_id: "wamid.1" }));
+
+vi.mock("./meta-send", () => ({
+  engineSendText: (...a: unknown[]) =>
+    (engineSendText as unknown as (...x: unknown[]) => unknown)(...a),
+  engineSendMedia: vi.fn(async () => ({ whatsapp_message_id: "wamid.2" })),
+  engineSendInteractiveButtons: vi.fn(async () => ({
+    whatsapp_message_id: "wamid.3",
+  })),
+  engineSendInteractiveList: vi.fn(async () => ({
+    whatsapp_message_id: "wamid.4",
+  })),
+}));
+
+import { dispatchInboundToFlows, entryTriggerTexts } from "./engine";
+import type { ParsedInbound } from "./types";
+
+const KEYWORD_FLOW = {
+  id: "flow-1",
+  account_id: "acct-1",
+  user_id: "u-1",
+  status: "active",
+  trigger_type: "keyword",
+  trigger_config: { keywords: ["order status"] },
+  entry_node_id: "start",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const NODES = [
+  {
+    id: "n1",
+    flow_id: "flow-1",
+    node_key: "start",
+    node_type: "start",
+    config: { next_node_key: "greet" },
+  },
+  {
+    id: "n2",
+    flow_id: "flow-1",
+    node_key: "greet",
+    node_type: "send_message",
+    config: { text: "Looking that up…", next_node_key: "done" },
+  },
+  {
+    id: "n3",
+    flow_id: "flow-1",
+    node_key: "done",
+    node_type: "end",
+    config: {},
+  },
+];
+
+function dispatch(message: ParsedInbound) {
+  return dispatchInboundToFlows({
+    accountId: "acct-1",
+    userId: "u-1",
+    contactId: "ct-1",
+    conversationId: "cv-1",
+    message,
+    isFirstInboundMessage: false,
+  });
+}
+
+/** flow_runs INSERTs made during a dispatch. */
+function startedRuns() {
+  return h.state.inserted.filter((i) => i.table === "flow_runs");
+}
+
+beforeEach(() => {
+  // No run in progress — the whole point is the entry-trigger path.
+  h.state.activeRuns = [];
+  h.state.flows = [];
+  h.state.nodes = NODES;
+  h.state.inserted = [];
+  h.state.insertedRun = null;
+  h.state.rpcCalls = [];
+  engineSendText.mockClear();
+});
+
+describe("entryTriggerTexts", () => {
+  it("offers the typed text for a text message", () => {
+    expect(
+      entryTriggerTexts({
+        kind: "text",
+        text: "order status",
+        meta_message_id: "m1",
+      }),
+    ).toEqual(["order status"]);
+  });
+
+  it("offers both the button title and its reply id", () => {
+    expect(
+      entryTriggerTexts({
+        kind: "interactive_reply",
+        reply_id: "btn_1",
+        reply_title: "Order status",
+        meta_message_id: "m1",
+      }),
+    ).toEqual(["Order status", "btn_1"]);
+  });
+
+  it("drops blanks and collapses a title identical to the id", () => {
+    expect(
+      entryTriggerTexts({
+        kind: "interactive_reply",
+        reply_id: "btn_1",
+        reply_title: "btn_1",
+        meta_message_id: "m1",
+      }),
+    ).toEqual(["btn_1"]);
+    expect(
+      entryTriggerTexts({
+        kind: "interactive_reply",
+        reply_id: "btn_1",
+        reply_title: "   ",
+        meta_message_id: "m1",
+      }),
+    ).toEqual(["btn_1"]);
+  });
+});
+
+describe("dispatchInboundToFlows — entry triggers (#490)", () => {
+  it("starts a keyword flow when the customer taps a matching button", async () => {
+    h.state.flows = [KEYWORD_FLOW];
+
+    const result = await dispatch({
+      kind: "interactive_reply",
+      reply_id: "btn_1",
+      reply_title: "Order status",
+      meta_message_id: "m1",
+    });
+
+    // Before the fix this returned {consumed: false, outcome: "no_match"}
+    // — the tap was rejected before the keyword matcher ever ran.
+    expect(result.consumed).toBe(true);
+    expect(result.flow_run_id).toBe("run-1");
+    expect(
+      h.state.inserted.filter((i) => i.table === "flow_runs"),
+    ).toHaveLength(1);
+    expect(h.state.rpcCalls).toContain("increment_flow_execution_count");
+    // The flow really ran, not just got created.
+    expect(engineSendText).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches on the reply id when the visible title does not", async () => {
+    h.state.flows = [
+      { ...KEYWORD_FLOW, trigger_config: { keywords: ["order_status"] } },
+    ];
+
+    const result = await dispatch({
+      kind: "interactive_reply",
+      reply_id: "order_status",
+      reply_title: "Where is my parcel?",
+      meta_message_id: "m1",
+    });
+
+    expect(result.consumed).toBe(true);
+    expect(result.flow_run_id).toBe("run-1");
+    expect(startedRuns()).toHaveLength(1);
+  });
+
+  it("still starts the same flow for the typed text (unchanged path)", async () => {
+    h.state.flows = [KEYWORD_FLOW];
+
+    const result = await dispatch({
+      kind: "text",
+      text: "order status please",
+      meta_message_id: "m1",
+    });
+
+    expect(result.consumed).toBe(true);
+    expect(result.flow_run_id).toBe("run-1");
+    expect(startedRuns()).toHaveLength(1);
+  });
+
+  it("leaves a non-matching tap for the automations dispatcher", async () => {
+    h.state.flows = [KEYWORD_FLOW];
+
+    const result = await dispatch({
+      kind: "interactive_reply",
+      reply_id: "btn_9",
+      reply_title: "Talk to a human",
+      meta_message_id: "m1",
+    });
+
+    // consumed:false is what lets the webhook fire the
+    // `interactive_reply` automation trigger instead.
+    expect(result.consumed).toBe(false);
+    expect(result.outcome).toBe("no_match");
+    expect(h.state.inserted.filter((i) => i.table === "flow_runs")).toEqual([]);
+  });
+
+  it("does not start a manual-trigger flow from a tap", async () => {
+    h.state.flows = [{ ...KEYWORD_FLOW, trigger_type: "manual" }];
+
+    const result = await dispatch({
+      kind: "interactive_reply",
+      reply_id: "btn_1",
+      reply_title: "Order status",
+      meta_message_id: "m1",
+    });
+
+    expect(result.consumed).toBe(false);
+  });
+
+  it("starts a first_inbound_message flow when the first inbound is a tap", async () => {
+    h.state.flows = [
+      {
+        ...KEYWORD_FLOW,
+        trigger_type: "first_inbound_message",
+        trigger_config: {},
+      },
+    ];
+
+    const result = await dispatchInboundToFlows({
+      accountId: "acct-1",
+      userId: "u-1",
+      contactId: "ct-1",
+      conversationId: "cv-1",
+      message: {
+        kind: "interactive_reply",
+        reply_id: "btn_1",
+        reply_title: "Yes, tell me more",
+        meta_message_id: "m1",
+      },
+      isFirstInboundMessage: true,
+    });
+
+    // A broadcast template's quick-reply button can genuinely be a
+    // contact's first-ever inbound; the automations side already
+    // treated it that way.
+    expect(result.consumed).toBe(true);
+    expect(result.flow_run_id).toBe("run-1");
+    expect(startedRuns()).toHaveLength(1);
+  });
+});

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -111,6 +111,28 @@ export function matchesKeywordTrigger(
   return false;
 }
 
+/**
+ * The strings an inbound message offers to a flow's *entry* trigger.
+ *
+ * Typed text offers itself. A button / list tap offers two: the visible
+ * title — what the customer would have typed had the button not been
+ * there — and the stable reply_id, because the automation engine's
+ * `interactive_reply` trigger routes on the id, so an author moving a
+ * menu into a flow reaches for the same value.
+ *
+ * Matching the id does mean a keyword that happens to be a substring of
+ * an id can fire (ids are author-controlled slugs, defaulting to
+ * `btn_1`). That is the same substring semantic keyword triggers
+ * already have for typed text, and the alternative — ignoring the id —
+ * silently breaks the author who keyed on it.
+ */
+export function entryTriggerTexts(message: ParsedInbound): string[] {
+  if (message.kind === "text") return [message.text];
+  return [...new Set([message.reply_title, message.reply_id])].filter(
+    (v): v is string => Boolean(v && v.trim()),
+  );
+}
+
 /** Nodes that advance to a next_node_key without waiting for input. */
 export function isAutoAdvancing(node_type: string): boolean {
   return (
@@ -316,9 +338,15 @@ async function findEntryFlow(
   message: ParsedInbound,
   isFirstInbound: boolean,
 ): Promise<FlowRow | null> {
-  // Only text messages can match an entry trigger. Interactive replies
-  // are responses to existing prompts; they never start a new flow.
-  if (message.kind !== "text") return null;
+  // A tap used to be rejected outright here, on the reasoning that
+  // interactive replies are responses to existing prompts. That holds
+  // only while a prompt is outstanding — and this function runs solely
+  // when the contact has NO active run, so there is nothing the tap
+  // could be answering. What it actually blocked was issue #490: an
+  // *automation* sends the buttons, the customer taps one, and the flow
+  // whose keyword matches that button never starts. Retyping the label
+  // by hand worked, which is the tell — same words, different envelope.
+  const candidates = entryTriggerTexts(message);
 
   // Pull all active flows for this account. Active set is bounded
   // (the builder discourages double-trigger overlap; partial index
@@ -334,13 +362,17 @@ async function findEntryFlow(
   const typed = flows as FlowRow[];
   for (const flow of typed) {
     if (flow.trigger_type === "keyword") {
-      if (matchesKeywordTrigger(
-        message.text,
-        flow.trigger_config as KeywordTriggerConfig,
-      )) {
+      const cfg = flow.trigger_config as KeywordTriggerConfig;
+      if (candidates.some((text) => matchesKeywordTrigger(text, cfg))) {
         return flow;
       }
     } else if (flow.trigger_type === "first_inbound_message" && isFirstInbound) {
+      // Also reachable by a tap now: a broadcast template with a
+      // quick-reply button can genuinely be what prompts a contact's
+      // first-ever inbound. The automations dispatcher has always
+      // treated a tap that way (the webhook pushes
+      // `first_inbound_message` regardless of envelope) — flows were
+      // the inconsistent half.
       return flow;
     }
     // 'manual' triggers do not auto-start from inbound messages.


### PR DESCRIPTION
Fixes #490.

## The bug

An automation sends reply buttons; the customer taps one; the flow whose keyword matches that button doesn't start. Retyping the same words by hand *does* start it. Same text, different envelope — which is the tell.

`findEntryFlow` rejected anything that wasn't typed text on its first line:

```ts
// Only text messages can match an entry trigger. Interactive replies
// are responses to existing prompts; they never start a new flow.
if (message.kind !== "text") return null;
```

The reasoning holds while a prompt is outstanding — but this function runs **only** when the contact has no active run, so there is nothing the tap could be answering. What the guard actually blocked was every tap on buttons the flow engine didn't send: automation menus, and template quick-replies from a broadcast.

## The fix

A tap now offers two strings to the keyword matcher:

- **the button's visible title** — what the customer would have typed had the button not been there, and the reporter's case;
- **the reply_id** — because the automations engine's `interactive_reply` trigger routes on the id, so an author moving a menu from an automation into a flow reaches for that same value.

Either one matching starts the flow. Ids are author-controlled slugs (defaulting to `btn_1`), so a keyword that is a substring of an id can fire — that's the same substring semantic keyword triggers already have for typed text, and ignoring the id would silently break anyone who keyed on it.

`first_inbound_message` triggers are reachable from a tap now too. A broadcast template's quick-reply button can genuinely be a contact's first-ever inbound, and the webhook has always pushed `first_inbound_message` to the automations dispatcher regardless of envelope — flows were the inconsistent half.

**Precedence is unchanged.** A flow that consumes the tap suppresses the `interactive_reply` automation trigger for that message, exactly as flows already win over automations for typed keywords. If you have both an automation on `interactive_reply` and a flow keyed to the same button, the flow now wins — worth knowing, though a menu wired both ways was already ambiguous.

## Verification

New `src/lib/flows/dispatch.test.ts` — 9 tests driving the real `dispatchInboundToFlows` against a fake Supabase, asserting a run row was inserted and the flow actually executed (`engineSendText` called), not just that a helper returned true. A helper-level test would have missed this bug entirely, since the tap never reached the matcher. Covers: tap starts a keyword flow, id-only match, typed text unchanged, non-matching tap left for automations (`consumed: false`), manual triggers still not auto-started, and first-inbound-by-tap.

Full suite: 756 passing, 0 lint errors, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)