### PR TITLE
fix: give the broadcast wizard's "Upload CSV" audience a file picker (#512)

### DIFF
--- a/src/components/broadcasts/step2-select-audience.tsx
+++ b/src/components/broadcasts/step2-select-audience.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { createClient } from '@/lib/supabase/client';
+import { parseBroadcastCsv } from '@/lib/broadcast-csv';
 import { CustomField, Tag } from '@/types';
 import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
 import {
   Users,
   Tags,
   Filter,
   Upload,
+  FileText,
   Loader2,
   ArrowRight,
   ArrowLeft,
@@ -91,6 +94,16 @@ export function Step2SelectAudience({
   const [loadingFields, setLoadingFields] = useState(false);
   const [estimatedCount, setEstimatedCount] = useState<number | null>(null);
   const [loadingCount, setLoadingCount] = useState(false);
+  // The picked file's name, shown back to the user. The parsed rows
+  // themselves live on `audience.csvContacts` (owned by the wizard) so
+  // they survive stepping forward and back.
+  const [pickedCsvName, setPickedCsvName] = useState<string | null>(null);
+  const csvInputRef = useRef<HTMLInputElement>(null);
+
+  const csvCount = audience.csvContacts?.length ?? 0;
+  // Only meaningful while the rows it produced are still in play —
+  // picking another audience type wipes `csvContacts`.
+  const csvFileName = csvCount > 0 ? pickedCsvName : null;
 
   // Tags are used both by the primary "Filter by Tags" audience type
   // AND by the exclude-list below — so always load once on mount.
@@ -212,6 +225,30 @@ export function Step2SelectAudience({
   useEffect(() => {
     fetchEstimatedCount();
   }, [fetchEstimatedCount]);
+
+  async function handleCsvChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = e.target.files?.[0];
+    if (!selected) return;
+
+    const result = parseBroadcastCsv(await selected.text());
+
+    if (!result.ok) {
+      toast.error(
+        result.error === 'missing_phone_column'
+          ? t('selectAudience.errorCsvMissingPhone')
+          : t('selectAudience.errorCsvParse'),
+      );
+      // Clear the input so re-picking the same corrected file still
+      // fires `change` (the browser suppresses it for an identical value).
+      e.target.value = '';
+      setPickedCsvName(null);
+      onUpdate({ ...audience, csvContacts: undefined });
+      return;
+    }
+
+    setPickedCsvName(selected.name);
+    onUpdate({ ...audience, csvContacts: result.contacts });
+  }
 
   function toggleTag(tagId: string) {
     const current = audience.tagIds ?? [];
@@ -388,6 +425,49 @@ export function Step2SelectAudience({
               />
             </div>
           )}
+        </div>
+      )}
+
+      {audience.type === 'csv' && (
+        <div className="space-y-3 rounded-xl border border-border bg-card/50 p-4">
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              {t('selectAudience.uploadCsv')}
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t('selectAudience.csvFormatDesc')}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => csvInputRef.current?.click()}
+            className="group flex w-full flex-col items-center gap-2 rounded-lg border border-dashed border-border bg-muted/40 px-4 py-6 text-center transition-colors hover:border-primary/40 hover:bg-muted/70"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground group-hover:text-foreground">
+              {csvFileName ? (
+                <FileText className="h-5 w-5" />
+              ) : (
+                <Upload className="h-5 w-5" />
+              )}
+            </div>
+            <p className="text-sm text-foreground">
+              {csvFileName ?? t('selectAudience.uploadCsv')}
+            </p>
+            {csvCount > 0 && (
+              <p className="text-xs text-primary">
+                {t('selectAudience.csvContactsFound', { count: csvCount })}
+              </p>
+            )}
+          </button>
+
+          <input
+            ref={csvInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleCsvChange}
+            className="hidden"
+          />
         </div>
       )}
 

--- a/src/hooks/use-broadcast-sending.ts
+++ b/src/hooks/use-broadcast-sending.ts
@@ -7,6 +7,7 @@ import {
   BATCH_SEND_ATTEMPTS,
   batchRetryDelayMs,
 } from '@/lib/broadcast-retry';
+import { normalizeKey } from '@/lib/contacts/dedupe';
 import { Contact, MessageTemplate } from '@/types';
 
 export type CustomFieldOperator = 'is' | 'is_not' | 'contains';
@@ -224,6 +225,9 @@ export function useBroadcastSending(): UseBroadcastSendingReturn {
    * Pre-existing implementation synthesized `csv-N` strings as
    * contact_id, which failed the UUID cast on insert — every CSV
    * broadcast silently created zero recipients.
+   *
+   * Matching is on the normalized number throughout, so it agrees with
+   * the account-wide unique index rather than colliding with it.
    */
   async function upsertCsvContacts(
     supabase: ReturnType<typeof createClient>,
@@ -242,37 +246,47 @@ export function useBroadcastSending(): UseBroadcastSendingReturn {
       throw new Error('Your profile is not linked to an account.');
     }
 
-    // De-duplicate by phone within the CSV (users can paste duplicates).
-    const uniqueByPhone = new Map<string, { phone: string; name?: string }>();
+    // De-duplicate within the CSV on the NORMALIZED number — the same
+    // key the DB's UNIQUE (account_id, phone_normalized) index uses
+    // (migration 022). Keyed on the raw string instead, "+1 555-0100"
+    // and "15550100" survived as two rows and the insert below died on
+    // a 23505, failing the whole broadcast.
+    const uniqueByKey = new Map<string, { phone: string; name?: string }>();
     for (const row of csvRows) {
-      if (row.phone) uniqueByPhone.set(row.phone, row);
+      const key = normalizeKey(row.phone);
+      if (key && !uniqueByKey.has(key)) uniqueByKey.set(key, row);
     }
-    const phones = [...uniqueByPhone.keys()];
+    const keys = [...uniqueByKey.keys()];
 
-    // Single round-trip lookup of existing contacts by phone.
+    // Single round-trip lookup of the contacts already in this ACCOUNT.
+    // Scoping to `user_id` missed rows a teammate created on a shared
+    // account, so those numbers looked new and their inserts collided
+    // with the account-wide unique index.
     const { data: existing, error: lookupErr } = await supabase
       .from('contacts')
       .select('*')
-      .eq('user_id', user.id)
-      .in('phone', phones);
+      .eq('account_id', accountId)
+      .in('phone_normalized', keys);
     if (lookupErr) {
       throw new Error(`Failed to look up CSV contacts: ${lookupErr.message}`);
     }
 
-    const byPhone = new Map<string, Contact>();
+    const byKey = new Map<string, Contact>();
     for (const c of (existing ?? []) as Contact[]) {
-      if (c.phone) byPhone.set(c.phone, c);
+      const key = normalizeKey(c.phone ?? '');
+      if (key) byKey.set(key, c);
     }
 
     // Insert only missing contacts, in one batch per 200 rows (PostgREST
     // has a default payload cap — 200 keeps individual requests small).
-    const missing = phones
-      .filter((p) => !byPhone.has(p))
-      .map((phone) => ({
+    const missing = keys
+      .filter((k) => !byKey.has(k))
+      .map((k) => uniqueByKey.get(k)!)
+      .map((row) => ({
         user_id: user.id,
         account_id: accountId,
-        phone,
-        name: uniqueByPhone.get(phone)?.name ?? null,
+        phone: row.phone,
+        name: row.name ?? null,
       }));
 
     const INSERT_CHUNK = 200;
@@ -286,13 +300,14 @@ export function useBroadcastSending(): UseBroadcastSendingReturn {
         throw new Error(`Failed to create CSV contacts: ${insertErr.message}`);
       }
       for (const c of (inserted ?? []) as Contact[]) {
-        if (c.phone) byPhone.set(c.phone, c);
+        const key = normalizeKey(c.phone ?? '');
+        if (key) byKey.set(key, c);
       }
     }
 
     // Preserve input order so analytics roughly matches the CSV order.
-    return phones
-      .map((p) => byPhone.get(p))
+    return keys
+      .map((k) => byKey.get(k))
       .filter((c): c is Contact => Boolean(c));
   }
 

--- a/src/lib/broadcast-csv.test.ts
+++ b/src/lib/broadcast-csv.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { parseBroadcastCsv } from './broadcast-csv';
+
+describe('parseBroadcastCsv', () => {
+  it('parses phone + name into the audience shape', () => {
+    const result = parseBroadcastCsv(
+      `phone,name
++15551230000,Ada
++15559990000,Grace`
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      duplicates: 0,
+      contacts: [
+        { phone: '+15551230000', name: 'Ada' },
+        { phone: '+15559990000', name: 'Grace' },
+      ],
+    });
+  });
+
+  it('omits name when the column is absent', () => {
+    const result = parseBroadcastCsv(`phone\n+15551230000`);
+    expect(result).toEqual({
+      ok: true,
+      duplicates: 0,
+      contacts: [{ phone: '+15551230000' }],
+    });
+  });
+
+  it('drops the extra columns the importer understands', () => {
+    const result = parseBroadcastCsv(
+      `phone,name,email,company,tags
++15551230000,Ada,ada@example.com,Analytical Engines,"VIP, Lead"`
+    );
+    expect(result).toEqual({
+      ok: true,
+      duplicates: 0,
+      contacts: [{ phone: '+15551230000', name: 'Ada' }],
+    });
+  });
+
+  it('tolerates any column order', () => {
+    const result = parseBroadcastCsv(`name,phone\nAda,+15551230000`);
+    expect(result).toEqual({
+      ok: true,
+      duplicates: 0,
+      contacts: [{ phone: '+15551230000', name: 'Ada' }],
+    });
+  });
+
+  // The downstream upsert inserts against UNIQUE (account_id,
+  // phone_normalized) (migration 022). If two spellings of one number
+  // both reached it, the whole broadcast would die on a 23505 — so
+  // collapsing them here is the fix, not a nicety.
+  it('collapses differently-formatted spellings of the same number', () => {
+    const result = parseBroadcastCsv(
+      `phone,name
++1 (555) 123-0000,Ada
+15551230000,Ada Again`
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      duplicates: 1,
+      contacts: [{ phone: '+1 (555) 123-0000', name: 'Ada' }],
+    });
+  });
+
+  it('reports a missing phone header distinctly from an empty file', () => {
+    expect(parseBroadcastCsv(`name,email\nAda,ada@example.com`)).toEqual({
+      ok: false,
+      error: 'missing_phone_column',
+    });
+    // No header at all reads the same way — there is no `phone` column.
+    expect(parseBroadcastCsv('')).toEqual({
+      ok: false,
+      error: 'missing_phone_column',
+    });
+  });
+
+  it('reports no_valid_rows when the header is good but no number is', () => {
+    expect(parseBroadcastCsv(`phone,name\n,Ada\n"",Grace`)).toEqual({
+      ok: false,
+      error: 'no_valid_rows',
+    });
+  });
+
+  it('handles CRLF line endings and a trailing newline', () => {
+    const result = parseBroadcastCsv(
+      'phone,name\r\n+15551230000,Ada\r\n+15559990000,Grace\r\n'
+    );
+    expect(result).toEqual({
+      ok: true,
+      duplicates: 0,
+      contacts: [
+        { phone: '+15551230000', name: 'Ada' },
+        { phone: '+15559990000', name: 'Grace' },
+      ],
+    });
+  });
+});

--- a/src/lib/broadcast-csv.ts
+++ b/src/lib/broadcast-csv.ts
@@ -1,0 +1,63 @@
+/**
+ * CSV → broadcast audience.
+ *
+ * The broadcast wizard's "Upload CSV" audience type needs a
+ * `{ phone, name }[]` list, which is a narrower shape than the
+ * contacts importer's. Rather than re-parse, this reuses the shared
+ * `parseContactCsv` + `dedupeByPhone` so a CSV that imports cleanly on
+ * the Contacts page also broadcasts cleanly (issue #512).
+ *
+ * De-duplication happens HERE, on the normalized number, because the
+ * downstream contact upsert inserts against a UNIQUE index on
+ * (account_id, phone_normalized) (migration 022). Two spellings of the
+ * same number in one file ("+1 555-0100" and "15550100") would
+ * otherwise reach that index as separate inserts and fail the whole
+ * broadcast with a constraint error.
+ *
+ * Pure and unit-tested: the wizard is a client component and
+ * `vitest.config.ts` runs `environment: "node"` with no jsdom, so the
+ * logic has to live outside the component to be testable.
+ */
+
+import { dedupeByPhone } from '@/lib/contacts/dedupe';
+import { parseContactCsv } from '@/lib/contacts/parse-contact-csv';
+
+/** The shape the wizard hands to `createAndSendBroadcast`. */
+export interface BroadcastCsvContact {
+  phone: string;
+  name?: string;
+}
+
+export type BroadcastCsvError =
+  /** No `phone` header — the one column we can't work without. */
+  | 'missing_phone_column'
+  /** Header was fine, but not one row carried a usable number. */
+  | 'no_valid_rows';
+
+export type ParseBroadcastCsvResult =
+  | {
+      ok: true;
+      contacts: BroadcastCsvContact[];
+      /** Rows dropped as same-number repeats (or as blank numbers). */
+      duplicates: number;
+    }
+  | { ok: false; error: BroadcastCsvError };
+
+export function parseBroadcastCsv(text: string): ParseBroadcastCsvResult {
+  const { rows, hasPhoneColumn } = parseContactCsv(text);
+
+  if (!hasPhoneColumn) return { ok: false, error: 'missing_phone_column' };
+
+  const { unique, duplicates } = dedupeByPhone(rows);
+  if (unique.length === 0) return { ok: false, error: 'no_valid_rows' };
+
+  return {
+    ok: true,
+    // Drop email/company/tags: the broadcast audience only addresses
+    // people, and `name` is the sole field template variables can map.
+    contacts: unique.map(({ phone, name }) =>
+      name ? { phone, name } : { phone }
+    ),
+    duplicates,
+  };
+}

--- a/src/lib/contacts/parse-contact-csv.test.ts
+++ b/src/lib/contacts/parse-contact-csv.test.ts
@@ -31,6 +31,7 @@ describe('parseContactCsv', () => {
 +15559876543,Bob,Customer`;
 
     expect(parseContactCsv(csv)).toEqual({
+      hasPhoneColumn: true,
       hasTagsColumn: true,
       hasCompanyColumn: false,
       rows: [
@@ -57,6 +58,7 @@ describe('parseContactCsv', () => {
 +15551234567,Alice`;
 
     expect(parseContactCsv(csv)).toEqual({
+      hasPhoneColumn: true,
       hasTagsColumn: false,
       hasCompanyColumn: false,
       rows: [

--- a/src/lib/contacts/parse-contact-csv.ts
+++ b/src/lib/contacts/parse-contact-csv.ts
@@ -33,6 +33,13 @@ export function parseTagCell(value: string | undefined): string[] {
 
 export interface ParseContactCsvResult {
   rows: ParsedContactRow[];
+  /**
+   * True when the CSV header includes the required `phone` column.
+   * `rows` is empty both when the column is missing and when the file
+   * simply has no usable data rows; callers that need to tell those
+   * apart (to pick the right error message) read this flag.
+   */
+  hasPhoneColumn: boolean;
   /** True when the CSV header includes a `tags` column. */
   hasTagsColumn: boolean;
   /** True when the CSV header includes a `company` column. */
@@ -42,7 +49,12 @@ export interface ParseContactCsvResult {
 export function parseContactCsv(text: string): ParseContactCsvResult {
   const lines = text.trim().split(/\r?\n/);
   if (lines.length < 2) {
-    return { rows: [], hasTagsColumn: false, hasCompanyColumn: false };
+    return {
+      rows: [],
+      hasPhoneColumn: false,
+      hasTagsColumn: false,
+      hasCompanyColumn: false,
+    };
   }
 
   const headers = lines[0]
@@ -51,7 +63,12 @@ export function parseContactCsv(text: string): ParseContactCsvResult {
 
   const phoneIdx = headers.indexOf('phone');
   if (phoneIdx === -1) {
-    return { rows: [], hasTagsColumn: false, hasCompanyColumn: false };
+    return {
+      rows: [],
+      hasPhoneColumn: false,
+      hasTagsColumn: false,
+      hasCompanyColumn: false,
+    };
   }
 
   const nameIdx = headers.indexOf('name');
@@ -90,6 +107,7 @@ export function parseContactCsv(text: string): ParseContactCsvResult {
 
   return {
     rows,
+    hasPhoneColumn: true,
     hasTagsColumn: tagsIdx >= 0,
     hasCompanyColumn: companyIdx >= 0,
   };


### PR DESCRIPTION
Fixes #512.

## The bug, confirmed

`step2-select-audience.tsx` renders a panel for `tags` and for
`custom_field`, and none for `csv`. Selecting **Upload CSV** therefore
showed nothing at all: no file input existed, `audience.csvContacts`
stayed `undefined`, `isValid` stayed `false`, and **Next** sat disabled
with no way forward — exactly as reported.

Everything around the picker was already there: the audience type, the
`upsertCsvContacts` path in `use-broadcast-sending.ts`, and all five
i18n strings in both `en.json` and `ko.json` (`uploadCsv`,
`csvFormatDesc`, `csvContactsFound`, `errorCsvParse`,
`errorCsvMissingPhone`). Only the UI was missing, so **no new
translation keys were needed**.

## What changed

**1. The panel** — a dropzone that opens a `.csv` picker, shows the
filename and the valid-row count, and re-picks on click. Errors surface
via `toast` using the two existing messages.

**2. `src/lib/broadcast-csv.ts` (new, unit-tested)** — reuses the
contacts importer's `parseContactCsv` + `dedupeByPhone`, so a file that
imports cleanly on the Contacts page also broadcasts cleanly. It de-dupes
on the **normalized** number, which matters: the DB has
`UNIQUE (account_id, phone_normalized)` (migration 022), so `+1 555-0100`
and `15550100` in the same file previously arrived as two separate
inserts and failed the entire broadcast with a `23505`.

**3. `upsertCsvContacts`** — looked up existing contacts with
`.eq('user_id', user.id).in('phone', phones)`. Two misses, one symptom:

- `user_id` scoping skipped contacts a teammate created on a shared
  account;
- exact-string `phone` matching skipped any stored number written in a
  different format.

Both made an existing contact look new, and the insert then collided
with the account-wide unique index → `Failed to create CSV contacts`.
Now scoped to `account_id` and matched on `phone_normalized`.

**4. `parseContactCsv`** gains a `hasPhoneColumn` flag so callers can
distinguish "no `phone` header" from "header fine, no usable rows" and
pick the right message. Additive; the importer behaves identically.

## Verification

All four CI steps pass locally on this branch: `lint` (0 errors, 37
warnings — same count as `origin/main`), `typecheck`, `test` (833
passing, 8 new), `build`.

**Not browser-verified.** Step 2 is behind Supabase auth and needs an
approved WhatsApp template to reach, so the panel was not exercised
against a live deployment. The parsing and de-dup logic is covered by
unit tests; the component itself cannot be, since `vitest.config.ts`
runs `environment: "node"` with no jsdom.

## Out of scope

The media-template comment on #512 ("asks for an image URL, no preview,
broadcast fails with unknown error") is a different code path
(`step3-personalize` + the header-media builder) and is not addressed
here. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)