### PR TITLE
fix(contacts): surface the real reason a CSV import row failed

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -455,7 +455,11 @@
       "resultTags": "{count} tag assigned",
       "resultTags_plural": "{count} tags assigned",
       "resultSkipped": "{count} skipped",
+      "resultInvalidPhone": "{count} invalid phone",
+      "resultInvalidPhone_plural": "{count} invalid phones",
       "resultFailed": "{count} failed",
+      "failedRowsHeading": "Failed rows",
+      "unknownReason": "Unknown error",
       "willBeCreated": "{name} (will be created on import)",
       "columns": {
         "phone": "Phone",
@@ -477,6 +481,8 @@
       "toastTagsSkipped": "Unknown tags skipped (create them in Settings first): {sample}{more}",
       "toastSkipped": "{count} duplicate skipped",
       "toastSkipped_plural": "{count} duplicates skipped",
+      "toastInvalidPhone": "{count} contact had no usable phone number",
+      "toastInvalidPhone_plural": "{count} contacts had no usable phone number",
       "toastFailed": "{count} contact failed to import",
       "toastFailed_plural": "{count} contacts failed to import",
       "toastError": "Import failed"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -455,7 +455,11 @@
       "resultTags": "태그 {count}개 지정됨",
       "resultTags_plural": "태그 {count}개 지정됨",
       "resultSkipped": "{count}개 건너뜀",
+      "resultInvalidPhone": "전화번호 오류 {count}개",
+      "resultInvalidPhone_plural": "전화번호 오류 {count}개",
       "resultFailed": "{count}개 실패",
+      "failedRowsHeading": "실패한 행",
+      "unknownReason": "알 수 없는 오류",
       "willBeCreated": "{name} (가져오기 시 생성됨)",
       "columns": {
         "phone": "전화번호",
@@ -477,6 +481,8 @@
       "toastTagsSkipped": "알 수 없는 태그를 건너뛰었습니다 (설정에서 먼저 만드세요): {sample}{more}",
       "toastSkipped": "중복 {count}건을 건너뛰었습니다",
       "toastSkipped_plural": "중복 {count}건을 건너뛰었습니다",
+      "toastInvalidPhone": "연락처 {count}개에 사용할 수 있는 전화번호가 없었습니다",
+      "toastInvalidPhone_plural": "연락처 {count}개에 사용할 수 있는 전화번호가 없었습니다",
       "toastFailed": "연락처 {count}개를 가져오지 못했습니다",
       "toastFailed_plural": "연락처 {count}개를 가져오지 못했습니다",
       "toastError": "가져오기 실패"

--- a/src/components/contacts/import-modal.tsx
+++ b/src/components/contacts/import-modal.tsx
@@ -142,7 +142,9 @@ export function ImportModal({
   const [result, setResult] = useState<{
     imported: number;
     skipped: number;
+    invalidPhone: number;
     failed: number;
+    failedDetails: { phone: string; name?: string; reason: string }[];
     tagsAssigned: number;
   } | null>(null);
 
@@ -221,9 +223,18 @@ export function ImportModal({
       let imported = 0;
       let skipped = 0;
       let failed = 0;
+      const failedDetails: { phone: string; name?: string; reason: string }[] =
+        [];
 
       // 1) De-dupe within the file by normalized phone (keep first).
-      const { unique, duplicates: inFileDupes } = dedupeByPhone(parsedRows);
+      //    Rows with no usable phone at all are counted separately —
+      //    they never duplicated anything, so lumping them into
+      //    `skipped` would misreport them as dupes (see dedupeByPhone).
+      const {
+        unique,
+        duplicates: inFileDupes,
+        invalid: invalidPhone,
+      } = dedupeByPhone(parsedRows);
       skipped += inFileDupes;
 
       // 2) Skip numbers already in this account. One read of the
@@ -309,6 +320,22 @@ export function ImportModal({
               skipped++;
             } else {
               failed++;
+              // Keep the actual DB error instead of discarding it —
+              // "N contacts failed" with no reason attached left no
+              // way to tell an RLS/constraint failure from a fluke,
+              // let alone which contact it was.
+              console.error(
+                '[contacts import] insert failed for',
+                row.phone,
+                singleErr
+              );
+              failedDetails.push({
+                phone: row.phone,
+                name: row.name ?? undefined,
+                reason:
+                  (singleErr as { message?: string } | null)?.message ||
+                  t('unknownReason'),
+              });
             }
           }
         } else {
@@ -341,7 +368,14 @@ export function ImportModal({
         toast.warning(t('toastTagsWarning'));
       }
 
-      setResult({ imported, skipped, failed, tagsAssigned });
+      setResult({
+        imported,
+        skipped,
+        invalidPhone,
+        failed,
+        failedDetails,
+        tagsAssigned,
+      });
       if (imported > 0) {
         toast.success(t('toastImported', { count: imported }));
         onImported();
@@ -357,6 +391,9 @@ export function ImportModal({
       }
       if (skipped > 0) {
         toast.info(t('toastSkipped', { count: skipped }));
+      }
+      if (invalidPhone > 0) {
+        toast.warning(t('toastInvalidPhone', { count: invalidPhone }));
       }
       if (failed > 0) {
         toast.error(t('toastFailed', { count: failed }));
@@ -586,6 +623,12 @@ export function ImportModal({
                     {t('resultSkipped', { count: result.skipped })}
                   </div>
                 )}
+                {result.invalidPhone > 0 && (
+                  <div className="flex items-center gap-1.5 text-sm text-amber-400">
+                    <AlertTriangle className="size-4 shrink-0" />
+                    {t('resultInvalidPhone', { count: result.invalidPhone })}
+                  </div>
+                )}
                 {result.failed > 0 && (
                   <div className="flex items-center gap-1.5 text-sm text-red-400">
                     <XCircle className="size-4 shrink-0" />
@@ -593,6 +636,27 @@ export function ImportModal({
                   </div>
                 )}
               </div>
+
+              {result.failedDetails.length > 0 && (
+                <div className="mt-3 space-y-1 border-t border-border/80 pt-3">
+                  <p className="text-[11px] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+                    {t('failedRowsHeading')}
+                  </p>
+                  <ul className="max-h-32 space-y-1 overflow-y-auto text-xs">
+                    {result.failedDetails.map((row, i) => (
+                      <li
+                        key={i}
+                        className="flex items-baseline gap-2 text-muted-foreground"
+                      >
+                        <span className="shrink-0 font-mono text-popover-foreground">
+                          {row.name ? `${row.name} (${row.phone})` : row.phone}
+                        </span>
+                        <span className="truncate">{row.reason}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/lib/contacts/dedupe.test.ts
+++ b/src/lib/contacts/dedupe.test.ts
@@ -56,13 +56,14 @@ describe("dedupeByPhone", () => {
     expect(duplicates).toBe(1);
   });
 
-  it("drops rows with no digits", () => {
-    const { unique, duplicates } = dedupeByPhone([
+  it("drops rows with no digits, counted as invalid rather than duplicate", () => {
+    const { unique, duplicates, invalid } = dedupeByPhone([
       { phone: "   " },
       { phone: "+1 555-3333" },
     ]);
     expect(unique).toHaveLength(1);
-    expect(duplicates).toBe(1);
+    expect(duplicates).toBe(0);
+    expect(invalid).toBe(1);
   });
 });
 

--- a/src/lib/contacts/dedupe.ts
+++ b/src/lib/contacts/dedupe.ts
@@ -76,21 +76,25 @@ export function isUniqueViolation(error: unknown): boolean {
 
 /**
  * De-duplicate parsed CSV rows by normalized phone, keeping the first
- * occurrence of each. Rows with an empty normalized phone are dropped
- * (they can't be a valid contact). Returns the unique rows plus the
- * count removed as in-file duplicates.
+ * occurrence of each. Rows with an empty normalized phone can't be a
+ * valid contact and are dropped too, but counted separately as
+ * `invalid` rather than folded into `duplicates` — they never
+ * duplicated anything, and the import result should say so instead of
+ * telling the user a contact with a real, unique number was skipped
+ * as a dupe.
  */
 export function dedupeByPhone<T extends { phone: string }>(
   rows: T[],
-): { unique: T[]; duplicates: number } {
+): { unique: T[]; duplicates: number; invalid: number } {
   const seen = new Set<string>();
   const unique: T[] = [];
   let duplicates = 0;
+  let invalid = 0;
 
   for (const row of rows) {
     const key = normalizeKey(row.phone);
     if (!key) {
-      duplicates++;
+      invalid++;
       continue;
     }
     if (seen.has(key)) {
@@ -101,5 +105,5 @@ export function dedupeByPhone<T extends { phone: string }>(
     unique.push(row);
   }
 
-  return { unique, duplicates };
+  return { unique, duplicates, invalid };
 }

--- a/src/lib/contacts/parse-contact-csv.test.ts
+++ b/src/lib/contacts/parse-contact-csv.test.ts
@@ -52,6 +52,22 @@ describe('parseContactCsv', () => {
     });
   });
 
+  it('keeps a row with an empty phone cell instead of dropping it silently', () => {
+    const csv = `phone,name
++15551234567,Alice
+,Bob`;
+
+    const { rows } = parseContactCsv(csv);
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toEqual({
+      phone: '',
+      name: 'Bob',
+      email: undefined,
+      company: undefined,
+      tagNames: [],
+    });
+  });
+
   it('returns empty tagNames when tags column is absent', () => {
     const csv = `phone,name
 +15551234567,Alice`;

--- a/src/lib/contacts/parse-contact-csv.ts
+++ b/src/lib/contacts/parse-contact-csv.ts
@@ -66,8 +66,13 @@ export function parseContactCsv(text: string): ParseContactCsvResult {
     if (!line) continue;
 
     const values = parseCsvLine(line);
-    const phone = values[phoneIdx]?.replace(/["']/g, '').trim();
-    if (!phone) continue;
+    // A row with no usable phone is pushed through rather than dropped
+    // here — dedupeByPhone (shared with the webhook/manual-form paths)
+    // already treats an empty normalized key as invalid, and counting
+    // it there means the import result can tell the user "N contacts
+    // had no phone" instead of the row just vanishing with the total
+    // row count silently short of what's actually in the file.
+    const phone = values[phoneIdx]?.replace(/["']/g, '').trim() ?? '';
 
     rows.push({
       phone,


### PR DESCRIPTION
## Summary

- The CSV contact import (`import-modal.tsx`) swallowed the actual Postgres/PostgREST error for any per-row insert failure that wasn't a unique violation — the user only ever saw "N contacts failed to import" with no phone, name, or underlying reason. The real error is now captured and shown per-row (name/phone + reason) in the import result panel.
- `dedupeByPhone` folded rows with an unparseable/empty phone into the same `duplicates` counter as real in-file collisions, so a contact that never duplicated anything was reported to the user as a dupe. Split into a separate `invalid` count/result line.
- `parseContactCsv` silently dropped rows with an empty phone cell before they were ever counted anywhere — the parsed row count came up short of the file with no indication why. They're now kept and land in the same `invalid` bucket.

Found while investigating a real report: a user imported a CSV where 2 valid-looking contacts were rejected with zero explanation, while an actual duplicate in the same file was accepted (that acceptance is a separate, known gap — bulk import dedupes on exact normalized-phone match only, not the trunk-prefix-tolerant fuzzy match the webhook/manual-form paths use elsewhere — not changed here to keep this fix scoped).

## Test plan

- [x] `npm run typecheck && npm run lint && npm test` (826/826 passing)
- [ ] Import a CSV with a row that fails validation server-side (e.g. RLS) and confirm the reason shows in the result panel
- [ ] Import a CSV with a blank-phone row and confirm it's reported as "invalid phone", not silently dropped or counted as a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DP3Ua7KpuW7g4yZ9Gm1eAE