### PR TITLE
fix: improve AI knowledge retrieval with Gemini embeddings

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -81,6 +81,22 @@ NEXT_PUBLIC_APP_LOCALE=en
 # See docs/automations-and-cron.md.
 # AUTOMATION_CRON_SECRET=generate-a-long-random-string
 
+# TEMPORARY ManyChat → WA CRM inbound mirror bridge
+# (POST /api/integrations/manychat/inbound). While a WhatsApp number is
+# still actively managed in ManyChat, this endpoint mirrors ManyChat's
+# inbound customer messages into the WA CRM Inbox (contact + conversation
+# + message only — it never sends to WhatsApp, and never runs AI reply,
+# Flows, or Automations). Remove both vars once ManyChat is retired.
+#
+# MANYCHAT_INGEST_SECRET: shared bearer secret ManyChat sends as
+# `Authorization: Bearer <secret>`. Generate any long random string:
+#   openssl rand -hex 32
+# MANYCHAT_INGEST_ACCOUNT_ID: the WA CRM `accounts.id` this bridge writes
+# into — resolved server-side against `whatsapp_config.account_id`.
+# ManyChat never sends account/user ids or Supabase keys.
+# MANYCHAT_INGEST_SECRET=
+# MANYCHAT_INGEST_ACCOUNT_ID=
+
 # Meta App ID (Meta for Developers → App Settings → Basic). Required to
 # create/edit message templates with an IMAGE header: Meta only accepts a
 # Resumable-Upload media handle (not a plain URL) as the header sample, and

--- a/.env.local.example
+++ b/.env.local.example
@@ -97,6 +97,27 @@ NEXT_PUBLIC_APP_LOCALE=en
 # MANYCHAT_INGEST_SECRET=
 # MANYCHAT_INGEST_ACCOUNT_ID=
 
+# TEMPORARY ManyChat outbound bridge (the other half of the coexistence
+# above). Lets an agent's reply from the WA CRM Inbox go out through
+# ManyChat's Public API instead of Meta, for a number ManyChat still
+# owns operationally. See src/lib/whatsapp/send-message.ts and
+# src/lib/manychat/api.ts. Remove both vars once ManyChat is retired.
+#
+# MANYCHAT_API_KEY: ManyChat's Public API bearer token (ManyChat →
+# Settings → API). Sent as `Authorization: Bearer <key>` to
+# api.manychat.com — server-side only, NEVER expose with NEXT_PUBLIC_,
+# and never logged.
+# MANYCHAT_API_KEY=
+#
+# WHATSAPP_OUTBOUND_TRANSPORT: which transport sendMessageToConversation()
+# uses for agent-composed sends. Supported values: `meta` | `manychat`.
+# Safe default when unset (or any other value): `meta` — the pre-existing
+# behavior. Setting `manychat` restricts outbound to text messages only,
+# and requires the target contact to already have a
+# `manychat_contact_links` row (written by the inbound bridge) — there is
+# no fallback to Meta.
+# WHATSAPP_OUTBOUND_TRANSPORT=meta
+
 # Meta App ID (Meta for Developers → App Settings → Basic). Required to
 # create/edit message templates with an IMAGE header: Meta only accepts a
 # Resumable-Upload media handle (not a plain URL) as the header sample, and

--- a/.env.local.example
+++ b/.env.local.example
@@ -117,6 +117,34 @@ NEXT_PUBLIC_APP_LOCALE=en
 # `manychat_contact_links` row (written by the inbound bridge) — there is
 # no fallback to Meta.
 # WHATSAPP_OUTBOUND_TRANSPORT=meta
+#
+# MANYCHAT_AI_AUTOREPLY_ENABLED: server-only feature flag. When 'true',
+# POST /api/integrations/manychat/inbound schedules the existing AI
+# auto-reply (`dispatchInboundToAiReply` — same engine the native Meta
+# webhook uses, with its own account-level `auto_reply_enabled` switch,
+# handoff, and reply-cap gates) for a genuine new inbound message,
+# deferred via `after()` so ManyChat's request is never delayed by the
+# LLM call. Any value other than the exact string 'true' — including
+# unset/absent — disables it. Safe default: false. Do NOT set this to
+# true at deploy time — flip it only after confirming provider/model/
+# key/system prompt/knowledge base via Settings → AI Assistant and the
+# Playground, and after enabling auto-reply for the account.
+# MANYCHAT_AI_AUTOREPLY_ENABLED=false
+#
+# MANYCHAT_AI_AUTOREPLY_CONTACT_IDS: optional controlled-rollout
+# allowlist for the flag above. Comma-separated ManyChat contact/
+# subscriber ids (the same `contact_id` ManyChat sends the inbound
+# bridge). Server-only.
+#   - Unset or empty (the default): no restriction — every contact
+#     eligible under the account's normal AI auto-reply gates can get
+#     an AI reply once MANYCHAT_AI_AUTOREPLY_ENABLED=true.
+#   - Set with one or more ids: AI only fires for an EXACT match
+#     against this list — every other contact is skipped, even though
+#     the flag above is on. Use this to flip AUTOREPLY_ENABLED=true in
+#     production and test against a single controlled contact first,
+#     then clear this var (leave it empty) once validated so AI applies
+#     normally account-wide.
+# MANYCHAT_AI_AUTOREPLY_CONTACT_IDS=
 
 # Meta App ID (Meta for Developers → App Settings → Basic). Required to
 # create/edit message templates with an IMAGE header: Meta only accepts a

--- a/messages/en.json
+++ b/messages/en.json
@@ -1688,6 +1688,7 @@
       "embeddingsKey": "Embeddings key",
       "optionalSemanticSearch": "(optional — enables semantic knowledge-base search)",
       "embeddingsHint": "An OpenAI key used only to embed your knowledge base (text-embedding-3-small){sameKeyText}. Leave blank to use keyword search instead. Clear it to turn semantic search off.",
+      "embeddingsHintGemini": "Optional. You may reuse the same Gemini API key to enable semantic knowledge-base search with gemini-embedding-2. Leave blank to use keyword search instead. Clear it to turn semantic search off.",
       "sameKeyText": " — can be the same key as above",
       "behaviour": "Behaviour",
       "behaviourDesc": "Tell the assistant about your business — products, tone, what it may and may not promise. This context feeds both drafts and auto-replies.",
@@ -1709,7 +1710,8 @@
       "saveSuccess": "AI assistant saved.",
       "saveFailed": "Failed to save.",
       "removeSuccess": "AI configuration removed.",
-      "removeFailed": "Failed to remove."
+      "removeFailed": "Failed to remove.",
+      "reindexRequired": "Embedding provider changed. Reindex the knowledge base before using semantic search."
     },
     "aiKnowledge": {
       "loadFailed": "Failed to load knowledge base",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1688,6 +1688,7 @@
       "embeddingsKey": "임베딩 키",
       "optionalSemanticSearch": "(선택 — 의미 기반 지식베이스 검색을 활성화합니다)",
       "embeddingsHint": "지식베이스를 임베딩하는 데만 사용되는 OpenAI 키입니다(text-embedding-3-small){sameKeyText}. 비워두면 키워드 검색을 사용합니다. 비우면 의미 기반 검색이 꺼집니다.",
+      "embeddingsHintGemini": "선택 사항입니다. 위와 동일한 Gemini API 키를 사용하여 gemini-embedding-2로 의미 기반 지식베이스 검색을 활성화할 수 있습니다. 비워두면 키워드 검색을 사용합니다. 비우면 의미 기반 검색이 꺼집니다.",
       "sameKeyText": " — 위와 동일한 키를 사용할 수 있습니다",
       "behaviour": "동작 방식",
       "behaviourDesc": "비즈니스에 대해 어시스턴트에게 알려주세요 — 제품, 어조, 약속해도 되는 것과 안 되는 것. 이 맥락은 초안 작성과 자동 응답 모두에 반영됩니다.",
@@ -1709,7 +1710,8 @@
       "saveSuccess": "AI 어시스턴트가 저장되었습니다.",
       "saveFailed": "저장하지 못했습니다.",
       "removeSuccess": "AI 설정이 제거되었습니다.",
-      "removeFailed": "제거하지 못했습니다."
+      "removeFailed": "제거하지 못했습니다.",
+      "reindexRequired": "임베딩 제공업체가 변경되었습니다. 시맨틱 검색을 사용하기 전에 지식베이스를 다시 색인하세요."
     },
     "aiKnowledge": {
       "loadFailed": "지식베이스를 불러오지 못했습니다",

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,33 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
+const SUPABASE_CSP_ORIGINS = (() => {
+  const rawUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
 
+  if (!rawUrl) {
+    return {
+      http: "https://*.supabase.co",
+      ws: "wss://*.supabase.co",
+    };
+  }
+
+  try {
+    const url = new URL(rawUrl);
+    const http = url.origin;
+
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+
+    return {
+      http,
+      ws: url.origin,
+    };
+  } catch {
+    return {
+      http: "https://*.supabase.co",
+      ws: "wss://*.supabase.co",
+    };
+  }
+})();
 /**
  * Baseline security headers applied to every response.
  *
@@ -51,11 +77,11 @@ const SECURITY_HEADERS = [
       "img-src 'self' data: blob: https:",
       // Outbound media previews (blob: from MediaRecorder + file picker)
       // and Supabase public-bucket audio/video the inbox renders.
-      "media-src 'self' blob: https://*.supabase.co",
+      `media-src 'self' blob: ${SUPABASE_CSP_ORIGINS.http}`,
       "font-src 'self' data:",
       // Supabase REST + realtime (WSS). All Meta API calls happen
       // server-side, so graph.facebook.com does not belong here.
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      `connect-src 'self' ${SUPABASE_CSP_ORIGINS.http} ${SUPABASE_CSP_ORIGINS.ws}`,
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1060,25 +1060,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -4653,9 +4667,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4725,9 +4739,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4744,11 +4758,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4839,9 +4853,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5586,9 +5600,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.339",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
-      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6471,9 +6485,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -8679,10 +8693,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "license": "MIT"
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -9180,9 +9197,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -9382,12 +9399,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -10132,14 +10150,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -11021,9 +11039,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/app/api/ai/config/route.test.ts
+++ b/src/app/api/ai/config/route.test.ts
@@ -13,21 +13,51 @@ const USER_ID = 'user-1'
 
 let callerRole = 'admin'
 let existingConfigRow: Record<string, unknown> | null = null
+/** Set to force the ai_knowledge_chunks clear-update to fail. */
+let chunksClearError: { message: string } | null = null
+/** Set to force the ai_configs insert/update (the config save) to fail. */
+let configSaveError: { message: string } | null = null
 const insertCalls: { table: string; row: Record<string, unknown> }[] = []
-const updateCalls: { table: string; row: Record<string, unknown> }[] = []
+const updateCalls: {
+  table: string
+  row: Record<string, unknown>
+  eqArgs: [string, unknown][]
+}[] = []
+const deleteCalls: { table: string; eqArgs: [string, unknown][] }[] = []
+/** Records 'clear' / 'config-write' in the order the route actually issues
+ *  them, so ordering (not just occurrence) can be asserted directly. */
+const writeOrder: ('clear' | 'config-write')[] = []
 
 function makeSupabaseMock() {
   function builder(table: string) {
-    let mode: 'select' | 'insert' | 'update' = 'select'
+    let mode: 'select' | 'insert' | 'update' | 'delete' = 'select'
     let pendingRow: Record<string, unknown> | undefined
+    const eqArgs: [string, unknown][] = []
 
     const resolveResult = () => {
       if (mode === 'insert') {
         insertCalls.push({ table, row: pendingRow! })
+        if (table === 'ai_configs') {
+          writeOrder.push('config-write')
+          if (configSaveError) return { data: null, error: configSaveError }
+        }
         return { data: null, error: null }
       }
       if (mode === 'update') {
-        updateCalls.push({ table, row: pendingRow! })
+        updateCalls.push({ table, row: pendingRow!, eqArgs: [...eqArgs] })
+        if (table === 'ai_knowledge_chunks') {
+          writeOrder.push('clear')
+          if (chunksClearError) return { data: null, error: chunksClearError }
+          return { data: null, error: null }
+        }
+        if (table === 'ai_configs') {
+          writeOrder.push('config-write')
+          if (configSaveError) return { data: null, error: configSaveError }
+        }
+        return { data: null, error: null }
+      }
+      if (mode === 'delete') {
+        deleteCalls.push({ table, eqArgs: [...eqArgs] })
         return { data: null, error: null }
       }
       if (table === 'profiles') {
@@ -44,7 +74,10 @@ function makeSupabaseMock() {
 
     const b: Record<string, unknown> = {}
     b.select = vi.fn(() => b)
-    b.eq = vi.fn(() => b)
+    b.eq = vi.fn((col: string, val: unknown) => {
+      eqArgs.push([col, val])
+      return b
+    })
     b.maybeSingle = vi.fn(() => Promise.resolve(resolveResult()))
     b.insert = vi.fn((row: Record<string, unknown>) => {
       mode = 'insert'
@@ -54,6 +87,10 @@ function makeSupabaseMock() {
     b.update = vi.fn((row: Record<string, unknown>) => {
       mode = 'update'
       pendingRow = row
+      return b
+    })
+    b.delete = vi.fn(() => {
+      mode = 'delete'
       return b
     })
     b.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
@@ -116,8 +153,12 @@ const GEMINI_BODY = {
 beforeEach(() => {
   callerRole = 'admin'
   existingConfigRow = null
+  chunksClearError = null
+  configSaveError = null
   insertCalls.length = 0
   updateCalls.length = 0
+  deleteCalls.length = 0
+  writeOrder.length = 0
   supabaseMock = makeSupabaseMock()
   validateAiCredentials.mockClear()
   validateAiCredentials.mockResolvedValue(undefined)
@@ -286,21 +327,41 @@ describe('POST /api/ai/config — provider switch revalidation', () => {
 })
 
 describe('POST /api/ai/config — embeddings key stays separate for Gemini', () => {
-  it('validates and encrypts an embeddings key independently of the Gemini chat key', async () => {
+  it('validates and encrypts an embeddings key as a SEPARATE field from the Gemini chat key (explicit opt-in, no auto-reuse)', async () => {
+    // The user pastes a distinct value into the embeddings field — even
+    // though provider=gemini (so this gets validated as a Gemini
+    // embeddings key), it must never be silently copied from api_key.
     const res = await postConfig({
       ...GEMINI_BODY,
-      embeddings_api_key: 'sk-openai-embeddings-key',
+      embeddings_api_key: 'AIzaSyDistinctEmbeddingsKey',
     })
 
     expect(res.status).toBe(200)
-    expect(embedTexts).toHaveBeenCalledWith('sk-openai-embeddings-key', ['ping'])
-    // Two distinct encrypt() calls — the Gemini key and the embeddings key —
-    // never the Gemini key reused as the embeddings key.
+    // provider=gemini → the embeddings key is validated as a Gemini key,
+    // never guessed by the key's shape/prefix.
+    expect(embedTexts).toHaveBeenCalledWith('gemini', 'AIzaSyDistinctEmbeddingsKey', ['ping'], {
+      kind: 'query',
+    })
+    // Two distinct encrypt() calls — the chat key and the embeddings key —
+    // never the chat key reused as the embeddings key.
     expect(encrypt).toHaveBeenCalledWith('AIzaSyGeminiTestKey')
-    expect(encrypt).toHaveBeenCalledWith('sk-openai-embeddings-key')
-    expect(insertCalls[0].row.embeddings_api_key).toBe('enc:sk-openai-embeddings-key')
+    expect(encrypt).toHaveBeenCalledWith('AIzaSyDistinctEmbeddingsKey')
+    expect(insertCalls[0].row.embeddings_api_key).toBe('enc:AIzaSyDistinctEmbeddingsKey')
     expect(insertCalls[0].row.api_key).toBe('enc:AIzaSyGeminiTestKey')
     expect(insertCalls[0].row.embeddings_api_key).not.toBe(insertCalls[0].row.api_key)
+  })
+
+  it('accepts the SAME Gemini key pasted into both the chat and embeddings fields (explicit opt-in reuse)', async () => {
+    const res = await postConfig({
+      ...GEMINI_BODY,
+      embeddings_api_key: 'AIzaSyGeminiTestKey', // same value as api_key
+    })
+
+    expect(res.status).toBe(200)
+    expect(embedTexts).toHaveBeenCalledWith('gemini', 'AIzaSyGeminiTestKey', ['ping'], {
+      kind: 'query',
+    })
+    expect(insertCalls[0].row.embeddings_api_key).toBe('enc:AIzaSyGeminiTestKey')
   })
 
   it('omitting the embeddings key leaves it untouched, and Gemini works fine without one', async () => {
@@ -308,5 +369,457 @@ describe('POST /api/ai/config — embeddings key stays separate for Gemini', () 
     expect(res.status).toBe(200)
     expect(embedTexts).not.toHaveBeenCalled()
     expect(insertCalls[0].row).not.toHaveProperty('embeddings_api_key')
+  })
+})
+
+describe('POST /api/ai/config — embeddings provider selection by chat provider', () => {
+  it('provider=openai + embeddings key → validated as OpenAI embeddings', async () => {
+    const res = await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-openai-chat-key',
+      embeddings_api_key: 'sk-openai-embed-key',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    expect(res.status).toBe(200)
+    expect(embedTexts).toHaveBeenCalledWith('openai', 'sk-openai-embed-key', ['ping'], { kind: 'query' })
+  })
+
+  it('provider=anthropic + embeddings key → still validated as OpenAI embeddings (Anthropic has no embeddings endpoint)', async () => {
+    const res = await postConfig({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      api_key: 'sk-ant-chat-key',
+      embeddings_api_key: 'sk-openai-embed-key',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    expect(res.status).toBe(200)
+    expect(embedTexts).toHaveBeenCalledWith('openai', 'sk-openai-embed-key', ['ping'], { kind: 'query' })
+  })
+})
+
+describe('POST /api/ai/config — clears stale embeddings on an embedding-space change (fail-safe ordering: clear BEFORE save)', () => {
+  function chunksClearCall() {
+    return updateCalls.find((c) => c.table === 'ai_knowledge_chunks')
+  }
+
+  it('gemini → openai: clear ocurre ANTES del save (update) de ai_configs', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaOldChat',
+      embeddings_api_key: 'enc:AIzaOldEmbed',
+    }
+
+    const res = await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+      // embeddings_api_key omitted → the existing embeddings key carries
+      // over unchanged; only the CHAT provider (and thus the derived
+      // embeddings provider) changes.
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.knowledge_reindex_required).toBe(true)
+    const clearCall = chunksClearCall()
+    expect(clearCall).toBeDefined()
+    expect(clearCall!.row).toEqual({ embedding: null })
+    // Ordering proof: the clear must be issued strictly before the config
+    // write, not just "also happen".
+    expect(writeOrder).toEqual(['clear', 'config-write'])
+  })
+
+  it('openai → gemini: clear ocurre ANTES del save', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'enc:sk-old-chat',
+      embeddings_api_key: 'enc:sk-old-embed',
+    }
+
+    const res = await postConfig({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'AIzaNewChat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.knowledge_reindex_required).toBe(true)
+    expect(chunksClearCall()).toBeDefined()
+    expect(writeOrder).toEqual(['clear', 'config-write'])
+  })
+
+  it('gemini + key → gemini with the key explicitly cleared: clears embeddings', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+
+    const res = await postConfig({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      embeddings_api_key: null, // explicit clear
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.knowledge_reindex_required).toBe(true)
+    expect(chunksClearCall()).toBeDefined()
+  })
+
+  it('no embeddings key → gemini + key: clears (idempotent even if already NULL)', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'enc:sk-old-chat',
+      embeddings_api_key: null,
+    }
+
+    const res = await postConfig({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'AIzaNewChat',
+      embeddings_api_key: 'AIzaNewEmbed',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.knowledge_reindex_required).toBe(true)
+    expect(chunksClearCall()).toBeDefined()
+  })
+
+  it('the clear is scoped strictly by account_id', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+
+    await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    const clearCall = chunksClearCall()
+    expect(clearCall!.eqArgs).toEqual([['account_id', ACCOUNT_ID]])
+  })
+
+  it('never deletes documents or chunks — only NULLs the embedding column', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+
+    await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    expect(deleteCalls).toHaveLength(0)
+    // The update touches ONLY the embedding column — title/content/fts
+    // untouched (the route doesn't even have those values to write).
+    expect(chunksClearCall()!.row).toEqual({ embedding: null })
+  })
+
+  it('openai → anthropic does NOT clear (both use OpenAI embeddings)', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'enc:sk-old-chat',
+      embeddings_api_key: 'enc:sk-embed',
+    }
+
+    const res = await postConfig({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      api_key: 'sk-ant-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.knowledge_reindex_required).toBeUndefined()
+    expect(chunksClearCall()).toBeUndefined()
+    expect(writeOrder).toEqual(['config-write'])
+  })
+
+  it('same-provider embeddings key rotation (OpenAI key A → key B) does NOT clear', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'enc:sk-chat',
+      embeddings_api_key: 'enc:sk-embed-A',
+    }
+
+    const res = await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      embeddings_api_key: 'sk-embed-B',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.knowledge_reindex_required).toBeUndefined()
+    expect(chunksClearCall()).toBeUndefined()
+  })
+
+  it('same-provider embeddings key rotation (Gemini key A → key B) does NOT clear', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbedA',
+    }
+
+    const res = await postConfig({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      embeddings_api_key: 'AIzaEmbedB',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.knowledge_reindex_required).toBeUndefined()
+    expect(chunksClearCall()).toBeUndefined()
+  })
+
+  it('a successful provider-change save reports knowledge_reindex_required: true', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+
+    const res = await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(json.knowledge_reindex_required).toBe(true)
+  })
+})
+
+describe('POST /api/ai/config — fail-safe: if the clear fails, the new config is NEVER saved', () => {
+  function chunksClearCall() {
+    return updateCalls.find((c) => c.table === 'ai_knowledge_chunks')
+  }
+  function configWriteCalls() {
+    return [
+      ...insertCalls.filter((c) => c.table === 'ai_configs'),
+      ...updateCalls.filter((c) => c.table === 'ai_configs'),
+    ]
+  }
+
+  it('si clear falla: el save de ai_configs NO se ejecuta', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+    chunksClearError = { message: 'db unreachable' }
+
+    await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    expect(chunksClearCall()).toBeDefined() // the clear WAS attempted
+    expect(configWriteCalls()).toHaveLength(0) // but the config write never ran
+    expect(writeOrder).toEqual(['clear']) // proves the write never followed
+  })
+
+  it('si clear falla: la respuesta no es success:true — es un error HTTP seguro (500), sin detalles internos de la DB', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+    chunksClearError = { message: 'password authentication failed for user "postgres"' }
+
+    const res = await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(json.success).toBeUndefined()
+    expect(json.knowledge_reindex_required).toBeUndefined()
+    expect(typeof json.error).toBe('string')
+    // Generic, safe message — never the raw DB error text.
+    expect(json.error).not.toContain('postgres')
+    expect(json.error).not.toContain('password')
+  })
+
+  it('si clear falla: el provider/config anterior permanece intacto (ningún insert/update de ai_configs se emitió)', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+    chunksClearError = { message: 'db unreachable' }
+
+    await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    // Nothing touched ai_configs at all — the stored row (provider, model,
+    // keys) is exactly what it was before this request.
+    expect(insertCalls.filter((c) => c.table === 'ai_configs')).toHaveLength(0)
+    expect(updateCalls.filter((c) => c.table === 'ai_configs')).toHaveLength(0)
+  })
+
+  it('si el clear funciona pero el save de config falla: el clear ya ocurrió y NO se intenta restaurar el vector viejo', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+    configSaveError = { message: 'db unreachable' }
+
+    const res = await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+    const json = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(json.success).toBeUndefined()
+    // The clear happened and is NOT rolled back — chunks.embedding stays
+    // NULL; this is the accepted safe outcome (lexical search still
+    // works, semantic search is temporarily unavailable until Reindex).
+    expect(chunksClearCall()).toBeDefined()
+    expect(writeOrder).toEqual(['clear', 'config-write'])
+    // Only ONE update call ever touched ai_knowledge_chunks — no second
+    // "restore"/rollback update was issued.
+    expect(updateCalls.filter((c) => c.table === 'ai_knowledge_chunks')).toHaveLength(1)
+  })
+
+  it('la clear query sigue scoped por account_id incluso en el camino fail-safe', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+    chunksClearError = { message: 'db unreachable' }
+
+    await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    const clearCall = chunksClearCall()
+    expect(clearCall!.eqArgs).toEqual([['account_id', ACCOUNT_ID]])
+  })
+
+  it('jamás emite un DELETE sobre documents/chunks, ni en el camino exitoso ni en el fail-safe', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaChat',
+      embeddings_api_key: 'enc:AIzaEmbed',
+    }
+    chunksClearError = { message: 'db unreachable' }
+
+    await postConfig({
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'sk-new-chat',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    expect(deleteCalls).toHaveLength(0)
   })
 })

--- a/src/app/api/ai/config/route.test.ts
+++ b/src/app/api/ai/config/route.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Gemini-focused coverage for POST/GET /api/ai/config. Only exercises the
+// parts of the route that change with a third provider — role enforcement,
+// account scoping, "verify before save", and the rest of the existing
+// behavior are assumed covered by the route's own long-standing design and
+// are only spot-checked here where Gemini could plausibly regress them.
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_ID = 'acct-1'
+const USER_ID = 'user-1'
+
+let callerRole = 'admin'
+let existingConfigRow: Record<string, unknown> | null = null
+const insertCalls: { table: string; row: Record<string, unknown> }[] = []
+const updateCalls: { table: string; row: Record<string, unknown> }[] = []
+
+function makeSupabaseMock() {
+  function builder(table: string) {
+    let mode: 'select' | 'insert' | 'update' = 'select'
+    let pendingRow: Record<string, unknown> | undefined
+
+    const resolveResult = () => {
+      if (mode === 'insert') {
+        insertCalls.push({ table, row: pendingRow! })
+        return { data: null, error: null }
+      }
+      if (mode === 'update') {
+        updateCalls.push({ table, row: pendingRow! })
+        return { data: null, error: null }
+      }
+      if (table === 'profiles') {
+        return { data: { account_id: ACCOUNT_ID, account_role: callerRole }, error: null }
+      }
+      if (table === 'accounts') {
+        return { data: { id: ACCOUNT_ID, name: 'Acme' }, error: null }
+      }
+      if (table === 'ai_configs') {
+        return { data: existingConfigRow, error: null }
+      }
+      return { data: null, error: null }
+    }
+
+    const b: Record<string, unknown> = {}
+    b.select = vi.fn(() => b)
+    b.eq = vi.fn(() => b)
+    b.maybeSingle = vi.fn(() => Promise.resolve(resolveResult()))
+    b.insert = vi.fn((row: Record<string, unknown>) => {
+      mode = 'insert'
+      pendingRow = row
+      return b
+    })
+    b.update = vi.fn((row: Record<string, unknown>) => {
+      mode = 'update'
+      pendingRow = row
+      return b
+    })
+    b.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(resolveResult()).then(resolve, reject)
+    return b
+  }
+
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: USER_ID } }, error: null })),
+    },
+    from: vi.fn((table: string) => builder(table)),
+  }
+}
+
+let supabaseMock = makeSupabaseMock()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}))
+
+vi.mock('@/lib/whatsapp/encryption', () => ({
+  encrypt: vi.fn((v: string) => `enc:${v}`),
+  decrypt: vi.fn((v: string) => v.replace(/^enc:/, '')),
+}))
+
+const { validateAiCredentials } = vi.hoisted(() => ({
+  validateAiCredentials: vi.fn(async () => undefined),
+}))
+vi.mock('@/lib/ai/validate', () => ({ validateAiCredentials }))
+
+const { embedTexts } = vi.hoisted(() => ({
+  embedTexts: vi.fn(async () => [[0.1, 0.2]]),
+}))
+vi.mock('@/lib/ai/embeddings', () => ({ embedTexts }))
+
+import { GET, POST } from './route'
+import { encrypt } from '@/lib/whatsapp/encryption'
+
+function postConfig(body: Record<string, unknown>) {
+  return POST(
+    new Request('http://localhost/api/ai/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+const GEMINI_BODY = {
+  provider: 'gemini',
+  model: 'gemini-3.8-flash',
+  api_key: 'AIzaSyGeminiTestKey',
+  system_prompt: 'Be concise.',
+  is_active: true,
+  auto_reply_enabled: false,
+  auto_reply_max_per_conversation: 3,
+}
+
+beforeEach(() => {
+  callerRole = 'admin'
+  existingConfigRow = null
+  insertCalls.length = 0
+  updateCalls.length = 0
+  supabaseMock = makeSupabaseMock()
+  validateAiCredentials.mockClear()
+  validateAiCredentials.mockResolvedValue(undefined)
+  embedTexts.mockClear()
+  ;(encrypt as ReturnType<typeof vi.fn>).mockClear()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/ai/config — accepts gemini', () => {
+  it('accepts provider "gemini" and inserts a new config row', async () => {
+    const res = await postConfig(GEMINI_BODY)
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(insertCalls).toHaveLength(1)
+    expect(insertCalls[0].row).toMatchObject({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+    })
+  })
+
+  it('rejects an invalid provider with 400', async () => {
+    const res = await postConfig({ ...GEMINI_BODY, provider: 'llama' })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/provider must be/i)
+    expect(insertCalls).toHaveLength(0)
+  })
+})
+
+describe('POST /api/ai/config — Gemini key handling', () => {
+  it('validates the Gemini key with the provider BEFORE persisting', async () => {
+    let validatedBeforeInsert = false
+    validateAiCredentials.mockImplementation(async () => {
+      validatedBeforeInsert = insertCalls.length === 0
+    })
+
+    await postConfig(GEMINI_BODY)
+
+    expect(validateAiCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'gemini', apiKey: 'AIzaSyGeminiTestKey' }),
+    )
+    expect(validatedBeforeInsert).toBe(true)
+  })
+
+  it('does not persist when Gemini key validation fails', async () => {
+    const { AiError } = await import('@/lib/ai/types')
+    validateAiCredentials.mockRejectedValue(
+      new AiError('Gemini rejected the API key', { code: 'invalid_key', status: 401 }),
+    )
+
+    const res = await postConfig(GEMINI_BODY)
+
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('invalid_key')
+    expect(insertCalls).toHaveLength(0)
+  })
+
+  it('stores the Gemini key AES-256-GCM-encrypted via the existing encrypt(), never plaintext', async () => {
+    await postConfig(GEMINI_BODY)
+
+    expect(encrypt).toHaveBeenCalledWith('AIzaSyGeminiTestKey')
+    expect(insertCalls[0].row.api_key).toBe('enc:AIzaSyGeminiTestKey')
+    expect(insertCalls[0].row.api_key).not.toBe('AIzaSyGeminiTestKey')
+  })
+})
+
+describe('GET /api/ai/config — never returns the key in plaintext', () => {
+  it('returns has_key: true but no api_key field, for a Gemini config', async () => {
+    existingConfigRow = {
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      system_prompt: null,
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+      handoff_agent_id: null,
+      api_key: 'enc:AIzaSyGeminiTestKey',
+      embeddings_api_key: null,
+    }
+
+    const res = await GET()
+    const json = await res.json()
+
+    expect(json.has_key).toBe(true)
+    expect(json.provider).toBe('gemini')
+    expect(json).not.toHaveProperty('api_key')
+    expect(JSON.stringify(json)).not.toContain('AIzaSyGeminiTestKey')
+  })
+})
+
+describe('POST /api/ai/config — provider switch revalidation', () => {
+  it('switching OpenAI → Gemini triggers revalidation even without a new key', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      api_key: 'enc:sk-old-openai-key',
+    }
+
+    const res = await postConfig({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      // No api_key — the stored (decrypted) OpenAI key gets reused as
+      // the string handed to validateAiCredentials, but the important
+      // thing is that a provider change alone still forces a live check.
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    expect(res.status).toBe(200)
+    expect(validateAiCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'gemini' }),
+    )
+  })
+
+  it('switching Gemini → Anthropic triggers revalidation', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaOldKey',
+    }
+
+    const res = await postConfig({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    expect(res.status).toBe(200)
+    expect(validateAiCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'anthropic' }),
+    )
+  })
+
+  it('editing only the system prompt on an existing Gemini config does NOT re-call the provider', async () => {
+    existingConfigRow = {
+      id: 'cfg-1',
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'enc:AIzaSameKey',
+    }
+
+    const res = await postConfig({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      system_prompt: 'A brand new business context.',
+      is_active: true,
+      auto_reply_enabled: false,
+      auto_reply_max_per_conversation: 3,
+    })
+
+    expect(res.status).toBe(200)
+    expect(validateAiCredentials).not.toHaveBeenCalled()
+    expect(updateCalls[0].row).toMatchObject({ system_prompt: 'A brand new business context.' })
+  })
+})
+
+describe('POST /api/ai/config — embeddings key stays separate for Gemini', () => {
+  it('validates and encrypts an embeddings key independently of the Gemini chat key', async () => {
+    const res = await postConfig({
+      ...GEMINI_BODY,
+      embeddings_api_key: 'sk-openai-embeddings-key',
+    })
+
+    expect(res.status).toBe(200)
+    expect(embedTexts).toHaveBeenCalledWith('sk-openai-embeddings-key', ['ping'])
+    // Two distinct encrypt() calls — the Gemini key and the embeddings key —
+    // never the Gemini key reused as the embeddings key.
+    expect(encrypt).toHaveBeenCalledWith('AIzaSyGeminiTestKey')
+    expect(encrypt).toHaveBeenCalledWith('sk-openai-embeddings-key')
+    expect(insertCalls[0].row.embeddings_api_key).toBe('enc:sk-openai-embeddings-key')
+    expect(insertCalls[0].row.api_key).toBe('enc:AIzaSyGeminiTestKey')
+    expect(insertCalls[0].row.embeddings_api_key).not.toBe(insertCalls[0].row.api_key)
+  })
+
+  it('omitting the embeddings key leaves it untouched, and Gemini works fine without one', async () => {
+    const res = await postConfig(GEMINI_BODY)
+    expect(res.status).toBe(200)
+    expect(embedTexts).not.toHaveBeenCalled()
+    expect(insertCalls[0].row).not.toHaveProperty('embeddings_api_key')
+  })
+})

--- a/src/app/api/ai/config/route.ts
+++ b/src/app/api/ai/config/route.ts
@@ -78,8 +78,8 @@ export async function POST(request: Request) {
     if (!body || typeof body !== 'object') return bad('Invalid request body')
 
     const provider = body.provider as AiProvider
-    if (provider !== 'openai' && provider !== 'anthropic') {
-      return bad('provider must be "openai" or "anthropic"')
+    if (provider !== 'openai' && provider !== 'anthropic' && provider !== 'gemini') {
+      return bad('provider must be "openai", "anthropic", or "gemini"')
     }
     const model = typeof body.model === 'string' ? body.model.trim() : ''
     if (!model) return bad('model is required')

--- a/src/app/api/ai/config/route.ts
+++ b/src/app/api/ai/config/route.ts
@@ -8,6 +8,7 @@ import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from '@/lib/rate-limit
 import { encrypt, decrypt } from '@/lib/whatsapp/encryption'
 import { validateAiCredentials } from '@/lib/ai/validate'
 import { embedTexts } from '@/lib/ai/embeddings'
+import { deriveEmbeddingsProvider } from '@/lib/ai/config'
 import { AiError, type AiProvider } from '@/lib/ai/types'
 
 function bad(message: string) {
@@ -128,9 +129,42 @@ export async function POST(request: Request) {
     // Reuse the stored key when the form didn't send a fresh one.
     const { data: existing } = await supabase
       .from('ai_configs')
-      .select('id, provider, model, api_key')
+      .select('id, provider, model, api_key, embeddings_api_key')
       .eq('account_id', accountId)
       .maybeSingle()
+
+    // ------------------------------------------------------------
+    // Embedding-space mismatch guard.
+    //
+    // `ai_knowledge_chunks.embedding` vectors don't record which
+    // provider/model produced them. Same dimension (1536) does NOT mean
+    // the same embedding space — an OpenAI text-embedding-3-small
+    // vector and a Gemini gemini-embedding-2 vector are not comparable,
+    // so if the account's embeddings provider changes (Gemini↔OpenAI,
+    // or a key is added/removed), any existing vectors must be cleared
+    // rather than silently mixed into future cosine-distance queries.
+    // A same-provider key rotation (openai→openai, gemini→gemini) or a
+    // chat-provider change that doesn't change the embeddings provider
+    // (openai↔anthropic, both use OpenAI embeddings) does NOT need this
+    // — the vector space is unchanged.
+    //
+    // Only presence is inspected here (never the decrypted plaintext),
+    // so the still-encrypted `existing.embeddings_api_key` can be
+    // passed straight through — see deriveEmbeddingsProvider's doc.
+    // ------------------------------------------------------------
+    const oldEmbeddingsProvider = existing
+      ? deriveEmbeddingsProvider(existing.provider, existing.embeddings_api_key)
+      : null
+    // Effective embeddings key AFTER this save: a freshly-sent key wins,
+    // an explicit clear (embeddings_api_key: null) wins, otherwise
+    // whatever was already stored carries over unchanged.
+    const effectiveNewEmbeddingsKey = rawEmbeddingsKey
+      ? rawEmbeddingsKey
+      : clearEmbeddingsKey
+        ? null
+        : (existing?.embeddings_api_key ?? null)
+    const newEmbeddingsProvider = deriveEmbeddingsProvider(provider, effectiveNewEmbeddingsKey)
+    const embeddingsProviderChanged = oldEmbeddingsProvider !== newEmbeddingsProvider
 
     let apiKeyPlain: string
     if (rawKey) {
@@ -167,6 +201,7 @@ export async function POST(request: Request) {
           autoReplyMaxPerConversation: maxPer,
           handoffAgentId: null,
           embeddingsApiKey: null,
+          embeddingsProvider: null,
         })
       } catch (err) {
         if (err instanceof AiError) {
@@ -184,7 +219,12 @@ export async function POST(request: Request) {
     // embed), same "verify before save" discipline as the chat key.
     if (rawEmbeddingsKey) {
       try {
-        await embedTexts(rawEmbeddingsKey, ['ping'])
+        // Same rule as loadAiConfig's deriveEmbeddingsProvider: Gemini
+        // chat accounts use Gemini embeddings, everyone else uses
+        // OpenAI. `provider` was already validated above.
+        await embedTexts(provider === 'gemini' ? 'gemini' : 'openai', rawEmbeddingsKey, ['ping'], {
+          kind: 'query',
+        })
       } catch (err) {
         if (err instanceof AiError) {
           return NextResponse.json(
@@ -215,6 +255,44 @@ export async function POST(request: Request) {
       shared.embeddings_api_key = null
     }
 
+    // ------------------------------------------------------------
+    // Clear stale vectors from a DIFFERENT embedding space BEFORE
+    // persisting the new config — fail-safe ordering is the whole
+    // point. If this clear fails, the new config is NOT saved: saving
+    // it anyway would leave the account's provider pointing at (say)
+    // OpenAI while its chunks still carry Gemini vectors sitting right
+    // next to it — exactly the incompatible-space mixing this guard
+    // exists to prevent. The OLD config (and OLD, still-consistent
+    // vectors) stay exactly as they were; a retry of this same save is
+    // what recovers. Never deletes documents/chunks/fts — only NULLs
+    // the embedding column, so lexical search is unaffected either way
+    // and this step is safely re-runnable.
+    //
+    // Losing semantic search temporarily (chunks with embedding=NULL
+    // until the next Reindex) is the accepted, safe outcome here — NOT
+    // restoring the old vectors, NOT rolling anything back, NOT
+    // auto-reindexing. Mixing embedding spaces silently would be worse.
+    // ------------------------------------------------------------
+    if (embeddingsProviderChanged) {
+      const { error: clearErr } = await supabase
+        .from('ai_knowledge_chunks')
+        .update({ embedding: null })
+        .eq('account_id', accountId)
+      if (clearErr) {
+        // Never log the error object raw (could carry query/DB
+        // internals) — just the message, and never anything from the
+        // request body's keys.
+        console.error(
+          '[ai/config POST] failed to clear stale embeddings before provider change — config NOT saved:',
+          clearErr.message,
+        )
+        return NextResponse.json(
+          { error: 'Failed to prepare knowledge base for the new embeddings provider.' },
+          { status: 500 },
+        )
+      }
+    }
+
     if (existing) {
       const { error: upErr } = await supabase
         .from('ai_configs')
@@ -243,7 +321,10 @@ export async function POST(request: Request) {
       }
     }
 
-    return NextResponse.json({ success: true })
+    return NextResponse.json({
+      success: true,
+      ...(embeddingsProviderChanged ? { knowledge_reindex_required: true } : {}),
+    })
   } catch (err) {
     return toErrorResponse(err)
   }

--- a/src/app/api/ai/knowledge/[id]/route.test.ts
+++ b/src/app/api/ai/knowledge/[id]/route.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// PATCH /api/ai/knowledge/[id] — confirms re-indexing after a content-only
+// edit uses the document's CURRENT (stored) title, and that editing both
+// title + content uses the NEW title — Gemini's asymmetric document format
+// needs the right title either way.
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_ID = 'acct-1'
+const USER_ID = 'user-1'
+const DOC_ID = 'doc-1'
+
+let callerRole = 'admin'
+/** The title PATCH's update+select returns — simulates the DB's current
+ *  stored value after applying whatever this request's `update` touched. */
+let resultingTitle = 'Stored Title'
+const updateCalls: Record<string, unknown>[] = []
+
+function makeSupabaseMock() {
+  function builder(table: string) {
+    const resolveResult = () => {
+      if (table === 'profiles') {
+        return { data: { account_id: ACCOUNT_ID, account_role: callerRole }, error: null }
+      }
+      if (table === 'accounts') {
+        return { data: { id: ACCOUNT_ID, name: 'Acme' }, error: null }
+      }
+      if (table === 'ai_knowledge_documents') {
+        return { data: { id: DOC_ID, title: resultingTitle }, error: null }
+      }
+      return { data: null, error: null }
+    }
+    const b: Record<string, unknown> = {}
+    b.select = vi.fn(() => b)
+    b.eq = vi.fn(() => b)
+    b.maybeSingle = vi.fn(() => Promise.resolve(resolveResult()))
+    b.update = vi.fn((row: Record<string, unknown>) => {
+      updateCalls.push(row)
+      return b
+    })
+    return b
+  }
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: USER_ID } }, error: null })),
+    },
+    from: vi.fn((table: string) => builder(table)),
+  }
+}
+
+let supabaseMock = makeSupabaseMock()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}))
+
+const { loadEmbeddingsKey } = vi.hoisted(() => ({
+  loadEmbeddingsKey: vi.fn(async () => ({
+    key: null as string | null,
+    corrupt: false,
+    provider: null as 'openai' | 'gemini' | null,
+  })),
+}))
+vi.mock('@/lib/ai/config', () => ({ loadEmbeddingsKey }))
+
+const { ingestDocument } = vi.hoisted(() => ({
+  ingestDocument: vi.fn(async () => undefined),
+}))
+vi.mock('@/lib/ai/knowledge', () => ({ ingestDocument }))
+
+import { PATCH } from './route'
+
+function patchDoc(body: Record<string, unknown>) {
+  return PATCH(
+    new Request('http://localhost/api/ai/knowledge/doc-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id: DOC_ID }) },
+  )
+}
+
+beforeEach(() => {
+  callerRole = 'admin'
+  resultingTitle = 'Stored Title'
+  updateCalls.length = 0
+  supabaseMock = makeSupabaseMock()
+  loadEmbeddingsKey.mockClear()
+  loadEmbeddingsKey.mockResolvedValue({ key: null, corrupt: false, provider: null })
+  ingestDocument.mockClear()
+  ingestDocument.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('PATCH /api/ai/knowledge/[id]', () => {
+  it('a content-only edit re-ingests using the CURRENT stored title (not undefined)', async () => {
+    resultingTitle = 'Contacto y ubicación - Lorteg' // simulates the row's existing title
+    const res = await patchDoc({ content: 'Updated content.' })
+
+    expect(res.status).toBe(200)
+    // The update payload itself must NOT include title — this request never touched it.
+    expect(updateCalls[0]).not.toHaveProperty('title')
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: null, embeddingsProvider: null },
+      DOC_ID,
+      'Contacto y ubicación - Lorteg',
+      'Updated content.',
+    )
+  })
+
+  it('editing both title and content re-ingests using the NEW title', async () => {
+    resultingTitle = 'New Title' // the row after this PATCH's update is applied
+    const res = await patchDoc({ title: 'New Title', content: 'Updated content.' })
+
+    expect(res.status).toBe(200)
+    expect(updateCalls[0]).toMatchObject({ title: 'New Title' })
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: null, embeddingsProvider: null },
+      DOC_ID,
+      'New Title',
+      'Updated content.',
+    )
+  })
+
+  it('a title-only edit (no content) does NOT re-ingest at all', async () => {
+    resultingTitle = 'Just A New Title'
+    const res = await patchDoc({ title: 'Just A New Title' })
+
+    expect(res.status).toBe(200)
+    expect(ingestDocument).not.toHaveBeenCalled()
+  })
+
+  it('passes the Gemini provider through on a content edit, with the current title', async () => {
+    loadEmbeddingsKey.mockResolvedValue({
+      key: 'AIzaKey',
+      corrupt: false,
+      provider: 'gemini',
+    })
+    resultingTitle = 'Productos y categorías - Lorteg'
+
+    await patchDoc({ content: 'Taladros disponibles.' })
+
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: 'AIzaKey', embeddingsProvider: 'gemini' },
+      DOC_ID,
+      'Productos y categorías - Lorteg',
+      'Taladros disponibles.',
+    )
+  })
+})

--- a/src/app/api/ai/knowledge/[id]/route.ts
+++ b/src/app/api/ai/knowledge/[id]/route.ts
@@ -68,7 +68,11 @@ export async function PATCH(request: Request, { params }: Params) {
       .update(update)
       .eq('account_id', accountId)
       .eq('id', id)
-      .select('id')
+      // `title` too — even on a content-only PATCH, re-embedding needs
+      // the document's CURRENT title (Gemini's asymmetric document
+      // format), which this row-select gives us for free regardless of
+      // whether this request touched it.
+      .select('id, title')
       .maybeSingle()
     if (error) {
       console.error('[ai/knowledge/[id] PATCH] error:', error)
@@ -77,12 +81,17 @@ export async function PATCH(request: Request, { params }: Params) {
     if (!updated) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
     if (content !== undefined) {
-      const { key: embeddingsApiKey, corrupt } = await loadEmbeddingsKey(
-        supabase,
-        accountId,
-      )
+      const { key: embeddingsApiKey, corrupt, provider: embeddingsProvider } =
+        await loadEmbeddingsKey(supabase, accountId)
       try {
-        await ingestDocument(supabase, accountId, { embeddingsApiKey }, id, content)
+        await ingestDocument(
+          supabase,
+          accountId,
+          { embeddingsApiKey, embeddingsProvider },
+          id,
+          updated.title,
+          content,
+        )
       } catch (err) {
         const message = err instanceof AiError ? err.message : 'indexing failed'
         console.error('[ai/knowledge/[id] PATCH] ingest error:', err)

--- a/src/app/api/ai/knowledge/reindex/route.test.ts
+++ b/src/app/api/ai/knowledge/reindex/route.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// POST /api/ai/knowledge/reindex — confirms the route correctly derives and
+// passes embeddingsProvider through to ingestDocument for every document
+// (the Gemini-embeddings addition), and that the pre-existing batch/error
+// semantics are unchanged.
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_ID = 'acct-1'
+const USER_ID = 'user-1'
+
+let callerRole = 'admin'
+let configRow: Record<string, unknown> | null = null
+let documentRows: { id: string; title: string | null; content: string }[] = []
+
+function makeSupabaseMock() {
+  function builder(table: string) {
+    const resolveResult = () => {
+      if (table === 'profiles') {
+        return { data: { account_id: ACCOUNT_ID, account_role: callerRole }, error: null }
+      }
+      if (table === 'accounts') {
+        return { data: { id: ACCOUNT_ID, name: 'Acme' }, error: null }
+      }
+      if (table === 'ai_configs') {
+        return { data: configRow, error: null }
+      }
+      return { data: null, error: null }
+    }
+    const b: Record<string, unknown> = {}
+    b.select = vi.fn(() => b)
+    b.eq = vi.fn(() => b)
+    b.maybeSingle = vi.fn(() => Promise.resolve(resolveResult()))
+    // ai_knowledge_documents: select('id, title, content').eq('account_id', ...)
+    // — no .maybeSingle(), the route awaits the builder directly.
+    b.then = (resolve: (v: unknown) => unknown) => {
+      if (table === 'ai_knowledge_documents') {
+        return resolve({ data: documentRows, error: null })
+      }
+      return resolve(resolveResult())
+    }
+    return b
+  }
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: USER_ID } }, error: null })),
+    },
+    from: vi.fn((table: string) => builder(table)),
+  }
+}
+
+let supabaseMock = makeSupabaseMock()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}))
+
+vi.mock('@/lib/whatsapp/encryption', () => ({
+  decrypt: vi.fn((v: string) => v.replace(/^enc:/, '')),
+}))
+
+const { ingestDocument } = vi.hoisted(() => ({
+  ingestDocument: vi.fn(async () => undefined),
+}))
+vi.mock('@/lib/ai/knowledge', () => ({ ingestDocument }))
+
+import { POST } from './route'
+
+beforeEach(() => {
+  callerRole = 'admin'
+  configRow = null
+  documentRows = []
+  supabaseMock = makeSupabaseMock()
+  ingestDocument.mockClear()
+  ingestDocument.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/ai/knowledge/reindex', () => {
+  it('reindexes every document and reports success (item: reindex funciona)', async () => {
+    documentRows = [
+      { id: 'doc-1', title: 'Title One', content: 'Doc one' },
+      { id: 'doc-2', title: 'Title Two', content: 'Doc two' },
+    ]
+    const res = await POST()
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toMatchObject({ success: true, reindexed: 2 })
+    expect(ingestDocument).toHaveBeenCalledTimes(2)
+  })
+
+  it('derives embeddingsProvider="gemini" and passes it, WITH the document title, to ingestDocument', async () => {
+    configRow = { provider: 'gemini', embeddings_api_key: 'enc:AIzaKey' }
+    documentRows = [{ id: 'doc-1', title: 'Contacto y ubicación - Lorteg', content: 'Doc one' }]
+
+    await POST()
+
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: 'AIzaKey', embeddingsProvider: 'gemini' },
+      'doc-1',
+      'Contacto y ubicación - Lorteg',
+      'Doc one',
+    )
+  })
+
+  it('derives embeddingsProvider="openai" for an OpenAI chat account, still passing the title', async () => {
+    configRow = { provider: 'openai', embeddings_api_key: 'enc:sk-key' }
+    documentRows = [{ id: 'doc-1', title: 'Title One', content: 'Doc one' }]
+
+    await POST()
+
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: 'sk-key', embeddingsProvider: 'openai' },
+      'doc-1',
+      'Title One',
+      'Doc one',
+    )
+  })
+
+  it('reindexes lexical-only (embeddingsProvider null) when there is no embeddings key', async () => {
+    configRow = null
+    documentRows = [{ id: 'doc-1', title: 'Title One', content: 'Doc one' }]
+
+    const res = await POST()
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toMatchObject({ success: true, reindexed: 1 })
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: null, embeddingsProvider: null },
+      'doc-1',
+      'Title One',
+      'Doc one',
+    )
+  })
+
+  it('stops immediately and reindexes nothing when the stored key cannot be decrypted', async () => {
+    const { decrypt } = await import('@/lib/whatsapp/encryption')
+    ;(decrypt as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('bad key')
+    })
+    configRow = { provider: 'gemini', embeddings_api_key: 'enc:corrupt' }
+    documentRows = [{ id: 'doc-1', title: 'Title One', content: 'Doc one' }]
+
+    const res = await POST()
+    const json = await res.json()
+
+    expect(json).toMatchObject({ success: false, reindexed: 0 })
+    expect(ingestDocument).not.toHaveBeenCalled()
+  })
+
+  it('a failing document reports partial progress instead of aborting silently', async () => {
+    documentRows = [
+      { id: 'doc-1', title: 'Title One', content: 'Doc one' },
+      { id: 'doc-2', title: 'Title Two', content: 'Doc two' },
+    ]
+    ingestDocument.mockResolvedValueOnce(undefined) // doc-1 succeeds
+    ingestDocument.mockRejectedValueOnce(new Error('rate limited')) // doc-2 fails
+
+    const res = await POST()
+    const json = await res.json()
+
+    expect(json.success).toBe(false)
+    expect(json.reindexed).toBe(1)
+    expect(json.error).toContain('rate limited')
+  })
+})

--- a/src/app/api/ai/knowledge/reindex/route.ts
+++ b/src/app/api/ai/knowledge/reindex/route.ts
@@ -21,7 +21,7 @@ export async function POST() {
 
     const { data: docs, error } = await supabase
       .from('ai_knowledge_documents')
-      .select('id, content')
+      .select('id, title, content')
       .eq('account_id', accountId)
     if (error) {
       console.error('[ai/knowledge/reindex] fetch error:', error)
@@ -31,10 +31,8 @@ export async function POST() {
       )
     }
 
-    const { key: embeddingsApiKey, corrupt } = await loadEmbeddingsKey(
-      supabase,
-      accountId,
-    )
+    const { key: embeddingsApiKey, corrupt, provider: embeddingsProvider } =
+      await loadEmbeddingsKey(supabase, accountId)
     // The whole point of Reindex is usually to backfill embeddings — so
     // if a key is configured but can't be decrypted, don't quietly do a
     // lexical-only pass and report success. Stop and tell the admin.
@@ -53,7 +51,14 @@ export async function POST() {
     let reindexed = 0
     for (const doc of docs ?? []) {
       try {
-        await ingestDocument(supabase, accountId, { embeddingsApiKey }, doc.id, doc.content)
+        await ingestDocument(
+          supabase,
+          accountId,
+          { embeddingsApiKey, embeddingsProvider },
+          doc.id,
+          doc.title,
+          doc.content,
+        )
         reindexed += 1
       } catch (err) {
         // One bad document (e.g. a mid-run embeddings rate-limit) should

--- a/src/app/api/ai/knowledge/route.test.ts
+++ b/src/app/api/ai/knowledge/route.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// POST /api/ai/knowledge — focused on confirming `title` is threaded through
+// to ingestDocument() correctly (Gemini's asymmetric document format needs
+// it). Role/account-scoping/rate-limit behavior is unchanged and not
+// re-tested here.
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_ID = 'acct-1'
+const USER_ID = 'user-1'
+
+let callerRole = 'admin'
+let embeddingsKeyResult: {
+  key: string | null
+  corrupt: boolean
+  provider: 'openai' | 'gemini' | null
+} = { key: null, corrupt: false, provider: null }
+const insertedDocs: Record<string, unknown>[] = []
+
+function makeSupabaseMock() {
+  function builder(table: string) {
+    let inserted: Record<string, unknown> | undefined
+    const resolveResult = () => {
+      if (table === 'profiles') {
+        return { data: { account_id: ACCOUNT_ID, account_role: callerRole }, error: null }
+      }
+      if (table === 'accounts') {
+        return { data: { id: ACCOUNT_ID, name: 'Acme' }, error: null }
+      }
+      if (table === 'ai_knowledge_documents' && inserted) {
+        insertedDocs.push(inserted)
+        return { data: { id: 'doc-new' }, error: null }
+      }
+      return { data: null, error: null }
+    }
+    const b: Record<string, unknown> = {}
+    b.select = vi.fn(() => b)
+    b.eq = vi.fn(() => b)
+    b.maybeSingle = vi.fn(() => Promise.resolve(resolveResult()))
+    b.single = vi.fn(() => Promise.resolve(resolveResult()))
+    b.insert = vi.fn((row: Record<string, unknown>) => {
+      inserted = row
+      return b
+    })
+    return b
+  }
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: USER_ID } }, error: null })),
+    },
+    from: vi.fn((table: string) => builder(table)),
+  }
+}
+
+let supabaseMock = makeSupabaseMock()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}))
+
+const { loadEmbeddingsKey } = vi.hoisted(() => ({
+  loadEmbeddingsKey: vi.fn(),
+}))
+vi.mock('@/lib/ai/config', () => ({ loadEmbeddingsKey }))
+
+const { ingestDocument } = vi.hoisted(() => ({
+  ingestDocument: vi.fn(async () => undefined),
+}))
+vi.mock('@/lib/ai/knowledge', () => ({ ingestDocument }))
+
+import { POST } from './route'
+
+function postKnowledge(body: Record<string, unknown>) {
+  return POST(
+    new Request('http://localhost/api/ai/knowledge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+beforeEach(() => {
+  callerRole = 'admin'
+  insertedDocs.length = 0
+  embeddingsKeyResult = { key: null, corrupt: false, provider: null }
+  supabaseMock = makeSupabaseMock()
+  loadEmbeddingsKey.mockClear()
+  loadEmbeddingsKey.mockImplementation(async () => embeddingsKeyResult)
+  ingestDocument.mockClear()
+  ingestDocument.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/ai/knowledge', () => {
+  it('passes the document title through to ingestDocument (lexical-only)', async () => {
+    const res = await postKnowledge({
+      title: 'Contacto y ubicación - Lorteg',
+      content: 'Razón social...',
+    })
+    expect(res.status).toBe(200)
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: null, embeddingsProvider: null },
+      'doc-new',
+      'Contacto y ubicación - Lorteg',
+      'Razón social...',
+    )
+  })
+
+  it('passes the title through when Gemini embeddings are configured', async () => {
+    embeddingsKeyResult = { key: 'AIzaKey', corrupt: false, provider: 'gemini' }
+    const res = await postKnowledge({
+      title: 'Productos y categorías - Lorteg',
+      content: 'Taladros, tornillos...',
+    })
+    expect(res.status).toBe(200)
+    expect(ingestDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      ACCOUNT_ID,
+      { embeddingsApiKey: 'AIzaKey', embeddingsProvider: 'gemini' },
+      'doc-new',
+      'Productos y categorías - Lorteg',
+      'Taladros, tornillos...',
+    )
+  })
+
+  it('persists the raw title/content — trimmed, but never prefixed', async () => {
+    await postKnowledge({ title: '  My Title  ', content: '  My content.  ' })
+    expect(insertedDocs[0]).toMatchObject({ title: 'My Title', content: 'My content.' })
+  })
+
+  it('400s when title or content is missing', async () => {
+    const res = await postKnowledge({ title: '', content: 'x' })
+    expect(res.status).toBe(400)
+    expect(ingestDocument).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/ai/knowledge/route.ts
+++ b/src/app/api/ai/knowledge/route.ts
@@ -70,16 +70,15 @@ export async function POST(request: Request) {
       )
     }
 
-    const { key: embeddingsApiKey, corrupt } = await loadEmbeddingsKey(
-      supabase,
-      accountId,
-    )
+    const { key: embeddingsApiKey, corrupt, provider: embeddingsProvider } =
+      await loadEmbeddingsKey(supabase, accountId)
     try {
       await ingestDocument(
         supabase,
         accountId,
-        { embeddingsApiKey },
+        { embeddingsApiKey, embeddingsProvider },
         doc.id,
+        title,
         content,
       )
     } catch (err) {

--- a/src/app/api/ai/test/route.test.ts
+++ b/src/app/api/ai/test/route.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Gemini-focused coverage for POST /api/ai/test ("Test key" button).
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_ID = 'acct-1'
+const USER_ID = 'user-1'
+
+let callerRole = 'admin'
+let storedConfigRow: Record<string, unknown> | null = null
+
+function makeSupabaseMock() {
+  function builder(table: string) {
+    const resolveResult = () => {
+      if (table === 'profiles') {
+        return { data: { account_id: ACCOUNT_ID, account_role: callerRole }, error: null }
+      }
+      if (table === 'accounts') {
+        return { data: { id: ACCOUNT_ID, name: 'Acme' }, error: null }
+      }
+      if (table === 'ai_configs') {
+        return { data: storedConfigRow, error: null }
+      }
+      return { data: null, error: null }
+    }
+    const b: Record<string, unknown> = {}
+    b.select = vi.fn(() => b)
+    b.eq = vi.fn(() => b)
+    b.maybeSingle = vi.fn(() => Promise.resolve(resolveResult()))
+    return b
+  }
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: USER_ID } }, error: null })),
+    },
+    from: vi.fn((table: string) => builder(table)),
+  }
+}
+
+let supabaseMock = makeSupabaseMock()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}))
+
+vi.mock('@/lib/whatsapp/encryption', () => ({
+  encrypt: vi.fn((v: string) => `enc:${v}`),
+  decrypt: vi.fn((v: string) => v.replace(/^enc:/, '')),
+}))
+
+const { validateAiCredentials } = vi.hoisted(() => ({
+  validateAiCredentials: vi.fn(async () => undefined),
+}))
+vi.mock('@/lib/ai/validate', () => ({ validateAiCredentials }))
+
+import { POST } from './route'
+
+function postTest(body: Record<string, unknown>) {
+  return POST(
+    new Request('http://localhost/api/ai/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+beforeEach(() => {
+  callerRole = 'admin'
+  storedConfigRow = null
+  supabaseMock = makeSupabaseMock()
+  validateAiCredentials.mockClear()
+  validateAiCredentials.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/ai/test — accepts gemini', () => {
+  it('validates a Gemini key via validateAiCredentials → generateReply → generateGemini', async () => {
+    const res = await postTest({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'AIzaSyGeminiTestKey',
+    })
+
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.ok).toBe(true)
+    expect(validateAiCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'gemini',
+        model: 'gemini-3.8-flash',
+        apiKey: 'AIzaSyGeminiTestKey',
+      }),
+    )
+  })
+
+  it('rejects an invalid provider with 400, still', async () => {
+    const res = await postTest({ provider: 'llama', model: 'x', api_key: 'k' })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/provider must be/i)
+    expect(validateAiCredentials).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a Gemini invalid_key rejection as 400 with the code', async () => {
+    const { AiError } = await import('@/lib/ai/types')
+    validateAiCredentials.mockRejectedValue(
+      new AiError('Gemini rejected the API key', { code: 'invalid_key', status: 401 }),
+    )
+    const res = await postTest({
+      provider: 'gemini',
+      model: 'gemini-3.8-flash',
+      api_key: 'bad-key',
+    })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('invalid_key')
+  })
+
+  it('reuses the stored (decrypted) key when none is supplied, and never echoes it back', async () => {
+    storedConfigRow = { api_key: 'enc:AIzaStoredKey' }
+
+    const res = await postTest({ provider: 'gemini', model: 'gemini-3.8-flash' })
+
+    expect(res.status).toBe(200)
+    expect(validateAiCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'AIzaStoredKey' }),
+    )
+    const json = await res.json()
+    expect(JSON.stringify(json)).not.toContain('AIzaStoredKey')
+  })
+
+  it('never logs the API key on a failed validation', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { AiError } = await import('@/lib/ai/types')
+    validateAiCredentials.mockRejectedValue(
+      new AiError('rejected', { code: 'invalid_key', status: 401 }),
+    )
+
+    await postTest({ provider: 'gemini', model: 'gemini-3.8-flash', api_key: 'AIzaSecretHere' })
+
+    const logged = errorSpy.mock.calls
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join('\n')
+    expect(logged).not.toContain('AIzaSecretHere')
+    errorSpy.mockRestore()
+  })
+})

--- a/src/app/api/ai/test/route.ts
+++ b/src/app/api/ai/test/route.ts
@@ -27,9 +27,9 @@ export async function POST(request: Request) {
     }
 
     const provider = body.provider as AiProvider
-    if (provider !== 'openai' && provider !== 'anthropic') {
+    if (provider !== 'openai' && provider !== 'anthropic' && provider !== 'gemini') {
       return NextResponse.json(
-        { error: 'provider must be "openai" or "anthropic"' },
+        { error: 'provider must be "openai", "anthropic", or "gemini"' },
         { status: 400 },
       )
     }

--- a/src/app/api/ai/test/route.ts
+++ b/src/app/api/ai/test/route.ts
@@ -73,6 +73,7 @@ export async function POST(request: Request) {
         autoReplyMaxPerConversation: 3,
         handoffAgentId: null,
         embeddingsApiKey: null,
+        embeddingsProvider: null,
       })
     } catch (err) {
       if (err instanceof AiError) {

--- a/src/app/api/integrations/manychat/inbound/route.test.ts
+++ b/src/app/api/integrations/manychat/inbound/route.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const h = vi.hoisted(() => ({
+  findOrCreateContact: vi.fn(),
+  findOrCreateConversation: vi.fn(),
+  reopenClosedConversation: vi.fn(),
+  state: {
+    configRow: { account_id: 'acc-1', user_id: 'user-1' } as
+      | { account_id: string; user_id: string }
+      | null,
+    configError: null as { message: string } | null,
+    /** Result the message upsert's .select() resolves to. */
+    messageUpsertResult: [{ id: 'msg-1' }] as { id: string }[],
+    messageUpsertError: null as { message: string } | null,
+    upsertCalls: [] as { row: Record<string, unknown>; options: unknown }[],
+    rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+  },
+}))
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    }),
+  },
+}))
+
+vi.mock('@/lib/automations/admin-client', () => ({
+  supabaseAdmin: () => ({
+    from(table: string) {
+      switch (table) {
+        case 'whatsapp_config':
+          return {
+            select: () => ({
+              eq: () => ({
+                maybeSingle: () =>
+                  Promise.resolve({
+                    data: h.state.configRow,
+                    error: h.state.configError,
+                  }),
+              }),
+            }),
+          }
+        case 'messages':
+          return {
+            upsert: (row: Record<string, unknown>, options: unknown) => {
+              h.state.upsertCalls.push({ row, options })
+              return {
+                select: () =>
+                  Promise.resolve({
+                    data: h.state.messageUpsertError ? null : h.state.messageUpsertResult,
+                    error: h.state.messageUpsertError,
+                  }),
+              }
+            },
+          }
+        default:
+          throw new Error(`unexpected table: ${table}`)
+      }
+    },
+    rpc: (name: string, args: Record<string, unknown>) => {
+      h.state.rpcCalls.push({ name, args })
+      return Promise.resolve({ data: null, error: null })
+    },
+  }),
+}))
+
+vi.mock('@/lib/contacts/find-or-create', () => ({
+  findOrCreateContact: h.findOrCreateContact,
+}))
+vi.mock('@/lib/conversations/find-or-create', () => ({
+  findOrCreateConversation: h.findOrCreateConversation,
+}))
+vi.mock('@/lib/conversations/reopen', () => ({
+  reopenClosedConversation: h.reopenClosedConversation,
+}))
+
+import { POST } from './route'
+
+const VALID_SECRET = 'test-manychat-secret'
+const VALID_ACCOUNT_ID = 'acc-1'
+
+function inboundRequest(
+  body: unknown,
+  opts: { auth?: string | null; rawText?: string } = {},
+): Request {
+  const headers = new Headers({ 'content-type': 'application/json' })
+  if (opts.auth !== null) {
+    headers.set('authorization', opts.auth ?? `Bearer ${VALID_SECRET}`)
+  }
+  return new Request('https://crm.example.com/api/integrations/manychat/inbound', {
+    method: 'POST',
+    headers,
+    body: opts.rawText ?? JSON.stringify(body),
+  })
+}
+
+const VALID_PAYLOAD = {
+  contact_id: 'mc-contact-1',
+  whatsapp_id: '+1 (555) 123-0000',
+  full_name: 'Ada Lovelace',
+  text: 'Hola, tengo una pregunta',
+  last_interaction: '2026-01-01T12:00:00.000Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.MANYCHAT_INGEST_SECRET = VALID_SECRET
+  process.env.MANYCHAT_INGEST_ACCOUNT_ID = VALID_ACCOUNT_ID
+  h.state.configRow = { account_id: 'acc-1', user_id: 'user-1' }
+  h.state.configError = null
+  h.state.messageUpsertResult = [{ id: 'msg-1' }]
+  h.state.messageUpsertError = null
+  h.state.upsertCalls = []
+  h.state.rpcCalls = []
+  h.findOrCreateContact.mockResolvedValue({
+    contact: { id: 'contact-1', name: 'Ada Lovelace', phone: '15551230000' },
+    wasCreated: false,
+  })
+  h.findOrCreateConversation.mockResolvedValue({
+    conversation: { id: 'conv-1', status: 'open', account_id: 'acc-1' },
+    created: false,
+  })
+  h.reopenClosedConversation.mockResolvedValue(false)
+})
+
+afterEach(() => {
+  delete process.env.MANYCHAT_INGEST_SECRET
+  delete process.env.MANYCHAT_INGEST_ACCOUNT_ID
+})
+
+describe('auth', () => {
+  it('503s when the bridge has no secret configured', async () => {
+    delete process.env.MANYCHAT_INGEST_SECRET
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(503)
+    expect(h.findOrCreateContact).not.toHaveBeenCalled()
+  })
+
+  it('503s when the bridge has no account id configured', async () => {
+    delete process.env.MANYCHAT_INGEST_ACCOUNT_ID
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(503)
+  })
+
+  it('401s when the Authorization header is missing', async () => {
+    const res = await POST(inboundRequest(VALID_PAYLOAD, { auth: null }))
+    expect(res.status).toBe(401)
+    expect(h.findOrCreateContact).not.toHaveBeenCalled()
+  })
+
+  it('401s when the bearer secret is wrong', async () => {
+    const res = await POST(inboundRequest(VALID_PAYLOAD, { auth: 'Bearer wrong-secret' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('401s on a non-Bearer Authorization header', async () => {
+    const res = await POST(inboundRequest(VALID_PAYLOAD, { auth: `Basic ${VALID_SECRET}` }))
+    expect(res.status).toBe(401)
+  })
+
+  it('accepts the request with no user session / cookies at all', async () => {
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(201)
+  })
+
+  // timingSafeEqual (node:crypto) throws RangeError on a buffer-length
+  // mismatch rather than returning false — the route must never let a
+  // supplied secret of a different length than MANYCHAT_INGEST_SECRET
+  // reach it directly. Exercise both directions so a regression that
+  // removes the length pre-check surfaces as an unhandled rejection
+  // here instead of a 500 in production.
+  it('does not throw when the supplied secret is shorter than the configured one', async () => {
+    await expect(
+      POST(inboundRequest(VALID_PAYLOAD, { auth: 'Bearer x' })),
+    ).resolves.toMatchObject({ status: 401 })
+  })
+
+  it('does not throw when the supplied secret is longer than the configured one', async () => {
+    await expect(
+      POST(inboundRequest(VALID_PAYLOAD, { auth: `Bearer ${VALID_SECRET}${'x'.repeat(500)}` })),
+    ).resolves.toMatchObject({ status: 401 })
+  })
+
+  it('does not throw on an empty bearer token', async () => {
+    await expect(
+      POST(inboundRequest(VALID_PAYLOAD, { auth: 'Bearer ' })),
+    ).resolves.toMatchObject({ status: 401 })
+  })
+})
+
+describe('payload validation', () => {
+  it('400s on invalid JSON', async () => {
+    const res = await POST(
+      inboundRequest(null, { rawText: '{not json' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it.each([
+    ['missing contact_id', { ...VALID_PAYLOAD, contact_id: undefined }],
+    ['empty contact_id', { ...VALID_PAYLOAD, contact_id: '   ' }],
+    ['missing whatsapp_id', { ...VALID_PAYLOAD, whatsapp_id: undefined }],
+    ['missing text', { ...VALID_PAYLOAD, text: undefined }],
+    ['empty text', { ...VALID_PAYLOAD, text: '' }],
+    ['wrong type for text', { ...VALID_PAYLOAD, text: 12345 }],
+    ['text over the size limit', { ...VALID_PAYLOAD, text: 'x'.repeat(8001) }],
+    ['full_name wrong type', { ...VALID_PAYLOAD, full_name: 42 }],
+    ['whatsapp_id has no digits', { ...VALID_PAYLOAD, whatsapp_id: 'abc' }],
+  ])('400s on %s', async (_label, payload) => {
+    const res = await POST(inboundRequest(payload))
+    expect(res.status).toBe(400)
+    expect(h.findOrCreateContact).not.toHaveBeenCalled()
+  })
+
+  it('allows an empty full_name', async () => {
+    const res = await POST(inboundRequest({ ...VALID_PAYLOAD, full_name: '' }))
+    expect(res.status).toBe(201)
+  })
+})
+
+describe('account resolution', () => {
+  it('404s when MANYCHAT_INGEST_ACCOUNT_ID has no whatsapp_config row', async () => {
+    h.state.configRow = null
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(404)
+    expect(h.findOrCreateContact).not.toHaveBeenCalled()
+  })
+
+  it('500s when the whatsapp_config lookup errors', async () => {
+    h.state.configError = { message: 'db down' }
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(500)
+  })
+
+  it('never trusts an account_id/user_id from the request body', async () => {
+    await POST(
+      inboundRequest({
+        ...VALID_PAYLOAD,
+        account_id: 'attacker-acc',
+        user_id: 'attacker-user',
+      }),
+    )
+    expect(h.findOrCreateContact).toHaveBeenCalledWith(
+      expect.anything(),
+      'acc-1',
+      'user-1',
+      expect.any(String),
+      expect.any(String),
+    )
+  })
+})
+
+describe('new message', () => {
+  it('inserts exactly once via the idempotent upsert and returns 201', async () => {
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+
+    expect(res.status).toBe(201)
+    expect(h.state.upsertCalls).toHaveLength(1)
+    expect(h.state.upsertCalls[0].options).toMatchObject({
+      onConflict: 'conversation_id,message_id',
+      ignoreDuplicates: true,
+    })
+    expect(h.state.upsertCalls[0].row).toMatchObject({
+      conversation_id: 'conv-1',
+      sender_type: 'customer',
+      content_type: 'text',
+      content_text: VALID_PAYLOAD.text,
+      status: 'delivered',
+      created_at: '2026-01-01T12:00:00.000Z',
+    })
+    expect(String(h.state.upsertCalls[0].row.message_id)).toMatch(/^manychat:/)
+  })
+
+  it('bumps the conversation via the same RPC the Meta webhook uses', async () => {
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.rpcCalls).toHaveLength(1)
+    expect(h.state.rpcCalls[0]).toMatchObject({
+      name: 'bump_conversation_on_inbound',
+      args: { p_conversation_id: 'conv-1', p_last_message_text: VALID_PAYLOAD.text },
+    })
+  })
+
+  it('reopens a closed conversation', async () => {
+    h.findOrCreateConversation.mockResolvedValue({
+      conversation: { id: 'conv-1', status: 'closed', account_id: 'acc-1' },
+      created: false,
+    })
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.reopenClosedConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'conv-1', status: 'closed' }),
+    )
+  })
+
+  it('uses `manychat:<external_id>` as the message_id when external_id is provided', async () => {
+    await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-42' }))
+    expect(h.state.upsertCalls[0].row.message_id).toBe('manychat:mc-evt-42')
+  })
+
+  it('derives a deterministic hash id from contact_id + last_interaction + text when external_id is absent', async () => {
+    await POST(inboundRequest(VALID_PAYLOAD))
+    const firstId = h.state.upsertCalls[0].row.message_id
+
+    h.state.upsertCalls = []
+    await POST(inboundRequest(VALID_PAYLOAD))
+    const secondId = h.state.upsertCalls[0].row.message_id
+
+    expect(firstId).toBe(secondId)
+  })
+
+  it('falls back to new Date() for an unparseable timestamp', async () => {
+    const before = Date.now()
+    await POST(inboundRequest({ ...VALID_PAYLOAD, last_interaction: 'not-a-date' }))
+    const after = Date.now()
+
+    const createdAt = new Date(
+      h.state.upsertCalls[0].row.created_at as string,
+    ).getTime()
+    expect(createdAt).toBeGreaterThanOrEqual(before)
+    expect(createdAt).toBeLessThanOrEqual(after)
+  })
+})
+
+describe('retry / duplicate delivery', () => {
+  it('does not duplicate the message and returns 200, not 201', async () => {
+    await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-99' }))
+    expect(h.state.rpcCalls).toHaveLength(1)
+
+    // Simulate the DB's unique-index conflict on the retry: the upsert
+    // resolves with zero rows.
+    h.state.messageUpsertResult = []
+    const res = await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-99' }))
+
+    expect(res.status).toBe(200)
+    expect(h.state.upsertCalls).toHaveLength(2)
+    // Unread must NOT be bumped a second time.
+    expect(h.state.rpcCalls).toHaveLength(1)
+    expect(h.reopenClosedConversation).toHaveBeenCalledTimes(1)
+  })
+
+  it('500s if the message upsert itself errors', async () => {
+    h.state.messageUpsertError = { message: 'constraint violation' }
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(500)
+    expect(h.state.rpcCalls).toHaveLength(0)
+  })
+})
+
+describe('never dispatches AI / Flows / Automations / outbound sends', () => {
+  it('does not import the AI reply, Flows, or Automations engines, or any WhatsApp send path', () => {
+    const source = readFileSync(join(__dirname, 'route.ts'), 'utf8')
+    expect(source).not.toMatch(/dispatchInboundToAiReply/)
+    expect(source).not.toMatch(/dispatchInboundToFlows/)
+    expect(source).not.toMatch(/runAutomationsForTrigger/)
+    expect(source).not.toMatch(/dispatchWebhookEvent/)
+    expect(source).not.toMatch(/@\/lib\/whatsapp\/meta-api/)
+    expect(source).not.toMatch(/@\/lib\/ai\//)
+    expect(source).not.toMatch(/@\/lib\/flows\//)
+    expect(source).not.toMatch(/@\/lib\/automations\/engine/)
+  })
+})
+
+describe('never logs the bearer secret', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+    logSpy.mockRestore()
+  })
+
+  /** Every argument logged across all three console methods, flattened to strings. */
+  function loggedText(): string {
+    const calls = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...logSpy.mock.calls]
+    return calls
+      .flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join('\n')
+  }
+
+  it('does not log the secret on a wrong-secret 401', async () => {
+    await POST(inboundRequest(VALID_PAYLOAD, { auth: 'Bearer wrong-secret' }))
+    const text = loggedText()
+    expect(text).not.toContain(VALID_SECRET)
+    expect(text).not.toContain('wrong-secret')
+  })
+
+  it('does not log the secret when the whatsapp_config lookup errors', async () => {
+    h.state.configError = { message: 'db down' }
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(loggedText()).not.toContain(VALID_SECRET)
+  })
+
+  it('does not log the secret when the message insert errors', async () => {
+    h.state.messageUpsertError = { message: 'constraint violation' }
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(loggedText()).not.toContain(VALID_SECRET)
+  })
+
+  it('does not log the secret on a genuine successful insert', async () => {
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(loggedText()).not.toContain(VALID_SECRET)
+  })
+})

--- a/src/app/api/integrations/manychat/inbound/route.test.ts
+++ b/src/app/api/integrations/manychat/inbound/route.test.ts
@@ -16,6 +16,8 @@ const h = vi.hoisted(() => ({
     messageUpsertError: null as { message: string } | null,
     upsertCalls: [] as { row: Record<string, unknown>; options: unknown }[],
     rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+    linkUpsertCalls: [] as { row: Record<string, unknown>; options: unknown }[],
+    linkUpsertError: null as { message: string } | null,
   },
 }))
 
@@ -55,6 +57,13 @@ vi.mock('@/lib/automations/admin-client', () => ({
                     error: h.state.messageUpsertError,
                   }),
               }
+            },
+          }
+        case 'manychat_contact_links':
+          return {
+            upsert: (row: Record<string, unknown>, options: unknown) => {
+              h.state.linkUpsertCalls.push({ row, options })
+              return Promise.resolve({ data: null, error: h.state.linkUpsertError })
             },
           }
         default:
@@ -116,6 +125,8 @@ beforeEach(() => {
   h.state.messageUpsertError = null
   h.state.upsertCalls = []
   h.state.rpcCalls = []
+  h.state.linkUpsertCalls = []
+  h.state.linkUpsertError = null
   h.findOrCreateContact.mockResolvedValue({
     contact: { id: 'contact-1', name: 'Ada Lovelace', phone: '15551230000' },
     wasCreated: false,
@@ -322,6 +333,60 @@ describe('new message', () => {
     ).getTime()
     expect(createdAt).toBeGreaterThanOrEqual(before)
     expect(createdAt).toBeLessThanOrEqual(after)
+  })
+})
+
+describe('manychat_contact_links mapping', () => {
+  it('upserts the ManyChat↔CRM contact mapping on a new message', async () => {
+    await POST(inboundRequest(VALID_PAYLOAD))
+
+    expect(h.state.linkUpsertCalls).toHaveLength(1)
+    expect(h.state.linkUpsertCalls[0].options).toMatchObject({
+      onConflict: 'account_id,contact_id',
+    })
+    expect(h.state.linkUpsertCalls[0].row).toMatchObject({
+      account_id: 'acc-1',
+      contact_id: 'contact-1',
+      manychat_contact_id: VALID_PAYLOAD.contact_id,
+      whatsapp_id: VALID_PAYLOAD.whatsapp_id,
+    })
+    expect(typeof h.state.linkUpsertCalls[0].row.updated_at).toBe('string')
+  })
+
+  it('also upserts the mapping on a retry/duplicate delivery', async () => {
+    await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-link' }))
+    expect(h.state.linkUpsertCalls).toHaveLength(1)
+
+    // Simulate the retry: the message upsert conflicts and returns zero rows.
+    h.state.messageUpsertResult = []
+    const res = await POST(
+      inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-link' }),
+    )
+
+    expect(res.status).toBe(200)
+    // The mapping write still ran a second time — it's independent of
+    // message idempotency.
+    expect(h.state.linkUpsertCalls).toHaveLength(2)
+  })
+
+  it('still mirrors the message into the Inbox even if the mapping write fails', async () => {
+    h.state.linkUpsertError = { message: 'constraint violation' }
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+
+    expect(res.status).toBe(201)
+    expect(h.state.upsertCalls).toHaveLength(1)
+  })
+
+  it('never trusts a manychat_contact_id other than payload.contact_id', async () => {
+    await POST(
+      inboundRequest({
+        ...VALID_PAYLOAD,
+        manychat_contact_id: 'attacker-controlled',
+      }),
+    )
+    expect(h.state.linkUpsertCalls[0].row.manychat_contact_id).toBe(
+      VALID_PAYLOAD.contact_id,
+    )
   })
 })
 

--- a/src/app/api/integrations/manychat/inbound/route.test.ts
+++ b/src/app/api/integrations/manychat/inbound/route.test.ts
@@ -6,6 +6,7 @@ const h = vi.hoisted(() => ({
   findOrCreateContact: vi.fn(),
   findOrCreateConversation: vi.fn(),
   reopenClosedConversation: vi.fn(),
+  dispatchInboundToAiReply: vi.fn(),
   state: {
     configRow: { account_id: 'acc-1', user_id: 'user-1' } as
       | { account_id: string; user_id: string }
@@ -18,6 +19,8 @@ const h = vi.hoisted(() => ({
     rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
     linkUpsertCalls: [] as { row: Record<string, unknown>; options: unknown }[],
     linkUpsertError: null as { message: string } | null,
+    /** Callbacks registered via after() — drain explicitly in a test to simulate post-response work. */
+    afterCallbacks: [] as (() => Promise<void> | void)[],
   },
 }))
 
@@ -28,6 +31,13 @@ vi.mock('next/server', () => ({
       status: init?.status ?? 200,
     }),
   },
+  after: (cb: () => Promise<void> | void) => {
+    h.state.afterCallbacks.push(cb)
+  },
+}))
+
+vi.mock('@/lib/ai/auto-reply', () => ({
+  dispatchInboundToAiReply: h.dispatchInboundToAiReply,
 }))
 
 vi.mock('@/lib/automations/admin-client', () => ({
@@ -115,6 +125,11 @@ const VALID_PAYLOAD = {
   last_interaction: '2026-01-01T12:00:00.000Z',
 }
 
+/** Runs every after() callback registered so far, exactly as the runtime would post-response. */
+async function drainAfterCallbacks() {
+  for (const cb of h.state.afterCallbacks) await cb()
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   process.env.MANYCHAT_INGEST_SECRET = VALID_SECRET
@@ -127,6 +142,7 @@ beforeEach(() => {
   h.state.rpcCalls = []
   h.state.linkUpsertCalls = []
   h.state.linkUpsertError = null
+  h.state.afterCallbacks = []
   h.findOrCreateContact.mockResolvedValue({
     contact: { id: 'contact-1', name: 'Ada Lovelace', phone: '15551230000' },
     wasCreated: false,
@@ -136,11 +152,13 @@ beforeEach(() => {
     created: false,
   })
   h.reopenClosedConversation.mockResolvedValue(false)
+  h.dispatchInboundToAiReply.mockResolvedValue(undefined)
 })
 
 afterEach(() => {
   delete process.env.MANYCHAT_INGEST_SECRET
   delete process.env.MANYCHAT_INGEST_ACCOUNT_ID
+  delete process.env.MANYCHAT_AI_AUTOREPLY_ENABLED
 })
 
 describe('auth', () => {
@@ -415,17 +433,228 @@ describe('retry / duplicate delivery', () => {
   })
 })
 
-describe('never dispatches AI / Flows / Automations / outbound sends', () => {
-  it('does not import the AI reply, Flows, or Automations engines, or any WhatsApp send path', () => {
+describe('never dispatches Flows / Automations / public webhooks / direct WhatsApp sends', () => {
+  it('imports dispatchInboundToAiReply (feature-flagged), but never Flows, Automations, public webhook fan-out, or any WhatsApp send path', () => {
     const source = readFileSync(join(__dirname, 'route.ts'), 'utf8')
-    expect(source).not.toMatch(/dispatchInboundToAiReply/)
+    // AI is intentionally wired in as of this change — locked in as a
+    // positive assertion so a future edit can't silently rip it back
+    // out along with something else.
+    expect(source).toMatch(/dispatchInboundToAiReply/)
+    expect(source).toMatch(/@\/lib\/ai\/auto-reply/)
+    // Everything else stays forbidden — this route is still a mirror
+    // for everything except AI.
     expect(source).not.toMatch(/dispatchInboundToFlows/)
     expect(source).not.toMatch(/runAutomationsForTrigger/)
     expect(source).not.toMatch(/dispatchWebhookEvent/)
     expect(source).not.toMatch(/@\/lib\/whatsapp\/meta-api/)
-    expect(source).not.toMatch(/@\/lib\/ai\//)
     expect(source).not.toMatch(/@\/lib\/flows\//)
     expect(source).not.toMatch(/@\/lib\/automations\/engine/)
+  })
+})
+
+describe('AI auto-reply dispatch (MANYCHAT_AI_AUTOREPLY_ENABLED)', () => {
+  it('feature flag absent → does not schedule AI', async () => {
+    delete process.env.MANYCHAT_AI_AUTOREPLY_ENABLED
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(201)
+    expect(h.state.afterCallbacks).toHaveLength(0)
+    expect(h.dispatchInboundToAiReply).not.toHaveBeenCalled()
+  })
+
+  it('feature flag "false" → does not schedule AI', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'false'
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.afterCallbacks).toHaveLength(0)
+  })
+
+  it('feature flag any value other than the exact string "true" → does not schedule AI', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'TRUE'
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.afterCallbacks).toHaveLength(0)
+  })
+
+  it('flag=true + a genuine new message → schedules AI exactly once, via after()', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+
+    expect(res.status).toBe(201)
+    // The response resolved WITHOUT the after() callback having run —
+    // proves the HTTP response never waited on the LLM call.
+    expect(h.dispatchInboundToAiReply).not.toHaveBeenCalled()
+    expect(h.state.afterCallbacks).toHaveLength(1)
+
+    await drainAfterCallbacks()
+    expect(h.dispatchInboundToAiReply).toHaveBeenCalledTimes(1)
+  })
+
+  it('duplicate/retry → does not schedule AI a second time', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-ai' }))
+    expect(h.state.afterCallbacks).toHaveLength(1)
+
+    // Simulate the retry: the message upsert conflicts and returns zero rows.
+    h.state.afterCallbacks = []
+    h.state.messageUpsertResult = []
+    const res = await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-ai' }))
+
+    expect(res.status).toBe(200)
+    expect(h.state.afterCallbacks).toHaveLength(0)
+    expect(h.dispatchInboundToAiReply).not.toHaveBeenCalled()
+  })
+
+  it('invalid payload → does not schedule AI', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    const res = await POST(inboundRequest({ ...VALID_PAYLOAD, text: '' }))
+    expect(res.status).toBe(400)
+    expect(h.state.afterCallbacks).toHaveLength(0)
+  })
+
+  it('the ManyChat↔CRM mapping upsert still runs exactly as before', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.linkUpsertCalls).toHaveLength(1)
+  })
+
+  it('the unread bump (RPC) still runs exactly once', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.rpcCalls).toHaveLength(1)
+  })
+
+  it('reopen still runs for a closed conversation', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    h.findOrCreateConversation.mockResolvedValue({
+      conversation: { id: 'conv-1', status: 'closed', account_id: 'acc-1' },
+      created: false,
+    })
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.reopenClosedConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'conv-1', status: 'closed' }),
+    )
+  })
+
+  it('AI receives exactly the server-resolved accountId/conversationId/contactId/configOwnerUserId — never client-supplied ids', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    h.findOrCreateContact.mockResolvedValue({
+      contact: { id: 'contact-xyz', name: 'Ada', phone: '15551230000' },
+      wasCreated: false,
+    })
+    h.findOrCreateConversation.mockResolvedValue({
+      conversation: { id: 'conv-xyz', status: 'open', account_id: 'acc-1' },
+      created: false,
+    })
+
+    await POST(
+      inboundRequest({
+        ...VALID_PAYLOAD,
+        account_id: 'attacker-acc',
+        user_id: 'attacker-user',
+        conversation_id: 'attacker-conv',
+      }),
+    )
+    await drainAfterCallbacks()
+
+    expect(h.dispatchInboundToAiReply).toHaveBeenCalledWith({
+      accountId: 'acc-1',
+      conversationId: 'conv-xyz',
+      contactId: 'contact-xyz',
+      configOwnerUserId: 'user-1',
+      suppressWhenAutomationsActive: false,
+    })
+  })
+})
+
+describe('AI auto-reply allowlist (MANYCHAT_AI_AUTOREPLY_CONTACT_IDS)', () => {
+  afterEach(() => {
+    delete process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS
+  })
+
+  it('enabled + allowlist contains the current contact_id → schedules AI', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = 'mc-contact-1'
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    expect(res.status).toBe(201)
+    expect(h.state.afterCallbacks).toHaveLength(1)
+  })
+
+  it('enabled + allowlist does NOT contain the current contact_id → does not schedule AI', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = 'someone-else,another-one'
+    const res = await POST(inboundRequest(VALID_PAYLOAD))
+    // The message itself still mirrors into the Inbox fine — only the
+    // AI dispatch is withheld.
+    expect(res.status).toBe(201)
+    expect(h.state.afterCallbacks).toHaveLength(0)
+    expect(h.state.upsertCalls).toHaveLength(1)
+  })
+
+  it('parses whitespace/comma-separated ids correctly (trim + exact match)', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = '  someone-else , mc-contact-1 ,, another '
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.afterCallbacks).toHaveLength(1)
+  })
+
+  it('an empty allowlist string ("") falls back to normal (all eligible contacts) behavior', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = ''
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.afterCallbacks).toHaveLength(1)
+  })
+
+  it('an allowlist that trims to nothing (only commas/whitespace) falls back to normal behavior', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = ' , , '
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.afterCallbacks).toHaveLength(1)
+  })
+
+  it('variable absent → normal (all eligible contacts) behavior', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    delete process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS
+    await POST(inboundRequest(VALID_PAYLOAD))
+    expect(h.state.afterCallbacks).toHaveLength(1)
+  })
+
+  it('a retry/duplicate never schedules AI, even for an allowlisted contact', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = 'mc-contact-1'
+    await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-allow' }))
+    expect(h.state.afterCallbacks).toHaveLength(1)
+
+    // Simulate the retry: the message upsert conflicts and returns zero rows.
+    h.state.afterCallbacks = []
+    h.state.messageUpsertResult = []
+    const res = await POST(inboundRequest({ ...VALID_PAYLOAD, external_id: 'mc-evt-allow' }))
+
+    expect(res.status).toBe(200)
+    expect(h.state.afterCallbacks).toHaveLength(0)
+  })
+
+  it('an invalid payload never schedules AI, even for an allowlisted contact', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = 'mc-contact-1'
+    const res = await POST(inboundRequest({ ...VALID_PAYLOAD, text: '' }))
+    expect(res.status).toBe(400)
+    expect(h.state.afterCallbacks).toHaveLength(0)
+  })
+
+  it('only payload.contact_id is checked against the allowlist — other body fields cannot spoof a match', async () => {
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED = 'true'
+    process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS = 'mc-contact-1'
+    // The real contact_id ('mc-other') is NOT allowlisted; smuggling
+    // 'mc-contact-1' under unrelated field names must not count.
+    const res = await POST(
+      inboundRequest({
+        ...VALID_PAYLOAD,
+        contact_id: 'mc-other',
+        manychat_contact_id: 'mc-contact-1',
+        account_id: 'mc-contact-1',
+      }),
+    )
+    expect(res.status).toBe(201)
+    expect(h.state.afterCallbacks).toHaveLength(0)
   })
 })
 

--- a/src/app/api/integrations/manychat/inbound/route.ts
+++ b/src/app/api/integrations/manychat/inbound/route.ts
@@ -1,21 +1,45 @@
 import { createHash, timingSafeEqual } from 'node:crypto'
-import { NextResponse } from 'next/server'
+import { NextResponse, after } from 'next/server'
 import { supabaseAdmin } from '@/lib/automations/admin-client'
 import { normalizePhone } from '@/lib/whatsapp/phone-utils'
 import { findOrCreateContact } from '@/lib/contacts/find-or-create'
 import { findOrCreateConversation } from '@/lib/conversations/find-or-create'
 import { reopenClosedConversation } from '@/lib/conversations/reopen'
+import { dispatchInboundToAiReply } from '@/lib/ai/auto-reply'
 
 /**
  * TEMPORARY bridge: mirrors inbound WhatsApp messages from ManyChat
  * (still the live-sending platform during this migration window) into
- * the WA CRM Inbox — contact, conversation, message only.
+ * the WA CRM Inbox — contact, conversation, message, mapping, and
+ * (optionally) AI auto-reply.
  *
- * Deliberately does NOT: send to WhatsApp, run AI auto-reply, run
- * Flows, or run Automations. This route is a read-only mirror of
- * ManyChat's own inbound handling, so those engines must never see a
- * message that originated here — remove this route once ManyChat is
- * decommissioned.
+ * Deliberately does NOT: send to WhatsApp directly, run Flows, or run
+ * Automations. This route is a read-only mirror of ManyChat's own
+ * inbound handling for everything except AI — those two engines must
+ * never see a message that originated here — remove this route once
+ * ManyChat is decommissioned.
+ *
+ * AI auto-reply IS wired up, but only when ALL of these hold:
+ *   - MANYCHAT_AI_AUTOREPLY_ENABLED === 'true' (server-only flag,
+ *     default/absent = false — see .env.local.example);
+ *   - this delivery was a genuine new message, not a retry/duplicate
+ *     (the idempotent message upsert below already tells us this);
+ *   - there's non-empty text (already guaranteed by payload validation,
+ *     re-checked here for clarity of the gate);
+ *   - MANYCHAT_AI_AUTOREPLY_CONTACT_IDS is either unset/empty (normal
+ *     production behavior — every eligible contact), or it's set and
+ *     the ManyChat contact_id THIS ROUTE ALREADY VALIDATED is exactly
+ *     in that list (controlled rollout — see `isManyChatAiAutoreplyAllowed`).
+ * When it fires, the LLM call is deferred via `after()` (same pattern
+ * the native Meta webhook uses) so ManyChat's External Request gets its
+ * 201 immediately and never blocks on OpenAI/Anthropic latency.
+ * `dispatchInboundToAiReply` owns its own eligibility gates (auto-reply
+ * enabled for the account, no human assigned, reply cap, etc.) and
+ * never throws — this route doesn't duplicate any of that logic. It's
+ * called with `suppressWhenAutomationsActive: false` — unlike the
+ * native Meta webhook, this route never dispatches Automations for the
+ * same inbound, so an active CRM automation here is irrelevant noise,
+ * not a competing responder.
  *
  * Auth: `Authorization: Bearer <MANYCHAT_INGEST_SECRET>`, compared with
  * `timingSafeEqual` (same pattern as GET /api/automations/cron). No
@@ -96,6 +120,31 @@ function buildMessageId(payload: ManyChatInboundPayload): string {
     .update(`${payload.contact_id}\u0000${payload.last_interaction ?? ''}\u0000${payload.text}`)
     .digest('hex')
   return `manychat:${hash}`
+}
+
+/**
+ * Controlled-rollout allowlist for `MANYCHAT_AI_AUTOREPLY_ENABLED`.
+ *
+ * `MANYCHAT_AI_AUTOREPLY_CONTACT_IDS` is a comma-separated list of
+ * ManyChat contact/subscriber ids. Absent or empty (after trimming each
+ * entry) → normal production behavior, every eligible contact. Present
+ * with at least one entry → AI only fires for an EXACT match against
+ * `manyChatContactId` — the value THIS ROUTE already validated as
+ * `payload.contact_id`, never anything else from the request body.
+ *
+ * Defensive parsing only: split on comma, trim, drop empty entries,
+ * exact string match. Never logs the parsed list (it's not a secret,
+ * but there's no reason to print it either).
+ */
+function isManyChatAiAutoreplyAllowed(manyChatContactId: string): boolean {
+  const raw = process.env.MANYCHAT_AI_AUTOREPLY_CONTACT_IDS
+  if (!raw) return true
+  const allowlist = raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+  if (allowlist.length === 0) return true
+  return allowlist.includes(manyChatContactId)
 }
 
 export async function POST(request: Request) {
@@ -262,6 +311,34 @@ export async function POST(request: Request) {
   }
 
   await reopenClosedConversation(admin, conversation)
+
+  // AI auto-reply — gated behind the feature flag (+ optional allowlist
+  // for a controlled rollout), and registered ONLY now that we know
+  // this was a genuine new message (past the duplicate/retry
+  // early-return above). Deferred via after() so the LLM call never
+  // delays ManyChat's response. Tenancy args come entirely from
+  // server-resolved state (config.account_id/user_id, the
+  // contact/conversation just created or found) — never from the
+  // request body. `payload.contact_id` is the ManyChat contact id this
+  // route already validated — the only value the allowlist check is
+  // ever compared against.
+  if (
+    process.env.MANYCHAT_AI_AUTOREPLY_ENABLED === 'true' &&
+    payload.text.trim() &&
+    isManyChatAiAutoreplyAllowed(payload.contact_id)
+  ) {
+    const aiArgs = {
+      accountId: config.account_id,
+      conversationId: conversation.id,
+      contactId: contactOutcome.contact.id,
+      configOwnerUserId: config.user_id,
+      // This route never dispatches Automations for this same inbound
+      // (unlike the native Meta webhook) — an active CRM automation
+      // here must not silence the AI.
+      suppressWhenAutomationsActive: false,
+    }
+    after(() => dispatchInboundToAiReply(aiArgs))
+  }
 
   return NextResponse.json({ status: 'created' }, { status: 201 })
 }

--- a/src/app/api/integrations/manychat/inbound/route.ts
+++ b/src/app/api/integrations/manychat/inbound/route.ts
@@ -185,6 +185,29 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Failed to resolve contact' }, { status: 500 })
   }
 
+  // Persist the ManyChat↔CRM contact mapping the outbound bridge relies
+  // on (src/lib/whatsapp/send-message.ts, WHATSAPP_OUTBOUND_TRANSPORT=
+  // manychat). Runs on EVERY delivery, including retries — the mapping
+  // has nothing to do with message idempotency, and a retry should
+  // still refresh `whatsapp_id`/`updated_at` if either changed. Kept
+  // outside the message-dedup branch below on purpose. Best-effort: a
+  // failed link write must not drop the inbound message from the Inbox.
+  const { error: linkError } = await admin
+    .from('manychat_contact_links')
+    .upsert(
+      {
+        account_id: config.account_id,
+        contact_id: contactOutcome.contact.id,
+        manychat_contact_id: payload.contact_id,
+        whatsapp_id: payload.whatsapp_id,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'account_id,contact_id' },
+    )
+  if (linkError) {
+    console.error('[manychat-inbound] manychat_contact_links upsert failed:', linkError.message)
+  }
+
   const convResult = await findOrCreateConversation(
     admin,
     config.account_id,

--- a/src/app/api/integrations/manychat/inbound/route.ts
+++ b/src/app/api/integrations/manychat/inbound/route.ts
@@ -1,0 +1,244 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/automations/admin-client'
+import { normalizePhone } from '@/lib/whatsapp/phone-utils'
+import { findOrCreateContact } from '@/lib/contacts/find-or-create'
+import { findOrCreateConversation } from '@/lib/conversations/find-or-create'
+import { reopenClosedConversation } from '@/lib/conversations/reopen'
+
+/**
+ * TEMPORARY bridge: mirrors inbound WhatsApp messages from ManyChat
+ * (still the live-sending platform during this migration window) into
+ * the WA CRM Inbox — contact, conversation, message only.
+ *
+ * Deliberately does NOT: send to WhatsApp, run AI auto-reply, run
+ * Flows, or run Automations. This route is a read-only mirror of
+ * ManyChat's own inbound handling, so those engines must never see a
+ * message that originated here — remove this route once ManyChat is
+ * decommissioned.
+ *
+ * Auth: `Authorization: Bearer <MANYCHAT_INGEST_SECRET>`, compared with
+ * `timingSafeEqual` (same pattern as GET /api/automations/cron). No
+ * user session/cookies — this is a server-to-server endpoint, and the
+ * account it writes into comes from `MANYCHAT_INGEST_ACCOUNT_ID`
+ * server-side, never from the request body.
+ */
+
+const MAX_ID_LENGTH = 200
+const MAX_TEXT_LENGTH = 8000
+
+interface ManyChatInboundPayload {
+  contact_id: string
+  whatsapp_id: string
+  full_name: string | null
+  text: string
+  last_interaction: string | number | null
+  external_id: string | null
+}
+
+function timingSafeEqualStrings(supplied: string, expected: string): boolean {
+  const suppliedBuf = Buffer.from(supplied)
+  const expectedBuf = Buffer.from(expected)
+  // Length check first — timingSafeEqual throws on a length mismatch
+  // rather than returning false.
+  return (
+    suppliedBuf.length === expectedBuf.length &&
+    timingSafeEqual(suppliedBuf, expectedBuf)
+  )
+}
+
+function isNonEmptyString(v: unknown, maxLen: number): v is string {
+  return typeof v === 'string' && v.trim().length > 0 && v.length <= maxLen
+}
+
+/**
+ * ManyChat's `last_interaction` shape isn't guaranteed (ISO string, or
+ * a unix timestamp in seconds or milliseconds). Accept the common
+ * forms; anything unparseable falls back to `new Date()` per spec.
+ */
+function parseTimestamp(value: string | number | null): Date {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const ms = value > 1e12 ? value : value * 1000
+    const d = new Date(ms)
+    if (!isNaN(d.getTime())) return d
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const trimmed = value.trim()
+    if (/^\d+$/.test(trimmed)) {
+      const n = Number(trimmed)
+      const ms = trimmed.length >= 13 ? n : n * 1000
+      const d = new Date(ms)
+      if (!isNaN(d.getTime())) return d
+    } else {
+      const d = new Date(trimmed)
+      if (!isNaN(d.getTime())) return d
+    }
+  }
+  return new Date()
+}
+
+/**
+ * Stable internal message_id, prefixed `manychat:` so it can never
+ * collide with a Meta `wamid.*` id. Idempotency key for retries:
+ *   - `external_id` present → used directly (ManyChat's own dedup key).
+ *   - otherwise → deterministic SHA-256 of contact_id + last_interaction
+ *     + text, so an identical retry (same three fields) always hashes
+ *     to the same id.
+ * Enforced at the DB layer by the same (conversation_id, message_id)
+ * unique index the Meta webhook relies on (migration 037) via
+ * upsert(..., { ignoreDuplicates: true }).
+ */
+function buildMessageId(payload: ManyChatInboundPayload): string {
+  if (payload.external_id) {
+    return `manychat:${payload.external_id}`
+  }
+  const hash = createHash('sha256')
+    .update(`${payload.contact_id}\u0000${payload.last_interaction ?? ''}\u0000${payload.text}`)
+    .digest('hex')
+  return `manychat:${hash}`
+}
+
+export async function POST(request: Request) {
+  const secret = process.env.MANYCHAT_INGEST_SECRET
+  const accountId = process.env.MANYCHAT_INGEST_ACCOUNT_ID
+  if (!secret || !accountId) {
+    return NextResponse.json(
+      { error: 'ManyChat bridge is not configured' },
+      { status: 503 },
+    )
+  }
+
+  const authHeader = request.headers.get('authorization') ?? ''
+  const supplied = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : ''
+  if (!supplied || !timingSafeEqualStrings(supplied, secret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let rawBody: unknown
+  try {
+    rawBody = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!rawBody || typeof rawBody !== 'object') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+  }
+  const body = rawBody as Record<string, unknown>
+
+  if (
+    !isNonEmptyString(body.contact_id, MAX_ID_LENGTH) ||
+    !isNonEmptyString(body.whatsapp_id, MAX_ID_LENGTH) ||
+    !isNonEmptyString(body.text, MAX_TEXT_LENGTH) ||
+    (body.full_name != null &&
+      (typeof body.full_name !== 'string' || body.full_name.length > MAX_ID_LENGTH)) ||
+    (body.last_interaction != null &&
+      typeof body.last_interaction !== 'string' &&
+      typeof body.last_interaction !== 'number') ||
+    (body.external_id != null && !isNonEmptyString(body.external_id, MAX_ID_LENGTH))
+  ) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+  }
+
+  const phone = normalizePhone(body.whatsapp_id as string)
+  if (!phone) {
+    return NextResponse.json({ error: 'Invalid whatsapp_id' }, { status: 400 })
+  }
+
+  const payload: ManyChatInboundPayload = {
+    contact_id: (body.contact_id as string).trim(),
+    whatsapp_id: body.whatsapp_id as string,
+    full_name: typeof body.full_name === 'string' ? body.full_name.trim() || null : null,
+    text: body.text as string,
+    last_interaction: (body.last_interaction as string | number | undefined) ?? null,
+    external_id:
+      typeof body.external_id === 'string' ? body.external_id.trim() || null : null,
+  }
+
+  const admin = supabaseAdmin()
+
+  // Resolve the WA CRM account this bridge writes into, server-side,
+  // from MANYCHAT_INGEST_ACCOUNT_ID — never from the request body.
+  const { data: config, error: configError } = await admin
+    .from('whatsapp_config')
+    .select('account_id, user_id')
+    .eq('account_id', accountId)
+    .maybeSingle()
+
+  if (configError) {
+    console.error('[manychat-inbound] whatsapp_config lookup failed:', configError.message)
+    return NextResponse.json({ error: 'Configuration lookup failed' }, { status: 500 })
+  }
+  if (!config) {
+    console.error('[manychat-inbound] no whatsapp_config row for MANYCHAT_INGEST_ACCOUNT_ID')
+    return NextResponse.json({ error: 'Account not configured' }, { status: 404 })
+  }
+
+  const contactOutcome = await findOrCreateContact(
+    admin,
+    config.account_id,
+    config.user_id,
+    phone,
+    payload.full_name || phone,
+  )
+  if (!contactOutcome) {
+    return NextResponse.json({ error: 'Failed to resolve contact' }, { status: 500 })
+  }
+
+  const convResult = await findOrCreateConversation(
+    admin,
+    config.account_id,
+    config.user_id,
+    contactOutcome.contact.id,
+  )
+  if (!convResult) {
+    return NextResponse.json({ error: 'Failed to resolve conversation' }, { status: 500 })
+  }
+  const conversation = convResult.conversation
+
+  const messageId = buildMessageId(payload)
+  const createdAt = parseTimestamp(payload.last_interaction)
+
+  // Idempotent insert — identical to the Meta webhook's idempotency
+  // boundary (migration 037's unique index on (conversation_id,
+  // message_id)). A retry with the same payload resolves to the same
+  // message_id and conflicts here, returning zero rows.
+  const { data: insertedRows, error: msgError } = await admin
+    .from('messages')
+    .upsert(
+      {
+        conversation_id: conversation.id,
+        sender_type: 'customer',
+        content_type: 'text',
+        content_text: payload.text,
+        message_id: messageId,
+        status: 'delivered',
+        created_at: createdAt.toISOString(),
+      },
+      { onConflict: 'conversation_id,message_id', ignoreDuplicates: true },
+    )
+    .select('id')
+
+  if (msgError) {
+    console.error('[manychat-inbound] message insert failed:', msgError.message)
+    return NextResponse.json({ error: 'Failed to store message' }, { status: 500 })
+  }
+
+  if (!insertedRows || insertedRows.length === 0) {
+    // Replayed delivery — no-op. Do not bump unread again, do not
+    // re-run anything below.
+    return NextResponse.json({ status: 'duplicate' }, { status: 200 })
+  }
+
+  const { error: bumpError } = await admin.rpc('bump_conversation_on_inbound', {
+    p_conversation_id: conversation.id,
+    p_last_message_text: payload.text,
+  })
+  if (bumpError) {
+    console.error('[manychat-inbound] bump_conversation_on_inbound failed:', bumpError.message)
+  }
+
+  await reopenClosedConversation(admin, conversation)
+
+  return NextResponse.json({ status: 'created' }, { status: 201 })
+}

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -4,7 +4,8 @@ import { decrypt, encrypt, isLegacyFormat } from '@/lib/whatsapp/encryption'
 import { getMediaUrl, downloadMedia } from '@/lib/whatsapp/meta-api'
 import { mirrorInboundMedia } from '@/lib/whatsapp/mirror-inbound-media'
 import { normalizePhone } from '@/lib/whatsapp/phone-utils'
-import { findExistingContact, isUniqueViolation } from '@/lib/contacts/dedupe'
+import { findOrCreateContact } from '@/lib/contacts/find-or-create'
+import { findOrCreateConversation } from '@/lib/conversations/find-or-create'
 import { reopenClosedConversation } from '@/lib/conversations/reopen'
 import { verifyMetaWebhookSignature } from '@/lib/whatsapp/webhook-signature'
 import { runAutomationsForTrigger } from '@/lib/automations/engine'
@@ -593,6 +594,7 @@ async function processMessage(
 
   // Find or create contact
   const contactOutcome = await findOrCreateContact(
+    supabaseAdmin(),
     accountId,
     configOwnerUserId,
     senderPhone,
@@ -603,6 +605,7 @@ async function processMessage(
 
   // Find or create conversation
   const convResult = await findOrCreateConversation(
+    supabaseAdmin(),
     accountId,
     configOwnerUserId,
     contactRecord.id
@@ -1100,145 +1103,4 @@ async function parseMessageContent(
         contentText: `[Unsupported message type: ${message.type}]`,
       }
   }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ContactRow = any
-
-interface ContactOutcome {
-  contact: ContactRow
-  /** True when this call created the row; drives new_contact_created
-   *  automation dispatch in processMessage. */
-  wasCreated: boolean
-}
-
-async function findOrCreateContact(
-  accountId: string,
-  configOwnerUserId: string,
-  phone: string,
-  name: string
-): Promise<ContactOutcome | null> {
-  // Find an existing contact for this account by phone. The shared
-  // helper pre-filters in SQL by the last-8-digit suffix (so we don't
-  // pull every contact on every inbound message) then applies the
-  // strict `phonesMatch` in JS on the small candidate set. The same
-  // helper backs the manual contact form and CSV import, so all three
-  // paths agree on what "same number" means (issue #212).
-  const existingContact = await findExistingContact(
-    supabaseAdmin(),
-    accountId,
-    phone,
-  )
-
-  if (existingContact) {
-    // Update name if it changed
-    if (name && name !== existingContact.name) {
-      await supabaseAdmin()
-        .from('contacts')
-        .update({ name, updated_at: new Date().toISOString() })
-        .eq('id', existingContact.id)
-    }
-    return { contact: existingContact, wasCreated: false }
-  }
-
-  // Create new contact. account_id is the tenancy column;
-  // user_id is the NOT NULL FK audit column (no inbound message
-  // has a single "user who created" it — we attribute to the
-  // WhatsApp config owner as a stable default).
-  const { data: newContact, error: createError } = await supabaseAdmin()
-    .from('contacts')
-    .insert({
-      account_id: accountId,
-      user_id: configOwnerUserId,
-      phone,
-      name: name || phone,
-    })
-    .select()
-    .single()
-
-  if (createError) {
-    // Lost a race: a concurrent inbound delivery (or another path)
-    // created this contact between our lookup and insert, and the
-    // unique index (migration 022) rejected the duplicate. Re-resolve
-    // the existing row instead of dropping the message.
-    if (isUniqueViolation(createError)) {
-      const raced = await findExistingContact(supabaseAdmin(), accountId, phone)
-      if (raced) return { contact: raced, wasCreated: false }
-    }
-    console.error('Error creating contact:', createError)
-    return null
-  }
-
-  return { contact: newContact, wasCreated: true }
-}
-
-async function findOrCreateConversation(
-  accountId: string,
-  configOwnerUserId: string,
-  contactId: string,
-) {
-  // Look for an existing conversation in this account, oldest-first.
-  //
-  // We deliberately do NOT use `.single()` here. `.single()` errors on
-  // *both* 0 rows and ≥2 rows, and the old code treated any error as
-  // "none found" and inserted a new row. So once two conversations
-  // existed for a contact (from a race — Meta retries a delivery, or a
-  // batch fans out to concurrent runs), every subsequent inbound
-  // message errored on the lookup and created yet another conversation,
-  // snowballing into a wall of duplicate chats (issue #363).
-  //
-  // Ordering oldest-first and taking one row makes the lookup resolve to
-  // the same canonical survivor the dedup migration (036) keeps, so any
-  // pre-existing duplicates converge instead of compounding.
-  const { data: existingRows, error: findError } = await supabaseAdmin()
-    .from('conversations')
-    .select('*')
-    .eq('account_id', accountId)
-    .eq('contact_id', contactId)
-    .order('created_at', { ascending: true })
-    .limit(1)
-
-  if (findError) {
-    console.error('Error finding conversation:', findError)
-    return null
-  }
-
-  if (existingRows && existingRows.length > 0) {
-    return { conversation: existingRows[0], created: false }
-  }
-
-  // Create new conversation. Same tenancy + audit split as
-  // findOrCreateContact above.
-  const { data: newConv, error: createError } = await supabaseAdmin()
-    .from('conversations')
-    .insert({
-      account_id: accountId,
-      user_id: configOwnerUserId,
-      contact_id: contactId,
-    })
-    .select()
-    .single()
-
-  if (createError) {
-    // Lost a race: a concurrent inbound delivery created the
-    // conversation between our lookup and insert, and the unique index
-    // (migration 036) rejected the duplicate. Re-resolve the winning
-    // row instead of dropping the message — mirrors findOrCreateContact.
-    if (isUniqueViolation(createError)) {
-      const { data: raced } = await supabaseAdmin()
-        .from('conversations')
-        .select('*')
-        .eq('account_id', accountId)
-        .eq('contact_id', contactId)
-        .order('created_at', { ascending: true })
-        .limit(1)
-      if (raced && raced.length > 0) {
-        return { conversation: raced[0], created: false }
-      }
-    }
-    console.error('Error creating conversation:', createError)
-    return null
-  }
-
-  return { conversation: newConv, created: true }
 }

--- a/src/components/settings/ai-config.tsx
+++ b/src/components/settings/ai-config.tsx
@@ -196,6 +196,15 @@ export function AiConfig() {
       const data = await res.json();
       if (res.ok) {
         toast.success(t('saveSuccess'));
+        // The embeddings provider changed (or a key was added/removed) —
+        // any existing vectors were cleared server-side to avoid mixing
+        // incompatible embedding spaces. Nudge the admin to reindex.
+        if (data.knowledge_reindex_required) {
+          toast.info(t('reindexRequired'));
+        }
+        if (data.warning) {
+          toast.warning(data.warning);
+        }
         await fetchConfig();
       } else {
         toast.error(data.error ?? t('saveFailed'));
@@ -371,14 +380,16 @@ export function AiConfig() {
                     setEmbeddingsKeyEdited(true);
                   }
                 }}
-                placeholder="sk-... (OpenAI)"
+                placeholder={provider === 'gemini' ? KEY_PLACEHOLDER.gemini : 'sk-... (OpenAI)'}
                 disabled={disabled}
                 autoComplete="off"
               />
               <p className="text-xs text-muted-foreground">
-                {t('embeddingsHint', {
-                  sameKeyText: provider === 'openai' ? t('sameKeyText') : '',
-                })}
+                {provider === 'gemini'
+                  ? t('embeddingsHintGemini')
+                  : t('embeddingsHint', {
+                      sameKeyText: provider === 'openai' ? t('sameKeyText') : '',
+                    })}
               </p>
             </div>
           </CardContent>

--- a/src/components/settings/ai-config.tsx
+++ b/src/components/settings/ai-config.tsx
@@ -41,11 +41,15 @@ const HANDOFF_QUEUE = '__queue__';
 const PROVIDER_LABEL: Record<AiProvider, string> = {
   openai: 'OpenAI',
   anthropic: 'Anthropic (Claude)',
+  gemini: 'Gemini (Google)',
 };
 
 const KEY_PLACEHOLDER: Record<AiProvider, string> = {
   openai: 'sk-...',
   anthropic: 'sk-ant-...',
+  // No single well-known prefix for Google AI Studio keys — a neutral
+  // description reads better than guessing/asserting a format.
+  gemini: 'Google AI Studio API key',
 };
 
 export function AiConfig() {
@@ -129,9 +133,7 @@ export function AiConfig() {
   const handleProviderChange = (next: AiProvider) => {
     setProvider(next);
     const isDefaultModel =
-      model === AI_PROVIDER_DEFAULT_MODEL.openai ||
-      model === AI_PROVIDER_DEFAULT_MODEL.anthropic ||
-      model.trim() === '';
+      Object.values(AI_PROVIDER_DEFAULT_MODEL).includes(model) || model.trim() === '';
     if (isDefaultModel) setModel(AI_PROVIDER_DEFAULT_MODEL[next]);
   };
 
@@ -281,6 +283,7 @@ export function AiConfig() {
                     <SelectItem value="anthropic">
                       {PROVIDER_LABEL.anthropic}
                     </SelectItem>
+                    <SelectItem value="gemini">{PROVIDER_LABEL.gemini}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/src/lib/ai/auto-reply.test.ts
+++ b/src/lib/ai/auto-reply.test.ts
@@ -107,9 +107,18 @@ describe('dispatchInboundToAiReply — eligibility gates', () => {
         args: { conversation_id: 'conv-1', max_replies: 3 },
       },
     ])
-    expect(h.engineSendText).toHaveBeenCalledWith(
-      expect.objectContaining({ conversationId: 'conv-1', text: 'Hello!' }),
-    )
+    // Exact args, not just a partial match — proves accountId,
+    // conversationId, contactId, and configOwnerUserId all flow through
+    // dispatchInboundToAiReply → sendAiTextToConversation → the Meta
+    // sender unchanged, and that aiGenerated is always set.
+    expect(h.engineSendText).toHaveBeenCalledWith({
+      accountId: 'acct-1',
+      userId: 'user-1',
+      conversationId: 'conv-1',
+      contactId: 'contact-1',
+      text: 'Hello!',
+      aiGenerated: true,
+    })
   })
 
   it('grounds the reply in retrieved knowledge', async () => {
@@ -124,6 +133,30 @@ describe('dispatchInboundToAiReply — eligibility gates', () => {
     h.state.autoResponders = [{ id: 'auto-1' }]
     await dispatchInboundToAiReply(ARGS)
     expect(h.generateReply).not.toHaveBeenCalled()
+    expect(h.engineSendText).not.toHaveBeenCalled()
+  })
+
+  it('suppressWhenAutomationsActive: true (explicit) behaves identically to the default — native Meta webhook call shape, unchanged', async () => {
+    h.state.autoResponders = [{ id: 'auto-1' }]
+    await dispatchInboundToAiReply({ ...ARGS, suppressWhenAutomationsActive: true })
+    expect(h.generateReply).not.toHaveBeenCalled()
+    expect(h.engineSendText).not.toHaveBeenCalled()
+  })
+
+  it('suppressWhenAutomationsActive: false skips the automations check entirely and continues to send (ManyChat bridge)', async () => {
+    h.state.autoResponders = [{ id: 'auto-1' }]
+    await dispatchInboundToAiReply({ ...ARGS, suppressWhenAutomationsActive: false })
+    expect(h.generateReply).toHaveBeenCalled()
+    expect(h.engineSendText).toHaveBeenCalled()
+  })
+
+  it('the native/default call shape (no suppressWhenAutomationsActive arg at all) is unaffected by this change', async () => {
+    // ARGS never sets the new field — proves the Meta webhook's
+    // existing call site (which never passes it) keeps suppressing on
+    // an active automation without needing any code change there.
+    expect(ARGS).not.toHaveProperty('suppressWhenAutomationsActive')
+    h.state.autoResponders = [{ id: 'auto-1' }]
+    await dispatchInboundToAiReply(ARGS)
     expect(h.engineSendText).not.toHaveBeenCalled()
   })
 

--- a/src/lib/ai/auto-reply.test.ts
+++ b/src/lib/ai/auto-reply.test.ts
@@ -77,6 +77,7 @@ function aiConfig(overrides: Partial<AiConfig> = {}): AiConfig {
     autoReplyMaxPerConversation: 3,
     handoffAgentId: null,
     embeddingsApiKey: null,
+    embeddingsProvider: null,
     ...overrides,
   }
 }

--- a/src/lib/ai/auto-reply.ts
+++ b/src/lib/ai/auto-reply.ts
@@ -7,7 +7,7 @@ import { buildSystemPrompt } from './defaults'
 import { buildHandoffSummary } from './handoff'
 import { logAiUsage } from './usage'
 import { latestUserMessage } from './query'
-import { engineSendText } from '@/lib/flows/meta-send'
+import { sendAiTextToConversation } from './send'
 import { checkRateLimit, RATE_LIMITS } from '@/lib/rate-limit'
 
 interface DispatchArgs {
@@ -18,6 +18,19 @@ interface DispatchArgs {
   /** The account's WhatsApp config owner, used for the outbound send's
    *  audit columns (mirrors how the flow runner passes it through). */
   configOwnerUserId: string
+  /**
+   * Stand down when the account has an active `new_message_received` /
+   * `keyword_match` automation, to avoid double-texting the customer.
+   * Default `true` — the correct behavior for any inbound path that
+   * ALSO dispatches Automations for this same message (the native Meta
+   * webhook: `runAutomationsForTrigger` runs alongside this call).
+   *
+   * The ManyChat bridge (`POST /api/integrations/manychat/inbound`)
+   * deliberately never dispatches Automations at all — a CRM automation
+   * being "active" there is irrelevant noise, not a real competing
+   * responder — so it passes `false` to skip this check entirely.
+   */
+  suppressWhenAutomationsActive?: boolean
 }
 
 /**
@@ -42,7 +55,13 @@ interface DispatchArgs {
 export async function dispatchInboundToAiReply(
   args: DispatchArgs,
 ): Promise<void> {
-  const { accountId, conversationId, contactId, configOwnerUserId } = args
+  const {
+    accountId,
+    conversationId,
+    contactId,
+    configOwnerUserId,
+    suppressWhenAutomationsActive,
+  } = args
 
   try {
     const db = supabaseAdmin()
@@ -50,22 +69,29 @@ export async function dispatchInboundToAiReply(
     const config = await loadAiConfig(db, accountId)
     if (!config || !config.autoReplyEnabled) return
 
-    // Deterministic, user-configured responders win over the LLM — the
-    // caller already excludes messages a Flow consumed. Message-level
-    // automations (`new_message_received` / `keyword_match`) are
-    // dispatched independently for this same inbound and may send their
-    // own reply, so if the account has any active one we stand down to
-    // avoid double-texting the customer. (Relationship triggers like
-    // `first_inbound_message` don't count — they're not per-message
-    // auto-responders.)
-    const { data: autoResponders } = await db
-      .from('automations')
-      .select('id')
-      .eq('account_id', accountId)
-      .eq('is_active', true)
-      .in('trigger_type', ['new_message_received', 'keyword_match'])
-      .limit(1)
-    if (autoResponders && autoResponders.length > 0) return
+    // Deterministic, user-configured responders win over the LLM — but
+    // only on paths that actually dispatch Automations for this same
+    // inbound (the native Meta webhook). Message-level automations
+    // (`new_message_received` / `keyword_match`) are dispatched
+    // independently there and may send their own reply, so if the
+    // account has any active one we stand down to avoid double-texting
+    // the customer. (Relationship triggers like `first_inbound_message`
+    // don't count — they're not per-message auto-responders.)
+    //
+    // Skipped entirely when `suppressWhenAutomationsActive === false`
+    // (the ManyChat bridge): that route never runs Automations at all,
+    // so an active automation there is irrelevant — checking it would
+    // only ever silence the AI for no reason.
+    if (suppressWhenAutomationsActive !== false) {
+      const { data: autoResponders } = await db
+        .from('automations')
+        .select('id')
+        .eq('account_id', accountId)
+        .eq('is_active', true)
+        .in('trigger_type', ['new_message_received', 'keyword_match'])
+        .limit(1)
+      if (autoResponders && autoResponders.length > 0) return
+    }
 
     const { data: conv, error: convErr } = await db
       .from('conversations')
@@ -179,13 +205,17 @@ export async function dispatchInboundToAiReply(
     }
     if (claimed !== true) return // lost the per-conversation cap race
 
-    await engineSendText({
+    // Transport-aware: sends via ManyChat while this account is bridged
+    // (WHATSAPP_OUTBOUND_TRANSPORT=manychat + MANYCHAT_INGEST_ACCOUNT_ID
+    // matches), or via Meta's engineSendText otherwise — see
+    // src/lib/ai/send.ts for the full contract. Either way this persists
+    // sender_type='bot' + ai_generated=true and never pauses flow_runs.
+    await sendAiTextToConversation({
       accountId,
-      userId: configOwnerUserId,
       conversationId,
       contactId,
       text,
-      aiGenerated: true,
+      configOwnerUserId,
     })
   } catch (err) {
     console.error('[ai auto-reply] dispatch failed:', err)

--- a/src/lib/ai/config.test.ts
+++ b/src/lib/ai/config.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/whatsapp/encryption', () => ({
   decrypt: (v: string) => `plain:${v}`,
 }))
 
-import { loadAiConfig } from './config'
+import { loadAiConfig, loadEmbeddingsKey } from './config'
 
 function dbReturning(row: Record<string, unknown> | null): SupabaseClient {
   const chain = {
@@ -47,5 +47,80 @@ describe('loadAiConfig requireActive', () => {
     expect(
       await loadAiConfig(dbReturning(null), 'acct', { requireActive: false }),
     ).toBeNull()
+  })
+})
+
+describe('loadAiConfig — embeddingsProvider derivation', () => {
+  it('provider=gemini + embeddings key → embeddingsProvider="gemini"', async () => {
+    const row = { ...ROW, provider: 'gemini', embeddings_api_key: 'enc-embed-key' }
+    const config = await loadAiConfig(dbReturning(row), 'acct', { requireActive: false })
+    expect(config!.embeddingsProvider).toBe('gemini')
+  })
+
+  it('provider=openai + embeddings key → embeddingsProvider="openai"', async () => {
+    const row = { ...ROW, provider: 'openai', embeddings_api_key: 'enc-embed-key' }
+    const config = await loadAiConfig(dbReturning(row), 'acct', { requireActive: false })
+    expect(config!.embeddingsProvider).toBe('openai')
+  })
+
+  it('provider=anthropic + embeddings key → embeddingsProvider="openai" (Anthropic has no embeddings endpoint)', async () => {
+    const row = { ...ROW, provider: 'anthropic', embeddings_api_key: 'enc-embed-key' }
+    const config = await loadAiConfig(dbReturning(row), 'acct', { requireActive: false })
+    expect(config!.embeddingsProvider).toBe('openai')
+  })
+
+  it('no embeddings key → embeddingsProvider=null, regardless of chat provider', async () => {
+    const geminiRow = { ...ROW, provider: 'gemini', embeddings_api_key: null }
+    const config = await loadAiConfig(dbReturning(geminiRow), 'acct', { requireActive: false })
+    expect(config!.embeddingsProvider).toBeNull()
+  })
+})
+
+describe('loadEmbeddingsKey — provider derivation', () => {
+  function dbReturningEmbeddings(row: Record<string, unknown> | null): SupabaseClient {
+    const chain = {
+      from: () => chain,
+      select: () => chain,
+      eq: () => chain,
+      maybeSingle: () => Promise.resolve({ data: row, error: null }),
+    }
+    return chain as unknown as SupabaseClient
+  }
+
+  it('gemini chat provider + key → provider="gemini"', async () => {
+    const result = await loadEmbeddingsKey(
+      dbReturningEmbeddings({ provider: 'gemini', embeddings_api_key: 'enc-key' }),
+      'acct',
+    )
+    expect(result).toEqual({ key: 'plain:enc-key', corrupt: false, provider: 'gemini' })
+  })
+
+  it('openai chat provider + key → provider="openai"', async () => {
+    const result = await loadEmbeddingsKey(
+      dbReturningEmbeddings({ provider: 'openai', embeddings_api_key: 'enc-key' }),
+      'acct',
+    )
+    expect(result.provider).toBe('openai')
+  })
+
+  it('anthropic chat provider + key → provider="openai"', async () => {
+    const result = await loadEmbeddingsKey(
+      dbReturningEmbeddings({ provider: 'anthropic', embeddings_api_key: 'enc-key' }),
+      'acct',
+    )
+    expect(result.provider).toBe('openai')
+  })
+
+  it('no key at all → key=null, provider=null', async () => {
+    const result = await loadEmbeddingsKey(
+      dbReturningEmbeddings({ provider: 'gemini', embeddings_api_key: null }),
+      'acct',
+    )
+    expect(result).toEqual({ key: null, corrupt: false, provider: null })
+  })
+
+  it('no row at all → key=null, provider=null', async () => {
+    const result = await loadEmbeddingsKey(dbReturningEmbeddings(null), 'acct')
+    expect(result).toEqual({ key: null, corrupt: false, provider: null })
   })
 })

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,9 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { decrypt } from '@/lib/whatsapp/encryption'
-import type { AiConfig } from './types'
+import type { AiConfig, AiProvider } from './types'
 
 interface AiConfigRow {
-  provider: 'openai' | 'anthropic'
+  provider: AiProvider
   model: string
   api_key: string
   system_prompt: string | null

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,6 +1,27 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { decrypt } from '@/lib/whatsapp/encryption'
-import type { AiConfig, AiProvider } from './types'
+import type { AiConfig, AiProvider, EmbeddingsProvider } from './types'
+
+/**
+ * Which embeddings provider an account's `embeddings_api_key` belongs
+ * to — derived, never stored. Gemini chat accounts use Gemini
+ * embeddings; OpenAI and Anthropic chat accounts use OpenAI embeddings
+ * (Anthropic has no embeddings endpoint). Null with no key at all —
+ * the caller never has to guess a provider from the key's shape.
+ *
+ * Only inspects whether `embeddingsApiKey` is present, never its
+ * content — so a caller that only needs a presence signal (e.g. the
+ * config route diffing old vs. new to decide whether to clear stale
+ * vectors) can pass the still-encrypted ciphertext here instead of
+ * decrypting it first.
+ */
+export function deriveEmbeddingsProvider(
+  chatProvider: AiProvider,
+  embeddingsApiKey: string | null,
+): EmbeddingsProvider | null {
+  if (!embeddingsApiKey) return null
+  return chatProvider === 'gemini' ? 'gemini' : 'openai'
+}
 
 interface AiConfigRow {
   provider: AiProvider
@@ -79,6 +100,7 @@ export async function loadAiConfig(
     autoReplyMaxPerConversation: row.auto_reply_max_per_conversation,
     handoffAgentId: row.handoff_agent_id,
     embeddingsApiKey,
+    embeddingsProvider: deriveEmbeddingsProvider(row.provider, embeddingsApiKey),
   }
 }
 
@@ -88,27 +110,31 @@ export async function loadAiConfig(
  * semantic search works) whenever an embeddings key is present, even if
  * the assistant's master switch is currently off.
  *
- * Returns `{ key, corrupt }`: `key` is null when there's no key OR it
- * can't be decrypted; `corrupt` distinguishes those cases so callers can
- * warn ("a key is set but unusable") rather than silently indexing
- * lexical-only and reporting success.
+ * Returns `{ key, corrupt, provider }`: `key` is null when there's no
+ * key OR it can't be decrypted; `corrupt` distinguishes those cases so
+ * callers can warn ("a key is set but unusable") rather than silently
+ * indexing lexical-only and reporting success; `provider` is the
+ * embeddings provider to embed with (derived from the account's chat
+ * `provider` the same way `loadAiConfig` does — see
+ * `deriveEmbeddingsProvider`), null whenever `key` is null.
  */
 export async function loadEmbeddingsKey(
   db: SupabaseClient,
   accountId: string,
-): Promise<{ key: string | null; corrupt: boolean }> {
+): Promise<{ key: string | null; corrupt: boolean; provider: EmbeddingsProvider | null }> {
   const { data, error } = await db
     .from('ai_configs')
-    .select('embeddings_api_key')
+    .select('provider, embeddings_api_key')
     .eq('account_id', accountId)
     .maybeSingle()
-  if (error || !data?.embeddings_api_key) return { key: null, corrupt: false }
+  if (error || !data?.embeddings_api_key) return { key: null, corrupt: false, provider: null }
   try {
-    return { key: decrypt(data.embeddings_api_key), corrupt: false }
+    const key = decrypt(data.embeddings_api_key)
+    return { key, corrupt: false, provider: deriveEmbeddingsProvider(data.provider, key) }
   } catch {
     console.error(
       `[ai config] embeddings key for account ${accountId} could not be decrypted — check ENCRYPTION_KEY.`,
     )
-    return { key: null, corrupt: true }
+    return { key: null, corrupt: true, provider: null }
   }
 }

--- a/src/lib/ai/defaults.ts
+++ b/src/lib/ai/defaults.ts
@@ -13,6 +13,7 @@ import type { AiProvider } from './types'
 export const AI_PROVIDER_DEFAULT_MODEL: Record<AiProvider, string> = {
   openai: 'gpt-5.4-mini',
   anthropic: 'claude-haiku-4-5-20251001',
+  gemini: 'gemini-3.8-flash',
 }
 
 /**

--- a/src/lib/ai/embeddings.test.ts
+++ b/src/lib/ai/embeddings.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { embedTexts, toVectorLiteral } from './embeddings'
+import {
+  embedTexts,
+  embedTextsOpenAi,
+  embedTextsGemini,
+  toVectorLiteral,
+  EMBEDDING_DIMENSIONS,
+  GEMINI_EMBEDDING_CONCURRENCY,
+} from './embeddings'
 import { AiError } from './types'
+
+const GEMINI_KEY = 'AIzaSyGeminiEmbeddingsKey'
 
 function okEmbeddings(count: number, shuffle = false): Response {
   const rows = Array.from({ length: count }, (_, i) => ({
@@ -9,6 +18,22 @@ function okEmbeddings(count: number, shuffle = false): Response {
   }))
   if (shuffle) rows.reverse()
   return { ok: true, status: 200, json: async () => ({ data: rows }) } as unknown as Response
+}
+
+function geminiVector(seed: number): number[] {
+  return Array.from({ length: EMBEDDING_DIMENSIONS }, (_, i) => seed + i * 0.0001)
+}
+
+function geminiOkResponse(seed: number): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ embedding: { values: geminiVector(seed) } }),
+  } as unknown as Response
+}
+
+function errResponse(status: number, json: unknown): Response {
+  return { ok: false, status, json: async () => json } as unknown as Response
 }
 
 beforeEach(() => vi.stubGlobal('fetch', vi.fn()))
@@ -20,11 +45,11 @@ describe('toVectorLiteral', () => {
   })
 })
 
-describe('embedTexts', () => {
+describe('embedTextsOpenAi', () => {
   it('returns [] and makes no request for empty input', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
-    expect(await embedTexts('sk-x', [])).toEqual([])
+    expect(await embedTextsOpenAi('sk-x', [])).toEqual([])
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -35,7 +60,7 @@ describe('embedTexts', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const out = await embedTexts('sk-x', ['a', 'b', 'c'])
+    const out = await embedTextsOpenAi('sk-x', ['a', 'b', 'c'])
     expect(out).toHaveLength(3)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, opts] = fetchMock.mock.calls[0]
@@ -43,6 +68,14 @@ describe('embedTexts', () => {
     expect(
       (opts as unknown as { headers: Record<string, string> }).headers.Authorization,
     ).toBe('Bearer sk-x')
+  })
+
+  it('sends the raw input text — no asymmetric-retrieval prefix (Gemini-only feature)', async () => {
+    const fetchMock = vi.fn(async (_url: string, opts: { body: string }) => okEmbeddings(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTextsOpenAi('sk-x', ['¿Dónde están ubicados?'])
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.input).toEqual(['¿Dónde están ubicados?'])
   })
 
   it('splits large inputs into multiple batches', async () => {
@@ -53,7 +86,7 @@ describe('embedTexts', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const inputs = Array.from({ length: 100 }, (_, i) => `t${i}`)
-    const out = await embedTexts('sk-x', inputs)
+    const out = await embedTextsOpenAi('sk-x', inputs)
     expect(out).toHaveLength(100)
     expect(fetchMock).toHaveBeenCalledTimes(2) // 96 + 4
   })
@@ -66,7 +99,7 @@ describe('embedTexts', () => {
         return okEmbeddings(n, true)
       }),
     )
-    const out = await embedTexts('sk-x', ['a', 'b', 'c'])
+    const out = await embedTextsOpenAi('sk-x', ['a', 'b', 'c'])
     expect(out[0]).toEqual([0, 0.5]) // index 0 first despite shuffle
     expect(out[2]).toEqual([2, 2.5])
   })
@@ -80,7 +113,7 @@ describe('embedTexts', () => {
         json: async () => ({ error: { message: 'bad key' } }),
       } as unknown as Response),
     )
-    await expect(embedTexts('sk-x', ['a'])).rejects.toMatchObject({
+    await expect(embedTextsOpenAi('sk-x', ['a'])).rejects.toMatchObject({
       code: 'invalid_key',
     })
   })
@@ -94,7 +127,7 @@ describe('embedTexts', () => {
         json: async () => ({ data: [{ embedding: [0.1] }, { embedding: [0.2] }] }),
       } as unknown as Response),
     )
-    await expect(embedTexts('sk-x', ['a', 'b'])).rejects.toBeInstanceOf(AiError)
+    await expect(embedTextsOpenAi('sk-x', ['a', 'b'])).rejects.toBeInstanceOf(AiError)
   })
 
   it('throws on a malformed response (count mismatch)', async () => {
@@ -106,6 +139,493 @@ describe('embedTexts', () => {
         json: async () => ({ data: [] }),
       } as unknown as Response),
     )
-    await expect(embedTexts('sk-x', ['a', 'b'])).rejects.toBeInstanceOf(AiError)
+    await expect(embedTextsOpenAi('sk-x', ['a', 'b'])).rejects.toBeInstanceOf(AiError)
+  })
+
+  it('redacts the key if OpenAI accidentally echoes it back in an error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errResponse(401, { error: { message: `bad key sk-x` } })),
+    )
+    let caught: AiError | null = null
+    try {
+      await embedTextsOpenAi('sk-x', ['a'])
+    } catch (err) {
+      caught = err as AiError
+    }
+    expect(caught!.message).not.toContain('sk-x')
+    expect(caught!.message).toContain('[REDACTED]')
+  })
+})
+
+describe('embedTextsGemini — asymmetric-retrieval prompt format', () => {
+  it('document embedding sends "title: {title} | text: {chunk}"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await embedTextsGemini(GEMINI_KEY, ['Razón social...'], {
+      kind: 'document',
+      title: 'Contacto y ubicación - Lorteg',
+    })
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.content.parts[0].text).toBe(
+      'title: Contacto y ubicación - Lorteg | text: Razón social...',
+    )
+  })
+
+  it('document embedding with no title sends "title: none | text: {chunk}"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await embedTextsGemini(GEMINI_KEY, ['Some content.'], { kind: 'document', title: null })
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.content.parts[0].text).toBe('title: none | text: Some content.')
+  })
+
+  it('document embedding with an empty/whitespace title also falls back to "none"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await embedTextsGemini(GEMINI_KEY, ['Some content.'], { kind: 'document', title: '   ' })
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.content.parts[0].text).toBe('title: none | text: Some content.')
+  })
+
+  it('query embedding sends "task: question answering | query: {query}"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await embedTextsGemini(GEMINI_KEY, ['¿Dónde están ubicados?'], { kind: 'query' })
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.content.parts[0].text).toBe(
+      'task: question answering | query: ¿Dónde están ubicados?',
+    )
+  })
+
+  it('the prefix is applied per-chunk when embedding several document chunks with the same title', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await embedTextsGemini(GEMINI_KEY, ['Chunk one.', 'Chunk two.'], {
+      kind: 'document',
+      title: 'Productos y categorías - Lorteg',
+    })
+
+    const texts = fetchMock.mock.calls.map(
+      (call) => JSON.parse((call[1] as { body: string }).body).content.parts[0].text,
+    )
+    expect(texts).toContain('title: Productos y categorías - Lorteg | text: Chunk one.')
+    expect(texts).toContain('title: Productos y categorías - Lorteg | text: Chunk two.')
+  })
+
+  it('never sends the raw unprefixed text to Gemini for a document embedding', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTextsGemini(GEMINI_KEY, ['Razón social...'], { kind: 'document', title: 'T' })
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.content.parts[0].text).not.toBe('Razón social...')
+  })
+})
+
+describe('embedTextsGemini — request shape (endpoint, headers, dimensions)', () => {
+  it('returns [] and makes no request for empty input', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await embedTextsGemini(GEMINI_KEY, [], { kind: 'query' })).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('calls the documented gemini-embedding-2 embedContent endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent',
+    )
+  })
+
+  it('authenticates via x-goog-api-key, not Authorization', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['x-goog-api-key']).toBe(GEMINI_KEY)
+    expect(init.headers.Authorization).toBeUndefined()
+  })
+
+  it('sends Content-Type: application/json', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['Content-Type']).toBe('application/json')
+  })
+
+  it('requests output_dimensionality: 1536', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.output_dimensionality).toBe(1536)
+  })
+
+  it('returns a valid 1536-length vector', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    const [vec] = await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })
+    expect(vec).toHaveLength(1536)
+  })
+
+  it('throws embeddings_malformed when the vector length is not 1536', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ embedding: { values: [0.1, 0.2, 0.3] } }),
+      } as unknown as Response),
+    )
+    await expect(
+      embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' }),
+    ).rejects.toMatchObject({ code: 'embeddings_malformed' })
+  })
+
+  it('throws embeddings_malformed when a value is not a finite number', async () => {
+    const bad = geminiVector(1)
+    bad[10] = Number.NaN
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ embedding: { values: bad } }),
+      } as unknown as Response),
+    )
+    await expect(
+      embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' }),
+    ).rejects.toMatchObject({ code: 'embeddings_malformed' })
+  })
+
+  it('throws embeddings_malformed when values contains a non-number', async () => {
+    const bad: unknown[] = geminiVector(1)
+    bad[5] = 'not-a-number'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ embedding: { values: bad } }),
+      } as unknown as Response),
+    )
+    await expect(embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })).rejects.toBeInstanceOf(
+      AiError,
+    )
+  })
+
+  it('maps 403 to invalid_key', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errResponse(403, { error: { message: 'API key not valid' } })),
+    )
+    await expect(
+      embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' }),
+    ).rejects.toMatchObject({ code: 'invalid_key' })
+  })
+
+  it('maps 429 to rate_limited', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errResponse(429, { error: { message: 'quota exceeded' } })),
+    )
+    await expect(
+      embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' }),
+    ).rejects.toMatchObject({ code: 'rate_limited' })
+  })
+
+  it('maps a timeout to code "timeout"', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('timed out', 'TimeoutError')),
+    )
+    await expect(
+      embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' }),
+    ).rejects.toMatchObject({ code: 'timeout' })
+  })
+
+  it('maps a network failure to code "network_error"', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('getaddrinfo ENOTFOUND')))
+    await expect(
+      embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' }),
+    ).rejects.toMatchObject({ code: 'network_error' })
+  })
+
+  it('never exposes the key in a thrown AiError, even if the upstream echoes it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        errResponse(403, { error: { message: `Rejected API key ${GEMINI_KEY}` } }),
+      ),
+    )
+    let caught: AiError | null = null
+    try {
+      await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })
+    } catch (err) {
+      caught = err as AiError
+    }
+    expect(caught).toBeInstanceOf(AiError)
+    expect(caught!.message).not.toContain(GEMINI_KEY)
+    expect(caught!.message).toContain('[REDACTED]')
+  })
+
+  it('never logs the key, on success or failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(geminiOkResponse(1)))
+    await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' })
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errResponse(401, { error: { message: 'bad' } })))
+    await embedTextsGemini(GEMINI_KEY, ['hola'], { kind: 'query' }).catch(() => {})
+
+    const logged = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...logSpy.mock.calls]
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join('\n')
+    expect(logged).not.toContain(GEMINI_KEY)
+
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+    logSpy.mockRestore()
+  })
+
+  it('preserves input order across parallel requests', async () => {
+    const fetchMock = vi.fn(async (_url: string, opts: { body: string }) => {
+      const body = JSON.parse(opts.body)
+      const text = body.content.parts[0].text as string
+      // text is the prefixed prompt ("task: question answering | query:
+      // t0") — extract the seed from the trailing "tN".
+      const seed = Number(text.match(/t(\d+)$/)?.[1])
+      // Resolve out of order (t0 resolves LAST) to prove the OUTPUT
+      // array order still matches the INPUT order, not arrival order.
+      const delay = seed === 0 ? 20 : 0
+      await new Promise((r) => setTimeout(r, delay))
+      return geminiOkResponse(seed)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const out = await embedTextsGemini(GEMINI_KEY, ['t0', 't1', 't2'], { kind: 'query' })
+    expect(out[0][0]).toBeCloseTo(0)
+    expect(out[1][0]).toBeCloseTo(1)
+    expect(out[2][0]).toBeCloseTo(2)
+  })
+
+  it('embeds one text per call — never folds multiple inputs into one embedContent request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTextsGemini(GEMINI_KEY, ['a', 'b', 'c'], { kind: 'document', title: 'T' })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    for (const call of fetchMock.mock.calls) {
+      const body = JSON.parse((call[1] as { body: string }).body)
+      expect(body.content.parts).toHaveLength(1)
+    }
+  })
+})
+
+describe('embedTextsGemini — bounded concurrency', () => {
+  it(`never runs more than GEMINI_EMBEDDING_CONCURRENCY (${GEMINI_EMBEDDING_CONCURRENCY}) fetches at once`, async () => {
+    const inputs = Array.from({ length: 20 }, (_, i) => `t${i}`)
+    let active = 0
+    let maxActive = 0
+    const releases: (() => void)[] = []
+
+    const fetchMock = vi.fn(() => {
+      active++
+      maxActive = Math.max(maxActive, active)
+      return new Promise<Response>((resolve) => {
+        releases.push(() => {
+          active--
+          resolve(geminiOkResponse(1))
+        })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const resultPromise = embedTextsGemini(GEMINI_KEY, inputs, {
+      kind: 'document',
+      title: 'T',
+    })
+
+    // Let the worker pool spin up and issue its first wave of fetches.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(active).toBe(GEMINI_EMBEDDING_CONCURRENCY)
+    expect(fetchMock).toHaveBeenCalledTimes(GEMINI_EMBEDDING_CONCURRENCY)
+
+    // Drain the queue by releasing whatever is currently pending, one
+    // wave at a time, asserting the bound holds as finished workers pick
+    // up the next item.
+    let guard = 0
+    while (releases.length > 0 && guard < 50) {
+      guard++
+      const wave = releases.splice(0, releases.length)
+      wave.forEach((r) => r())
+      await new Promise((r) => setTimeout(r, 0))
+      expect(active).toBeLessThanOrEqual(GEMINI_EMBEDDING_CONCURRENCY)
+    }
+
+    await resultPromise
+    expect(maxActive).toBe(GEMINI_EMBEDDING_CONCURRENCY)
+    expect(fetchMock).toHaveBeenCalledTimes(20)
+  })
+
+  it('preserves input→output order even when the pool is concurrency-limited', async () => {
+    const inputs = Array.from({ length: 12 }, (_, i) => `t${i}`)
+    // Resolve in reverse-ish order to prove the RESULT array is indexed
+    // by input position, not by completion order.
+    const fetchMock = vi.fn(async (_url: string, opts: { body: string }) => {
+      const text = JSON.parse(opts.body).content.parts[0].text as string
+      // text is the prefixed prompt — extract the seed from the trailing "tN".
+      const seed = Number(text.match(/t(\d+)$/)?.[1])
+      await new Promise((r) => setTimeout(r, (12 - seed) % 5))
+      return geminiOkResponse(seed)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const out = await embedTextsGemini(GEMINI_KEY, inputs, { kind: 'query' })
+    out.forEach((vec, i) => expect(vec[0]).toBeCloseTo(i))
+  })
+
+  it('a single failing call still rejects the whole batch (no silent partial results)', async () => {
+    const inputs = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+    const fetchMock = vi.fn(async (_url: string, opts: { body: string }) => {
+      const text = JSON.parse(opts.body).content.parts[0].text as string
+      if (text.endsWith('d')) return errResponse(500, { error: { message: 'boom' } })
+      return geminiOkResponse(1)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      embedTextsGemini(GEMINI_KEY, inputs, { kind: 'document', title: 'T' }),
+    ).rejects.toMatchObject({ code: 'provider_error' })
+  })
+
+  it('inputs=[] still makes no request under the concurrency-limited path', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await embedTextsGemini(GEMINI_KEY, [], { kind: 'query' })).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('embedTextsGemini — stops claiming new work after the first failure', () => {
+  it('a failure among the first N in-flight calls stops the pool from ever starting item N+1 — in-flight calls still finish, then it rejects with the first error', async () => {
+    const inputs = Array.from({ length: 20 }, (_, i) => `t${i}`)
+    const releases: (() => void)[] = []
+    let started = 0
+    let settledCount = 0
+
+    const fetchMock = vi.fn((_url: string, opts: { body: string }) => {
+      started++
+      const text = JSON.parse(opts.body).content.parts[0].text as string
+      const seed = Number(text.match(/t(\d+)$/)?.[1])
+      return new Promise<Response>((resolve, reject) => {
+        releases.push(() => {
+          settledCount++
+          if (seed === 2) reject(new Error('boom from item 2'))
+          else resolve(geminiOkResponse(seed))
+        })
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const resultPromise = embedTextsGemini(GEMINI_KEY, inputs, { kind: 'query' })
+    // Swallow here so the assertions below (which await it later) don't
+    // race an "unhandled rejection" warning; the real assertion is at
+    // the bottom via `.rejects`.
+    const guarded = resultPromise.catch((e) => e)
+
+    // Wave 1: the pool starts exactly GEMINI_EMBEDDING_CONCURRENCY (6)
+    // requests — items 0-5.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(started).toBe(GEMINI_EMBEDDING_CONCURRENCY)
+
+    // Fail item 2 (one of the first 6, still "in-flight" until now).
+    releases[2]()
+    await new Promise((r) => setTimeout(r, 0))
+
+    // No item 6 (the 7th) was ever started, even though 5 of the
+    // original 6 slots are still technically busy — the pool must not
+    // claim new work once `stopped` is set, regardless of how many
+    // other workers haven't yet noticed.
+    expect(started).toBe(GEMINI_EMBEDDING_CONCURRENCY)
+
+    // The other 5 requests that were ALREADY in flight before the
+    // failure are allowed to finish normally — no forced abort.
+    const stillPending = releases.filter((_, i) => i !== 2)
+    expect(stillPending).toHaveLength(GEMINI_EMBEDDING_CONCURRENCY - 1)
+    stillPending.forEach((release) => release())
+
+    // The function must not have settled while those were still
+    // pending — only once every started worker (in-flight ones
+    // included) has actually finished.
+    const result = await guarded
+    expect(result).toBeInstanceOf(Error)
+    expect((result as Error).message).toContain('boom from item 2')
+
+    // Still exactly 6 requests were ever made — never a 7th.
+    expect(started).toBe(GEMINI_EMBEDDING_CONCURRENCY)
+    expect(settledCount).toBe(GEMINI_EMBEDDING_CONCURRENCY)
+
+    await expect(resultPromise).rejects.toThrow('boom from item 2')
+  })
+
+  it('happy path (no failures) still processes every item and preserves order under the stop-on-failure pool', async () => {
+    const inputs = Array.from({ length: 9 }, (_, i) => `t${i}`)
+    const fetchMock = vi.fn(async (_url: string, opts: { body: string }) => {
+      const text = JSON.parse(opts.body).content.parts[0].text as string
+      const seed = Number(text.match(/t(\d+)$/)?.[1])
+      return geminiOkResponse(seed)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const out = await embedTextsGemini(GEMINI_KEY, inputs, { kind: 'query' })
+    expect(fetchMock).toHaveBeenCalledTimes(9)
+    out.forEach((vec, i) => expect(vec[0]).toBeCloseTo(i))
+  })
+})
+
+describe('embedTexts — provider dispatch', () => {
+  it('provider="openai" calls OpenAI, ignoring the asymmetric-prompt options', async () => {
+    const fetchMock = vi.fn(async (_url: string, opts: { body: string }) => {
+      const n = JSON.parse(opts.body).input.length
+      return okEmbeddings(n)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTexts('openai', 'sk-x', ['hola'], { kind: 'document', title: 'ignored' })
+    expect(fetchMock.mock.calls[0][0]).toContain('api.openai.com')
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.input).toEqual(['hola'])
+  })
+
+  it('provider="gemini" calls Gemini and applies the query prompt format', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiOkResponse(1))
+    vi.stubGlobal('fetch', fetchMock)
+    await embedTexts('gemini', GEMINI_KEY, ['hola'], { kind: 'query' })
+    expect(fetchMock.mock.calls[0][0]).toContain('generativelanguage.googleapis.com')
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.content.parts[0].text).toBe('task: question answering | query: hola')
+  })
+
+  it('returns [] and makes no request for empty input, for either provider', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await embedTexts('openai', 'sk-x', [], { kind: 'query' })).toEqual([])
+    expect(await embedTexts('gemini', GEMINI_KEY, [], { kind: 'query' })).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/ai/embeddings.ts
+++ b/src/lib/ai/embeddings.ts
@@ -1,29 +1,44 @@
-import { AiError } from './types'
+import { AiError, type EmbeddingsProvider } from './types'
 import { aiRequestTimeoutMs } from './defaults'
 import { providerHttpError, toNetworkError } from './providers/shared'
 
 // ============================================================
-// Embeddings (OpenAI-compatible).
+// Embeddings — OpenAI and Gemini.
 //
 // Used for the knowledge base's optional semantic-search path: embed
 // each chunk at ingest, and embed the query at retrieval. Anthropic has
-// no embeddings endpoint, so this is always OpenAI's — the account
-// supplies a (possibly separate) embeddings key. 1536-dim
-// text-embedding-3-small matches the `vector(1536)` column in
-// migration 030.
+// no embeddings endpoint, so an Anthropic-chat account with an
+// embeddings key still uses OpenAI here (see `deriveEmbeddingsProvider`
+// in config.ts). Both providers produce 1536-dim vectors, matching the
+// single `vector(1536)` column in migration 030 — no pgvector schema
+// change for adding Gemini.
 // ============================================================
 
 const OPENAI_EMBEDDINGS_URL = 'https://api.openai.com/v1/embeddings'
+const GEMINI_EMBEDDINGS_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent'
 
 export const EMBEDDING_MODEL = 'text-embedding-3-small'
+export const GEMINI_EMBEDDING_MODEL = 'gemini-embedding-2'
 export const EMBEDDING_DIMENSIONS = 1536
 
 // OpenAI accepts an array input; keep batches modest so a big re-index
 // stays under request-size limits and partial failures are cheap.
 const BATCH_SIZE = 96
 
-interface EmbeddingResponse {
+// Gemini's embedContent has no batch endpoint we rely on (see
+// embedTextsGemini below), so a big re-index would otherwise fire one
+// fetch per chunk with no cap. 6 is a conservative default: enough to
+// keep a re-index fast, low enough to stay well clear of a BYO key's
+// per-account rate limit on a single request burst.
+export const GEMINI_EMBEDDING_CONCURRENCY = 6
+
+interface OpenAiEmbeddingResponse {
   data?: { embedding?: number[]; index?: number }[]
+}
+
+interface GeminiEmbedContentResponse {
+  embedding?: { values?: unknown }
 }
 
 /** Format a vector for a pgvector column / RPC param: `[0.1,0.2,...]`.
@@ -34,11 +49,104 @@ export function toVectorLiteral(embedding: number[]): string {
 }
 
 /**
- * Embed a list of strings, preserving input order. Batched; throws
- * `AiError` on provider/network failure so callers can decide whether
- * to degrade (retrieval) or surface (ingest).
+ * Which side of retrieval a string is being embedded for. Gemini's
+ * embedContent has no `task_type` field for gemini-embedding-2 (unlike
+ * the older gemini-embedding-001) — Google's current guidance is to
+ * encode the task directly in the text instead (see `toGeminiPrompt`).
+ * OpenAI ignores this entirely; it always embeds the raw text.
  */
-export async function embedTexts(
+export type EmbeddingKind = 'query' | 'document'
+
+export interface EmbedOptions {
+  kind: EmbeddingKind
+  /** Document title — only used for kind:'document' with Gemini, to
+   *  build `title: {title} | text: {chunk}`. Ignored for kind:'query'
+   *  and for OpenAI. Defaults to 'none' when absent/empty, matching
+   *  Google's documented format for untitled documents. */
+  title?: string | null
+}
+
+/**
+ * Build Gemini's recommended asymmetric-retrieval prompt for
+ * gemini-embedding-2. Applied ONLY to the text sent to Gemini for
+ * embedding — never to what's persisted (`ai_knowledge_chunks.content`
+ * stores the raw chunk, unprefixed) and never to OpenAI, which embeds
+ * the original text as-is.
+ */
+function toGeminiPrompt(options: EmbedOptions, text: string): string {
+  if (options.kind === 'query') {
+    return `task: question answering | query: ${text}`
+  }
+  const title = options.title && options.title.trim() ? options.title.trim() : 'none'
+  return `title: ${title} | text: ${text}`
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` calls in flight at once,
+ * preserving output order to match input order regardless of which
+ * call finishes first. A worker-pool: `limit` workers pull the next
+ * unclaimed index off a shared cursor until the queue is drained. No
+ * new dependency — this is the whole implementation.
+ *
+ * Stops claiming NEW work as soon as any call fails — a worker checks
+ * the shared `stopped` flag before taking its next index, so once one
+ * fails, no further requests are started. This is deliberately NOT
+ * just "reject once and let `Promise.all` walk away": with a naive
+ * pool, workers B–F would keep pulling and firing new requests after
+ * worker A's failure while the caller had already moved on believing
+ * the batch was done. In-flight calls (already `await`ing `fn`) are
+ * left to finish normally — no forced abort, no retries — and this
+ * function does not return/throw until every started worker (in-
+ * flight ones included) has actually finished. Then, if anything
+ * failed, it throws the FIRST error seen (later ones are dropped).
+ */
+async function mapWithConcurrencyLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let nextIndex = 0
+  let stopped = false
+  let hasError = false
+  let firstError: unknown
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      if (stopped) return
+      const i = nextIndex++
+      if (i >= items.length) return
+      try {
+        results[i] = await fn(items[i], i)
+      } catch (err) {
+        if (!hasError) {
+          hasError = true
+          firstError = err
+        }
+        stopped = true
+        return
+      }
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(limit, items.length))
+  // Waits for every worker — including ones mid-flight when `stopped`
+  // was set — so the function never resolves/rejects while a request
+  // is still running in the background.
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
+
+  if (hasError) throw firstError
+  return results
+}
+
+/**
+ * Embed a list of strings with OpenAI, preserving input order. Batched;
+ * throws `AiError` on provider/network failure so callers can decide
+ * whether to degrade (retrieval) or surface (ingest). Always embeds the
+ * raw input text — OpenAI has no asymmetric-retrieval prompt format to
+ * apply here.
+ */
+export async function embedTextsOpenAi(
   apiKey: string,
   inputs: string[],
 ): Promise<number[][]> {
@@ -65,10 +173,10 @@ export async function embedTexts(
     }
 
     if (!res.ok) {
-      throw await providerHttpError('OpenAI embeddings', res)
+      throw await providerHttpError('OpenAI embeddings', res, { redact: [apiKey] })
     }
 
-    const data = (await res.json().catch(() => null)) as EmbeddingResponse | null
+    const data = (await res.json().catch(() => null)) as OpenAiEmbeddingResponse | null
     const rows = data?.data
     if (!rows || rows.length !== batch.length) {
       throw new AiError('Embeddings response was malformed.', {
@@ -97,4 +205,96 @@ export async function embedTexts(
   }
 
   return out
+}
+
+/**
+ * Embed one already-formatted prompt string with Gemini's `embedContent`
+ * REST endpoint, requesting `output_dimensionality: 1536` so the vector
+ * matches the same `vector(1536)` column OpenAI's text-embedding-3-small
+ * already uses.
+ */
+async function embedOneGemini(apiKey: string, prompt: string): Promise<number[]> {
+  const timeoutMs = aiRequestTimeoutMs()
+
+  let res: Response
+  try {
+    res = await fetch(GEMINI_EMBEDDINGS_URL, {
+      method: 'POST',
+      headers: {
+        'x-goog-api-key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: { parts: [{ text: prompt }] },
+        output_dimensionality: EMBEDDING_DIMENSIONS,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+  } catch (err) {
+    throw toNetworkError(err)
+  }
+
+  if (!res.ok) {
+    throw await providerHttpError('Gemini embeddings', res, { redact: [apiKey] })
+  }
+
+  const data = (await res.json().catch(() => null)) as GeminiEmbedContentResponse | null
+  const values = data?.embedding?.values
+  if (
+    !Array.isArray(values) ||
+    values.length !== EMBEDDING_DIMENSIONS ||
+    !values.every((v) => typeof v === 'number' && Number.isFinite(v))
+  ) {
+    throw new AiError('Gemini embeddings response was malformed.', {
+      code: 'embeddings_malformed',
+    })
+  }
+  return values as number[]
+}
+
+/**
+ * Embed a list of strings with Gemini, preserving input order.
+ *
+ * Each input is first wrapped in Google's recommended asymmetric prompt
+ * (`toGeminiPrompt` — query vs document format; see module docs) — the
+ * wrapped text is what's sent to Gemini, never what's persisted.
+ *
+ * One `embedContent` call per input — Gemini's single-content endpoint
+ * embeds exactly one piece of content, so this deliberately does NOT
+ * fold multiple chunks into one call (that would silently produce one
+ * vector for several chunks' worth of text). Calls run with at most
+ * `GEMINI_EMBEDDING_CONCURRENCY` in flight at once (see
+ * `mapWithConcurrencyLimit`), which also preserves the input order in
+ * the returned array regardless of completion order.
+ */
+export async function embedTextsGemini(
+  apiKey: string,
+  inputs: string[],
+  options: EmbedOptions,
+): Promise<number[][]> {
+  if (inputs.length === 0) return []
+  const prompts = inputs.map((text) => toGeminiPrompt(options, text))
+  return mapWithConcurrencyLimit(prompts, GEMINI_EMBEDDING_CONCURRENCY, (prompt) =>
+    embedOneGemini(apiKey, prompt),
+  )
+}
+
+/**
+ * Dispatch to the account's configured embeddings provider. `provider`
+ * comes from `AiConfig.embeddingsProvider` (derived in config.ts from
+ * the chat provider + presence of an embeddings key) — never guessed
+ * from the key's shape/prefix. `options` tells the Gemini path whether
+ * this is a query or document embedding (and the document's title,
+ * when applicable) — OpenAI ignores it.
+ */
+export async function embedTexts(
+  provider: EmbeddingsProvider,
+  apiKey: string,
+  inputs: string[],
+  options: EmbedOptions,
+): Promise<number[][]> {
+  if (inputs.length === 0) return []
+  return provider === 'gemini'
+    ? embedTextsGemini(apiKey, inputs, options)
+    : embedTextsOpenAi(apiKey, inputs)
 }

--- a/src/lib/ai/generate.test.ts
+++ b/src/lib/ai/generate.test.ts
@@ -13,6 +13,7 @@ function config(overrides: Partial<AiConfig> = {}): AiConfig {
     autoReplyMaxPerConversation: 3,
     handoffAgentId: null,
     embeddingsApiKey: null,
+    embeddingsProvider: null,
     ...overrides,
   }
 }

--- a/src/lib/ai/generate.test.ts
+++ b/src/lib/ai/generate.test.ts
@@ -126,6 +126,28 @@ describe('generateReply — OpenAI', () => {
       }),
     ).rejects.toBeInstanceOf(AiError)
   })
+
+  it('redacts the request API key if OpenAI accidentally echoes it back in an error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        errResponse(403, { error: { message: 'Rejected API key sk-test' } }),
+      ),
+    )
+    let caught: AiError | null = null
+    try {
+      await generateReply({
+        config: config({ apiKey: 'sk-test' }),
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'Hi' }],
+      })
+    } catch (err) {
+      caught = err as AiError
+    }
+    expect(caught).toBeInstanceOf(AiError)
+    expect(caught!.message).not.toContain('sk-test')
+    expect(caught!.message).toContain('[REDACTED]')
+  })
 })
 
 describe('generateReply — Anthropic', () => {
@@ -190,5 +212,141 @@ describe('generateReply — Anthropic', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body)
     expect(body.messages[0].role).toBe('user')
     expect(body.messages).toHaveLength(1)
+  })
+
+  it('redacts the request API key if Anthropic accidentally echoes it back in an error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        errResponse(403, { error: { message: 'Rejected API key sk-ant-x' } }),
+      ),
+    )
+    let caught: AiError | null = null
+    try {
+      await generateReply({
+        config: config({ provider: 'anthropic', apiKey: 'sk-ant-x' }),
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'Hi' }],
+      })
+    } catch (err) {
+      caught = err as AiError
+    }
+    expect(caught).toBeInstanceOf(AiError)
+    expect(caught!.message).not.toContain('sk-ant-x')
+    expect(caught!.message).toContain('[REDACTED]')
+  })
+})
+
+describe('generateReply — Gemini', () => {
+  it('calls the generateContent endpoint and returns the reply', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({
+        candidates: [{ content: { parts: [{ text: 'Sure — happy to help!' }] } }],
+        usageMetadata: { promptTokenCount: 42, candidatesTokenCount: 8, totalTokenCount: 50 },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await generateReply({
+      config: config({ provider: 'gemini', model: 'gemini-3.8-flash', apiKey: 'gm-test' }),
+      systemPrompt: 'sys',
+      messages: [{ role: 'user', content: 'Hi' }],
+    })
+
+    expect(res).toEqual({
+      text: 'Sure — happy to help!',
+      handoff: false,
+      usage: { promptTokens: 42, completionTokens: 8, totalTokens: 50 },
+    })
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain('generativelanguage.googleapis.com')
+    expect(opts.headers['x-goog-api-key']).toBe('gm-test')
+  })
+
+  it('maps a 403 to an invalid_key AiError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errResponse(403, { error: { message: 'API key not valid' } })),
+    )
+    await expect(
+      generateReply({
+        config: config({ provider: 'gemini' }),
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'Hi' }],
+      }),
+    ).rejects.toMatchObject({ code: 'invalid_key', status: 401 })
+  })
+
+  it('detects handoff in the model output', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse({ candidates: [{ content: { parts: [{ text: '[[HANDOFF]]' }] } }] }),
+      ),
+    )
+    const res = await generateReply({
+      config: config({ provider: 'gemini' }),
+      systemPrompt: 'sys',
+      messages: [{ role: 'user', content: 'I want to speak to a person' }],
+    })
+    expect(res.handoff).toBe(true)
+    expect(res.text).toBe('')
+  })
+})
+
+describe('generateReply — provider dispatch', () => {
+  it('provider=openai still calls OpenAI (api.openai.com)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ choices: [{ message: { content: 'ok' } }] }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    await generateReply({
+      config: config({ provider: 'openai' }),
+      systemPrompt: 'sys',
+      messages: [{ role: 'user', content: 'Hi' }],
+    })
+    expect(fetchMock.mock.calls[0][0]).toContain('api.openai.com')
+  })
+
+  it('provider=anthropic still calls Anthropic (api.anthropic.com)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ content: [{ type: 'text', text: 'ok' }] }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    await generateReply({
+      config: config({ provider: 'anthropic' }),
+      systemPrompt: 'sys',
+      messages: [{ role: 'user', content: 'Hi' }],
+    })
+    expect(fetchMock.mock.calls[0][0]).toContain('api.anthropic.com')
+  })
+
+  it('provider=gemini calls Gemini (generativelanguage.googleapis.com)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    await generateReply({
+      config: config({ provider: 'gemini' }),
+      systemPrompt: 'sys',
+      messages: [{ role: 'user', content: 'Hi' }],
+    })
+    expect(fetchMock.mock.calls[0][0]).toContain('generativelanguage.googleapis.com')
+  })
+
+  it('rejects an unsupported provider without calling any adapter', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(
+      generateReply({
+        // Deliberately outside the AiProvider union — proves the
+        // dispatch's default branch still rejects an invalid value at
+        // runtime even though the type system would normally catch it.
+        config: config({ provider: 'carrier-pigeon' as unknown as AiConfig['provider'] }),
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'Hi' }],
+      }),
+    ).rejects.toMatchObject({ code: 'unsupported_provider', status: 400 })
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/ai/generate.ts
+++ b/src/lib/ai/generate.ts
@@ -8,6 +8,7 @@ import {
 import { HANDOFF_SENTINEL, aiRequestTimeoutMs } from './defaults'
 import { generateOpenAi } from './providers/openai'
 import { generateAnthropic } from './providers/anthropic'
+import { generateGemini } from './providers/gemini'
 
 export interface GenerateArgs {
   config: AiConfig
@@ -40,6 +41,9 @@ export async function generateReply(args: GenerateArgs): Promise<GenerateResult>
       break
     case 'anthropic':
       result = await generateAnthropic(providerArgs)
+      break
+    case 'gemini':
+      result = await generateGemini(providerArgs)
       break
     default:
       throw new AiError(`Unsupported AI provider: ${config.provider}`, {

--- a/src/lib/ai/knowledge.test.ts
+++ b/src/lib/ai/knowledge.test.ts
@@ -7,13 +7,21 @@ vi.mock('./embeddings', () => ({
   toVectorLiteral: (v: number[]) => `[${v.join(',')}]`,
 }))
 
-import { retrieveKnowledge, ingestDocument } from './knowledge'
+import { retrieveKnowledge, ingestDocument, extractKeywords } from './knowledge'
 
 interface FakeState {
   semantic: { id: string; content: string }[]
+  /** Result for the strict full-query FTS search (the default response
+   *  for any term not overridden in `ftsByTerm`). */
   fts: { id: string; content: string }[]
+  /** Per-keyword override for the fallback's individual RPC calls —
+   *  keyed by the exact `p_query` term sent. */
+  ftsByTerm: Record<string, { id: string; content: string }[]>
+  /** Terms that should make the RPC call reject (simulates an RPC
+   *  error for the keyword-fallback path). */
+  ftsRejectTerms: Set<string>
   chunkCount: number
-  rpcCalls: string[]
+  rpcCalls: { name: string; query?: string }[]
   inserted: Record<string, unknown>[] | null
   deletedFor: string | null
 }
@@ -22,18 +30,28 @@ function makeDb() {
   const state: FakeState = {
     semantic: [],
     fts: [],
+    ftsByTerm: {},
+    ftsRejectTerms: new Set(),
     chunkCount: 5, // account has a non-empty KB by default
     rpcCalls: [],
     inserted: null,
     deletedFor: null,
   }
   const db = {
-    rpc: (name: string) => {
-      state.rpcCalls.push(name)
+    rpc: (name: string, args: Record<string, unknown>) => {
+      const query = args?.p_query as string | undefined
+      state.rpcCalls.push({ name, query })
       if (name === 'match_ai_knowledge_semantic')
         return Promise.resolve({ data: state.semantic, error: null })
-      if (name === 'match_ai_knowledge_fts')
+      if (name === 'match_ai_knowledge_fts') {
+        if (query !== undefined && state.ftsRejectTerms.has(query)) {
+          return Promise.reject(new Error(`RPC failed for term "${query}"`))
+        }
+        if (query !== undefined && query in state.ftsByTerm) {
+          return Promise.resolve({ data: state.ftsByTerm[query], error: null })
+        }
         return Promise.resolve({ data: state.fts, error: null })
+      }
       return Promise.resolve({ data: null, error: null })
     },
     from: () => ({
@@ -56,24 +74,27 @@ function makeDb() {
   return { db: db as unknown as SupabaseClient, state }
 }
 
+const OPENAI_CFG = { embeddingsApiKey: 'sk-x', embeddingsProvider: 'openai' as const }
+const NO_KEY_CFG = { embeddingsApiKey: null, embeddingsProvider: null }
+
 beforeEach(() => {
   h.embedTexts.mockReset()
-  h.embedTexts.mockImplementation(async (_key: string, inputs: string[]) =>
+  h.embedTexts.mockImplementation(async (_provider: string, _key: string, inputs: string[]) =>
     inputs.map((_, i) => [i, i]),
   )
 })
 
-describe('retrieveKnowledge', () => {
+describe('retrieveKnowledge — existing behavior (unchanged)', () => {
   it('returns [] for an empty query without touching the DB', async () => {
     const { db, state } = makeDb()
-    expect(await retrieveKnowledge(db, 'acct', { embeddingsApiKey: null }, '  ')).toEqual([])
+    expect(await retrieveKnowledge(db, 'acct', NO_KEY_CFG, '  ')).toEqual([])
     expect(state.rpcCalls).toEqual([])
   })
 
   it('short-circuits (no embed, no RPC) when the KB is empty', async () => {
     const { db, state } = makeDb()
     state.chunkCount = 0
-    const out = await retrieveKnowledge(db, 'acct', { embeddingsApiKey: 'sk-x' }, 'q')
+    const out = await retrieveKnowledge(db, 'acct', OPENAI_CFG, 'q')
     expect(out).toEqual([])
     expect(h.embedTexts).not.toHaveBeenCalled()
     expect(state.rpcCalls).toEqual([])
@@ -82,24 +103,24 @@ describe('retrieveKnowledge', () => {
   it('uses lexical FTS only when there is no embeddings key', async () => {
     const { db, state } = makeDb()
     state.fts = [{ id: 'f1', content: 'F1' }]
-    const out = await retrieveKnowledge(db, 'acct', { embeddingsApiKey: null }, 'q')
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'q')
     expect(out).toEqual(['F1'])
-    expect(state.rpcCalls).toEqual(['match_ai_knowledge_fts'])
+    expect(state.rpcCalls.map((c) => c.name)).toEqual(['match_ai_knowledge_fts'])
     expect(h.embedTexts).not.toHaveBeenCalled()
   })
 
-  it('uses semantic search when an embeddings key is present', async () => {
+  it('uses semantic search when an embeddings key is present, passing the provider through', async () => {
     const { db, state } = makeDb()
     state.semantic = [
       { id: 's1', content: 'S1' },
       { id: 's2', content: 'S2' },
       { id: 's3', content: 'S3' },
     ]
-    const out = await retrieveKnowledge(db, 'acct', { embeddingsApiKey: 'sk-x' }, 'q', 3)
+    const out = await retrieveKnowledge(db, 'acct', OPENAI_CFG, 'q', 3)
     expect(out).toEqual(['S1', 'S2', 'S3'])
-    expect(h.embedTexts).toHaveBeenCalledTimes(1)
+    expect(h.embedTexts).toHaveBeenCalledWith('openai', 'sk-x', ['q'], { kind: 'query' })
     // Enough semantic hits → no FTS top-up.
-    expect(state.rpcCalls).toEqual(['match_ai_knowledge_semantic'])
+    expect(state.rpcCalls.map((c) => c.name)).toEqual(['match_ai_knowledge_semantic'])
   })
 
   it('tops up with FTS and dedupes when semantic is short', async () => {
@@ -112,36 +133,238 @@ describe('retrieveKnowledge', () => {
       { id: 's2', content: 'S2-dup' }, // dedup by id
       { id: 'f1', content: 'F1' },
     ]
-    const out = await retrieveKnowledge(db, 'acct', { embeddingsApiKey: 'sk-x' }, 'q', 3)
+    const out = await retrieveKnowledge(db, 'acct', OPENAI_CFG, 'q', 3)
     expect(out).toEqual(['S1', 'S2', 'F1'])
-    expect(state.rpcCalls).toEqual([
+    expect(state.rpcCalls.map((c) => c.name)).toEqual([
       'match_ai_knowledge_semantic',
       'match_ai_knowledge_fts',
     ])
   })
 })
 
-describe('ingestDocument', () => {
-  it('embeds chunks when a key is present', async () => {
+describe('extractKeywords', () => {
+  it('strips punctuation and lowercases', () => {
+    expect(extractKeywords('¿Tienen Taladros?')).toEqual(['tienen', 'taladros'])
+  })
+
+  it('drops common Spanish/English stopwords', () => {
+    const kw = extractKeywords('Hola, ¿qué productos venden?')
+    expect(kw).not.toContain('hola')
+    expect(kw).not.toContain('qué')
+    expect(kw).not.toContain('que')
+    expect(kw).toContain('productos')
+    expect(kw).toContain('venden')
+  })
+
+  it('drops very short tokens', () => {
+    expect(extractKeywords('a de un mi tu')).toEqual([])
+  })
+
+  it('handles Unicode/accented tokens correctly', () => {
+    expect(extractKeywords('¿Dónde está la ubicación?')).toContain('ubicación')
+  })
+
+  it('deduplicates repeated terms', () => {
+    expect(extractKeywords('productos productos productos')).toEqual(['productos'])
+  })
+
+  it('caps the number of extracted keywords', () => {
+    const longQuery = Array.from({ length: 20 }, (_, i) => `keyword${i}`).join(' ')
+    expect(extractKeywords(longQuery).length).toBeLessThanOrEqual(6)
+  })
+
+  it('returns [] for an all-stopword / all-punctuation query', () => {
+    expect(extractKeywords('¿Y o?')).toEqual([])
+  })
+})
+
+describe('retrieveKnowledge — lexical keyword fallback (issue: 0 matches on natural questions)', () => {
+  it('"¿Tienen taladros?" finds the chunk via the "taladros" keyword when the strict AND-query finds nothing', async () => {
     const { db, state } = makeDb()
-    await ingestDocument(db, 'acct', { embeddingsApiKey: 'sk-x' }, 'doc-1', 'hello world')
-    expect(h.embedTexts).toHaveBeenCalledTimes(1)
+    state.fts = [] // strict full-sentence query: 0 results
+    state.ftsByTerm['taladros'] = [{ id: 'c1', content: 'Taladros disponibles en stock.' }]
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, '¿Tienen taladros?')
+    expect(out).toEqual(['Taladros disponibles en stock.'])
+  })
+
+  it('"Hola, ¿qué productos venden?" finds the chunk via the "productos" keyword', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    state.ftsByTerm['productos'] = [
+      { id: 'c2', content: 'Productos y categorías - Lorteg.' },
+    ]
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'Hola, ¿qué productos venden?')
+    expect(out).toEqual(['Productos y categorías - Lorteg.'])
+  })
+
+  it('"¿Hacen envíos fuera de Lima?" finds chunks via "envíos"/"lima" keywords', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    state.ftsByTerm['envíos'] = [{ id: 'c3', content: 'Hacemos envíos a todo el Perú.' }]
+    state.ftsByTerm['lima'] = [{ id: 'c4', content: 'Ubicados en Lima, Perú.' }]
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, '¿Hacen envíos fuera de Lima?', 5)
+    expect(out).toContain('Hacemos envíos a todo el Perú.')
+    expect(out).toContain('Ubicados en Lima, Perú.')
+  })
+
+  // "¿Dónde están ubicados?" is NOT a case the keyword fallback can be
+  // trusted to solve: "ubicados" and "ubicación" are different word
+  // forms, and FTS `'simple'` config does no stemming/lemmatization —
+  // Postgres will NOT match one against the other. Asserting otherwise
+  // would simulate behavior real Postgres doesn't have. This is
+  // precisely the gap semantic search exists to cover (below).
+  it('lexical-only: "¿Dónde están ubicados?" may legitimately return [] — "ubicados" ≠ "ubicación" under FTS \'simple\' (no stemming)', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    // Deliberately NOT overriding ftsByTerm['ubicados'] — the realistic
+    // simulation is that this term matches nothing, because the KB chunk
+    // contains "ubicación", a different literal token.
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, '¿Dónde están ubicados?')
+    expect(out).toEqual([])
+  })
+
+  it('semantic retrieval (Gemini) resolves "¿Dónde están ubicados?" via match_ai_knowledge_semantic, independent of exact wording', async () => {
+    const { db, state } = makeDb()
+    // The semantic RPC mock does no text matching at all — it's a pure
+    // stand-in for pgvector's cosine-distance ORDER BY, exactly like the
+    // real RPC would return for a paraphrase whose embedding happens to
+    // land near the "Contacto y ubicación" chunk's.
+    state.semantic = [{ id: 'c5', content: 'Contacto y ubicación - Lorteg.' }]
+    const geminiCfg = { embeddingsApiKey: 'AIzaKey', embeddingsProvider: 'gemini' as const }
+
+    const out = await retrieveKnowledge(db, 'acct', geminiCfg, '¿Dónde están ubicados?')
+
+    expect(out).toEqual(['Contacto y ubicación - Lorteg.'])
+    expect(h.embedTexts).toHaveBeenCalledWith('gemini', 'AIzaKey', ['¿Dónde están ubicados?'], {
+      kind: 'query',
+    })
+  })
+
+  it('a strict query that already matches does NOT trigger the keyword fallback', async () => {
+    const { db, state } = makeDb()
+    state.fts = [{ id: 'c1', content: 'Direct strict match.' }]
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'taladros')
+    expect(out).toEqual(['Direct strict match.'])
+    // Only the one strict call — no per-keyword fan-out.
+    expect(state.rpcCalls).toHaveLength(1)
+  })
+
+  it('deduplicates chunks matched by more than one fallback keyword', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    const sharedChunk = { id: 'c1', content: 'Productos y envíos en un mismo párrafo.' }
+    state.ftsByTerm['productos'] = [sharedChunk]
+    state.ftsByTerm['envíos'] = [sharedChunk]
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, '¿productos y envíos?', 5)
+    expect(out).toEqual(['Productos y envíos en un mismo párrafo.'])
+  })
+
+  it('caps fallback results at k across multiple keywords', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    state.ftsByTerm['productos'] = [
+      { id: 'c1', content: 'P1' },
+      { id: 'c2', content: 'P2' },
+    ]
+    state.ftsByTerm['envíos'] = [
+      { id: 'c3', content: 'E1' },
+      { id: 'c4', content: 'E2' },
+    ]
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'productos y envíos', 2)
+    expect(out).toHaveLength(2)
+  })
+
+  it('passes k as p_match_count on every fallback RPC call', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    await retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'productos y envíos', 3)
+    const ftsCalls = state.rpcCalls.filter((c) => c.name === 'match_ai_knowledge_fts')
+    expect(ftsCalls.length).toBeGreaterThan(1) // strict + at least one keyword
+  })
+
+  it('a rejected per-keyword RPC call degrades gracefully (best-effort) without losing other keywords\' results', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    state.ftsRejectTerms.add('productos')
+    state.ftsByTerm['envíos'] = [{ id: 'c1', content: 'Envíos disponibles.' }]
+
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'productos y envíos', 5)
+    expect(out).toEqual(['Envíos disponibles.'])
+  })
+
+  it('a query with no extractable keywords (all stopwords) skips the fallback without error', async () => {
+    const { db, state } = makeDb()
+    state.fts = []
+    const out = await retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'y o de la', 5)
+    expect(out).toEqual([])
+    // Only the one strict call — extractKeywords returned [], no fan-out.
+    expect(state.rpcCalls).toHaveLength(1)
+  })
+
+  it('an error on the strict lexical RPC still degrades to [] rather than throwing', async () => {
+    const db = {
+      rpc: () => Promise.reject(new Error('db unreachable')),
+      from: () => ({
+        select: () => ({ eq: () => Promise.resolve({ count: 5, error: null }) }),
+      }),
+    } as unknown as SupabaseClient
+    await expect(retrieveKnowledge(db, 'acct', NO_KEY_CFG, 'productos')).resolves.toEqual([])
+  })
+})
+
+describe('ingestDocument', () => {
+  it('embeds chunks with the configured provider when a key is present', async () => {
+    const { db, state } = makeDb()
+    await ingestDocument(db, 'acct', OPENAI_CFG, 'doc-1', 'Some Title', 'hello world')
+    expect(h.embedTexts).toHaveBeenCalledWith('openai', 'sk-x', ['hello world'], {
+      kind: 'document',
+      title: 'Some Title',
+    })
     expect(state.deletedFor).toBe('doc-1')
     expect(state.inserted).toHaveLength(1)
     expect(state.inserted![0].embedding).toBe('[0,0]') // literal from mocked embed
     expect(state.inserted![0].account_id).toBe('acct')
+    // The persisted content is the raw chunk — never the Gemini-only prefix.
+    expect(state.inserted![0].content).toBe('hello world')
+  })
+
+  it('embeds chunks with Gemini when embeddingsProvider is "gemini", passing the document title through', async () => {
+    const { db } = makeDb()
+    const geminiCfg = { embeddingsApiKey: 'AIzaGeminiKey', embeddingsProvider: 'gemini' as const }
+    await ingestDocument(db, 'acct', geminiCfg, 'doc-1', 'Contacto y ubicación - Lorteg', 'hello world')
+    expect(h.embedTexts).toHaveBeenCalledWith('gemini', 'AIzaGeminiKey', ['hello world'], {
+      kind: 'document',
+      title: 'Contacto y ubicación - Lorteg',
+    })
+  })
+
+  it('passes title: null through untouched when the document has no title', async () => {
+    const { db } = makeDb()
+    const geminiCfg = { embeddingsApiKey: 'AIzaGeminiKey', embeddingsProvider: 'gemini' as const }
+    await ingestDocument(db, 'acct', geminiCfg, 'doc-1', null, 'hello world')
+    expect(h.embedTexts).toHaveBeenCalledWith('gemini', 'AIzaGeminiKey', ['hello world'], {
+      kind: 'document',
+      title: null,
+    })
   })
 
   it('stores chunks without embeddings when there is no key', async () => {
     const { db, state } = makeDb()
-    await ingestDocument(db, 'acct', { embeddingsApiKey: null }, 'doc-1', 'hello world')
+    await ingestDocument(db, 'acct', NO_KEY_CFG, 'doc-1', 'Some Title', 'hello world')
     expect(h.embedTexts).not.toHaveBeenCalled()
     expect(state.inserted![0].embedding).toBeNull()
   })
 
   it('deletes existing chunks and inserts nothing for empty content', async () => {
     const { db, state } = makeDb()
-    await ingestDocument(db, 'acct', { embeddingsApiKey: 'sk-x' }, 'doc-1', '   ')
+    await ingestDocument(db, 'acct', OPENAI_CFG, 'doc-1', 'Some Title', '   ')
     expect(state.deletedFor).toBe('doc-1')
     expect(state.inserted).toBeNull()
     expect(h.embedTexts).not.toHaveBeenCalled()
@@ -151,7 +374,7 @@ describe('ingestDocument', () => {
     const { db, state } = makeDb()
     h.embedTexts.mockRejectedValueOnce(new Error('rate limited'))
     await expect(
-      ingestDocument(db, 'acct', { embeddingsApiKey: 'sk-x' }, 'doc-1', 'hello world'),
+      ingestDocument(db, 'acct', OPENAI_CFG, 'doc-1', 'Some Title', 'hello world'),
     ).rejects.toThrow('rate limited')
     // Chunks were inserted (lexical search works) despite the embed failure…
     expect(state.inserted).toHaveLength(1)

--- a/src/lib/ai/knowledge.ts
+++ b/src/lib/ai/knowledge.ts
@@ -6,7 +6,8 @@ import { embedTexts, toVectorLiteral } from './embeddings'
 // ============================================================
 // Knowledge base: ingest (chunk + optionally embed) and hybrid
 // retrieve (semantic when an embeddings key is present, topped up with
-// lexical full-text search).
+// lexical full-text search — with a keyword-decomposition fallback for
+// when the strict full-text query finds nothing).
 // ============================================================
 
 interface MatchRow {
@@ -14,11 +15,14 @@ interface MatchRow {
   content: string
 }
 
+type EmbeddingsConfig = Pick<AiConfig, 'embeddingsApiKey' | 'embeddingsProvider'>
+
 /**
  * (Re)build the chunks for one document. Deletes the document's
  * existing chunks, re-chunks the content, and — when the account has an
- * embeddings key — embeds each chunk. Runs under whatever client the
- * caller passes (service-role for ingest routes).
+ * embeddings key — embeds each chunk with the configured provider
+ * (`config.embeddingsProvider` — OpenAI or Gemini). Runs under whatever
+ * client the caller passes (service-role for ingest routes).
  *
  * Throws on embedding failure so the ingest route can report it; the
  * chunks are only written once embedding (if attempted) succeeds, so a
@@ -27,8 +31,9 @@ interface MatchRow {
 export async function ingestDocument(
   db: SupabaseClient,
   accountId: string,
-  config: Pick<AiConfig, 'embeddingsApiKey'>,
+  config: EmbeddingsConfig,
   documentId: string,
+  title: string | null,
   content: string,
 ): Promise<void> {
   const chunks = chunkText(content)
@@ -48,11 +53,20 @@ export async function ingestDocument(
   // AFTER inserting (embedding-less) rows, so the route can warn
   // "semantic indexing failed" — which is now truthful, because lexical
   // search really does still work.
+  //
+  // `title` only affects what gets SENT to Gemini for embedding
+  // (`title: {title} | text: {chunk}` — Google's recommended asymmetric
+  // document format for gemini-embedding-2); the persisted
+  // `content` below is always the raw, unprefixed chunk. OpenAI ignores
+  // `title` entirely — it embeds the chunk text as-is.
   let embeddings: number[][] | null = null
   let embedError: unknown = null
-  if (config.embeddingsApiKey) {
+  if (config.embeddingsApiKey && config.embeddingsProvider) {
     try {
-      embeddings = await embedTexts(config.embeddingsApiKey, chunks)
+      embeddings = await embedTexts(config.embeddingsProvider, config.embeddingsApiKey, chunks, {
+        kind: 'document',
+        title,
+      })
     } catch (err) {
       embedError = err
     }
@@ -72,19 +86,134 @@ export async function ingestDocument(
   if (embedError) throw embedError
 }
 
+// ------------------------------------------------------------
+// Lexical keyword fallback.
+//
+// `match_ai_knowledge_fts` runs `plainto_tsquery('simple', p_query)`,
+// which ANDs every token in the query — so a full natural-language
+// question ("Hola, ¿qué productos venden?") requires "hola" AND "que"
+// AND "productos" AND "venden" to ALL appear in the same chunk, which
+// almost never happens even when the chunk plainly answers the
+// question (it has "productos" but not "hola"/"que"/"venden"). When
+// that strict search returns nothing, decompose the query into
+// individual keywords and search each one — each is itself a valid
+// (single-token) plainto_tsquery, so this reuses the exact same
+// RPC/index, just OR'd across terms in the application layer instead
+// of AND'd inside Postgres.
+// ------------------------------------------------------------
+
+const MIN_KEYWORD_LENGTH = 3
+const MAX_FALLBACK_KEYWORDS = 6
+
+// Common closed-class words (articles, prepositions, pronouns,
+// conjunctions, auxiliary verbs) in Spanish and English — genuinely
+// stop words, not domain terms. Content verbs like "venden"/"tienen"
+// are deliberately NOT included: excluding them isn't linguistically
+// justified, and leaving them in is harmless (a per-term FTS search for
+// "tienen" just returns 0 rows and is ignored).
+const STOPWORDS = new Set([
+  // Spanish
+  'el', 'la', 'los', 'las', 'un', 'una', 'unos', 'unas', 'y', 'o', 'u', 'pero', 'si',
+  'de', 'del', 'al', 'en', 'por', 'para', 'con', 'sin', 'sobre', 'entre', 'hacia',
+  'hasta', 'desde', 'durante', 'antes', 'después', 'muy', 'más', 'menos', 'tan',
+  'tanto', 'este', 'esta', 'estos', 'estas', 'ese', 'esa', 'esos', 'esas', 'su', 'sus',
+  'mi', 'mis', 'tu', 'tus', 'nos', 'les', 'le', 'lo', 'se', 'me', 'te', 'nosotros',
+  'ustedes', 'yo', 'usted', 'ser', 'estar', 'hay', 'que', 'qué', 'como', 'cómo',
+  'donde', 'dónde', 'cuando', 'cuándo', 'cual', 'cuál', 'quien', 'quién', 'porque',
+  'hola', 'buenas', 'buenos', 'gracias', 'favor', 'the',
+  // English
+  'a', 'an', 'is', 'are', 'was', 'were', 'do', 'does', 'did', 'have', 'has', 'had',
+  'i', 'you', 'he', 'she', 'it', 'we', 'they', 'this', 'that', 'these', 'those',
+  'and', 'or', 'but', 'if', 'of', 'at', 'by', 'for', 'with', 'about', 'against',
+  'between', 'into', 'through', 'during', 'before', 'after', 'above', 'below', 'to',
+  'from', 'up', 'down', 'in', 'out', 'on', 'off', 'over', 'under', 'again', 'then',
+  'once', 'here', 'there', 'when', 'where', 'why', 'how', 'all', 'any', 'both',
+  'each', 'few', 'more', 'most', 'other', 'some', 'such', 'no', 'nor', 'not', 'only',
+  'own', 'same', 'so', 'than', 'too', 'very', 'can', 'will', 'just', 'should', 'now',
+  'what', 'which', 'who', 'whom', 'be', 'been', 'being', 'hi', 'hello', 'please',
+  'thanks',
+])
+
+/**
+ * Extract candidate keywords from a natural-language question for the
+ * per-term lexical fallback. Unicode-aware tokenization (accented
+ * words like "ubicación" survive intact), lowercased, punctuation
+ * stripped, very short tokens and stopwords removed, deduplicated, and
+ * capped so a verbose question can't fan out into dozens of RPC calls.
+ */
+export function extractKeywords(query: string): string[] {
+  const tokens = query.toLowerCase().normalize('NFC').match(/[\p{L}\p{N}]+/gu) ?? []
+  const seen = new Set<string>()
+  const keywords: string[] = []
+  for (const token of tokens) {
+    if (token.length < MIN_KEYWORD_LENGTH) continue
+    if (STOPWORDS.has(token)) continue
+    if (seen.has(token)) continue
+    seen.add(token)
+    keywords.push(token)
+    if (keywords.length >= MAX_FALLBACK_KEYWORDS) break
+  }
+  return keywords
+}
+
+/**
+ * Run the strict full-text RPC for each keyword in parallel and merge
+ * the results into `picked` (id → content, dedup'd, capped at `k`).
+ * Best-effort: an individual RPC failure/rejection is skipped rather
+ * than aborting the other keywords' results.
+ */
+async function fillFromKeywordFallback(
+  db: SupabaseClient,
+  accountId: string,
+  query: string,
+  k: number,
+  picked: Map<string, string>,
+): Promise<void> {
+  const keywords = extractKeywords(query)
+  if (keywords.length === 0) return
+
+  const settled = await Promise.allSettled(
+    keywords.map((term) =>
+      db.rpc('match_ai_knowledge_fts', {
+        p_account_id: accountId,
+        p_query: term,
+        p_match_count: k,
+      }),
+    ),
+  )
+
+  for (const result of settled) {
+    if (picked.size >= k) break
+    if (result.status !== 'fulfilled') continue
+    const { data, error } = result.value
+    if (error || !Array.isArray(data)) continue
+    for (const row of data as MatchRow[]) {
+      if (picked.size >= k) break
+      if (!picked.has(row.id)) picked.set(row.id, row.content)
+    }
+  }
+}
+
 /**
  * Retrieve up to `k` knowledge excerpts relevant to `queryText`.
  *
  * Semantic-primary when an embeddings key is configured (embed the
- * query → cosine-nearest chunks), then topped up with lexical full-text
- * matches to fill `k`. Lexical-only when there's no key. Best-effort:
- * any failure (no KB, embedding error, RPC error) degrades to fewer or
- * zero results and never throws into the draft / auto-reply path.
+ * query with the account's provider → cosine-nearest chunks), then
+ * topped up with lexical full-text matches to fill `k`. The lexical
+ * step tries the strict whole-query search FIRST; only when that finds
+ * literally nothing does it fall back to searching the query's
+ * individual keywords (see `fillFromKeywordFallback`) — a natural-
+ * language question ("¿Tienen taladros?") otherwise ANDs every token
+ * and matches nothing even when "taladros" plainly appears in the KB.
+ * Lexical-only (strict, then keyword fallback) when there's no
+ * embeddings key. Best-effort throughout: any failure (no KB, embedding
+ * error, RPC error) degrades to fewer or zero results and never throws
+ * into the draft / auto-reply path.
  */
 export async function retrieveKnowledge(
   db: SupabaseClient,
   accountId: string,
-  config: Pick<AiConfig, 'embeddingsApiKey'>,
+  config: EmbeddingsConfig,
   queryText: string,
   k = 5,
 ): Promise<string[]> {
@@ -108,9 +237,14 @@ export async function retrieveKnowledge(
   const picked = new Map<string, string>() // id → content, preserves order
 
   // Semantic path.
-  if (config.embeddingsApiKey) {
+  if (config.embeddingsApiKey && config.embeddingsProvider) {
     try {
-      const [queryEmbedding] = await embedTexts(config.embeddingsApiKey, [query])
+      const [queryEmbedding] = await embedTexts(
+        config.embeddingsProvider,
+        config.embeddingsApiKey,
+        [query],
+        { kind: 'query' },
+      )
       if (queryEmbedding) {
         const { data, error } = await db.rpc('match_ai_knowledge_semantic', {
           p_account_id: accountId,
@@ -134,11 +268,20 @@ export async function retrieveKnowledge(
         p_query: query,
         p_match_count: k,
       })
-      if (!error && Array.isArray(data)) {
-        for (const row of data as MatchRow[]) {
+      const strictRows = !error && Array.isArray(data) ? (data as MatchRow[]) : null
+      if (strictRows) {
+        for (const row of strictRows) {
           if (picked.size >= k) break
           if (!picked.has(row.id)) picked.set(row.id, row.content)
         }
+      }
+
+      // The strict AND-query found nothing at all — decompose into
+      // individual keyword searches rather than leaving a plainly
+      // answerable question unanswered.
+      const strictFoundNothing = !strictRows || strictRows.length === 0
+      if (strictFoundNothing && picked.size < k) {
+        await fillFromKeywordFallback(db, accountId, query, k, picked)
       }
     } catch (err) {
       console.error('[ai knowledge] lexical retrieval failed:', err)

--- a/src/lib/ai/providers/anthropic.ts
+++ b/src/lib/ai/providers/anthropic.ts
@@ -64,7 +64,7 @@ export async function generateAnthropic(args: ProviderArgs): Promise<ProviderRes
   }
 
   if (!res.ok) {
-    throw await providerHttpError('Anthropic', res)
+    throw await providerHttpError('Anthropic', res, { redact: [apiKey] })
   }
 
   const data = (await res.json().catch(() => null)) as AnthropicResponse | null

--- a/src/lib/ai/providers/gemini.test.ts
+++ b/src/lib/ai/providers/gemini.test.ts
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { generateGemini } from './gemini'
+import { AiError } from '../types'
+import type { ProviderArgs } from './shared'
+
+const API_KEY = 'gemini-secret-key-xyz'
+
+function baseArgs(overrides: Partial<ProviderArgs> = {}): ProviderArgs {
+  return {
+    apiKey: API_KEY,
+    model: 'gemini-3.8-flash',
+    systemPrompt: 'You are a helpful assistant.',
+    messages: [{ role: 'user', content: 'Hola' }],
+    timeoutMs: 30_000,
+    ...overrides,
+  }
+}
+
+function okResponse(json: unknown): Response {
+  return { ok: true, status: 200, json: async () => json } as unknown as Response
+}
+
+function errResponse(status: number, json: unknown): Response {
+  return { ok: false, status, json: async () => json } as unknown as Response
+}
+
+function successBody(text: string, usage?: Record<string, number>): unknown {
+  return {
+    candidates: [{ content: { parts: [{ text }] } }],
+    ...(usage ? { usageMetadata: usage } : {}),
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse(successBody('Hi there!'))))
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('generateGemini — request shape', () => {
+  it('calls the documented generateContent endpoint for the given model', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs({ model: 'gemini-3.8-flash' }))
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.8-flash:generateContent',
+    )
+  })
+
+  it('URL-encodes the model segment (safe path construction)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs({ model: 'weird/model name' }))
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/weird%2Fmodel%20name:generateContent',
+    )
+  })
+
+  it('authenticates via the x-goog-api-key header, not Authorization/Bearer', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs())
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['x-goog-api-key']).toBe(API_KEY)
+    expect(init.headers.Authorization).toBeUndefined()
+  })
+
+  it('sends Content-Type: application/json', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs())
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['Content-Type']).toBe('application/json')
+  })
+
+  it('sends the system prompt via systemInstruction.parts, never as a user message', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs({ systemPrompt: 'Be concise and friendly.' }))
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.systemInstruction).toEqual({ parts: [{ text: 'Be concise and friendly.' }] })
+    expect(body.contents.some((c: { parts: { text: string }[] }) =>
+      c.parts.some((p) => p.text === 'Be concise and friendly.'),
+    )).toBe(false)
+  })
+
+  it('maps role "user" to Gemini role "user"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs({ messages: [{ role: 'user', content: 'Hi' }] }))
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'Hi' }] }])
+  })
+
+  it('maps role "assistant" to Gemini role "model"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(
+      baseArgs({
+        messages: [
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Hello, how can I help?' },
+          { role: 'user', content: 'What are your hours?' },
+        ],
+      }),
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.contents[1]).toEqual({
+      role: 'model',
+      parts: [{ text: 'Hello, how can I help?' }],
+    })
+  })
+
+  it('merges consecutive same-role turns before sending', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(
+      baseArgs({
+        messages: [
+          { role: 'user', content: 'Hi' },
+          { role: 'user', content: 'Are you open today?' },
+        ],
+      }),
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.contents).toHaveLength(1)
+    expect(body.contents[0].parts[0].text).toBe('Hi\n\nAre you open today?')
+  })
+
+  it('sets generationConfig.maxOutputTokens to MAX_OUTPUT_TOKENS (1024)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs())
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.generationConfig.maxOutputTokens).toBe(1024)
+  })
+
+  it('sets thinkingConfig.thinkingLevel to "low"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs())
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.generationConfig.thinkingConfig).toEqual({ thinkingLevel: 'low' })
+  })
+
+  it('never sends temperature, topP, topK, candidateCount, or thinkingBudget', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs())
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.generationConfig).not.toHaveProperty('temperature')
+    expect(body.generationConfig).not.toHaveProperty('topP')
+    expect(body.generationConfig).not.toHaveProperty('topK')
+    expect(body.generationConfig).not.toHaveProperty('candidateCount')
+    expect(body.generationConfig.thinkingConfig).not.toHaveProperty('thinkingBudget')
+  })
+
+  it('does not request includeThoughts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(baseArgs())
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.generationConfig.thinkingConfig).not.toHaveProperty('includeThoughts')
+  })
+})
+
+describe('generateGemini — trailing model-turn edge case (no prefilled answer)', () => {
+  it('drops a trailing assistant/model turn rather than asking Gemini to continue it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(
+      baseArgs({
+        messages: [
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Welcome! How can I help?' },
+        ],
+      }),
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'Hi' }] }])
+  })
+
+  it('falls back to a neutral placeholder user turn when the history is bot-only', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await generateGemini(
+      baseArgs({ messages: [{ role: 'assistant', content: 'Welcome!' }] }),
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.contents).toHaveLength(1)
+    expect(body.contents[0].role).toBe('user')
+    expect(body.contents[0].parts[0].text).not.toBe('')
+  })
+
+  it('drops an empty-content message that survives merging (mergeConsecutive runs first, per spec)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(successBody('ok')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Not consecutive with another same-role turn, so mergeConsecutive
+    // leaves it standing alone — the empty-content filter then drops it.
+    await generateGemini(
+      baseArgs({
+        messages: [
+          { role: 'user', content: '   ' },
+          { role: 'assistant', content: 'Hi, how can I help?' },
+          { role: 'user', content: 'Real question' },
+        ],
+      }),
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.contents).toEqual([
+      { role: 'model', parts: [{ text: 'Hi, how can I help?' }] },
+      { role: 'user', parts: [{ text: 'Real question' }] },
+    ])
+  })
+})
+
+describe('generateGemini — response parsing', () => {
+  it('parses candidates[0].content.parts[].text', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse(successBody('The answer is 42.'))))
+    const result = await generateGemini(baseArgs())
+    expect(result.text).toBe('The answer is 42.')
+  })
+
+  it('ignores parts marked thought: true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { text: 'reasoning scratch work...', thought: true },
+                  { text: 'Final visible answer.' },
+                ],
+              },
+            },
+          ],
+        }),
+      ),
+    )
+    const result = await generateGemini(baseArgs())
+    expect(result.text).toBe('Final visible answer.')
+    expect(result.text).not.toContain('reasoning scratch work')
+  })
+
+  it('concatenates multiple final text parts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse({
+          candidates: [
+            { content: { parts: [{ text: 'Part one. ' }, { text: 'Part two.' }] } },
+          ],
+        }),
+      ),
+    )
+    const result = await generateGemini(baseArgs())
+    expect(result.text).toBe('Part one. Part two.')
+  })
+
+  it('throws empty_response on a 2xx with no usable text', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(okResponse({ candidates: [{ content: { parts: [] } }] })),
+    )
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({
+      code: 'empty_response',
+    })
+  })
+
+  it('throws empty_response when only thought parts are present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse({
+          candidates: [{ content: { parts: [{ text: 'thinking...', thought: true }] } }],
+        }),
+      ),
+    )
+    await expect(generateGemini(baseArgs())).rejects.toBeInstanceOf(AiError)
+  })
+
+  it('does not invent a fallback response body on empty_response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({ candidates: [] })))
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({
+      code: 'empty_response',
+      message: 'Gemini returned an empty response.',
+    })
+  })
+})
+
+describe('generateGemini — usage normalization', () => {
+  it('maps promptTokenCount to promptTokens', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse(successBody('ok', { promptTokenCount: 100, candidatesTokenCount: 20, totalTokenCount: 120 })),
+      ),
+    )
+    const result = await generateGemini(baseArgs())
+    expect(result.usage?.promptTokens).toBe(100)
+  })
+
+  it('maps candidatesTokenCount into completionTokens', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse(successBody('ok', { promptTokenCount: 10, candidatesTokenCount: 30, totalTokenCount: 40 })),
+      ),
+    )
+    const result = await generateGemini(baseArgs())
+    expect(result.usage?.completionTokens).toBe(30)
+  })
+
+  it('adds thoughtsTokenCount into completionTokens', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse(
+          successBody('ok', {
+            promptTokenCount: 10,
+            candidatesTokenCount: 30,
+            thoughtsTokenCount: 15,
+            totalTokenCount: 55,
+          }),
+        ),
+      ),
+    )
+    const result = await generateGemini(baseArgs())
+    expect(result.usage?.completionTokens).toBe(45) // 30 + 15
+  })
+
+  it('uses totalTokenCount as totalTokens when present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        okResponse(
+          successBody('ok', { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 999 }),
+        ),
+      ),
+    )
+    const result = await generateGemini(baseArgs())
+    expect(result.usage?.totalTokens).toBe(999)
+  })
+
+  it('tolerates missing usageMetadata entirely', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse(successBody('ok'))))
+    const result = await generateGemini(baseArgs())
+    expect(result.usage).toBeNull()
+  })
+})
+
+describe('generateGemini — errors', () => {
+  it('maps 403 to invalid_key', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errResponse(403, { error: { message: 'API key not valid' } })),
+    )
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({ code: 'invalid_key', status: 401 })
+  })
+
+  it('maps 401 to invalid_key too', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errResponse(401, { error: { message: 'unauthorized' } })))
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({ code: 'invalid_key' })
+  })
+
+  it('maps 429 to rate_limited', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errResponse(429, { error: { message: 'quota exceeded' } })),
+    )
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({ code: 'rate_limited' })
+  })
+
+  it('maps 500 to provider_error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errResponse(500, { error: { message: 'internal error' } })),
+    )
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({ code: 'provider_error' })
+  })
+
+  it('maps a timeout to code "timeout"', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError')),
+    )
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({ code: 'timeout' })
+  })
+
+  it('maps a network failure to code "network_error"', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('getaddrinfo ENOTFOUND')))
+    await expect(generateGemini(baseArgs())).rejects.toMatchObject({ code: 'network_error' })
+  })
+})
+
+describe('generateGemini — never exposes the API key', () => {
+  it('redacts the FULL key when the upstream error body echoes it back verbatim', async () => {
+    // Adversarial / accidental-upstream-leak case: the provider's own
+    // error message contains the complete request API key, not a
+    // truncated hint. providerHttpError's `redact` must strip it
+    // entirely before the AiError is ever constructed.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        errResponse(403, { error: { message: `Rejected API key ${API_KEY}` } }),
+      ),
+    )
+    let caught: AiError | null = null
+    try {
+      await generateGemini(baseArgs())
+    } catch (err) {
+      caught = err as AiError
+    }
+    expect(caught).toBeInstanceOf(AiError)
+    expect(caught!.message).not.toContain(API_KEY)
+    expect(caught!.message).toContain('[REDACTED]')
+  })
+
+  it('the key never appears in the empty_response AiError', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({ candidates: [] })))
+    let caught: AiError | null = null
+    try {
+      await generateGemini(baseArgs())
+    } catch (err) {
+      caught = err as AiError
+    }
+    expect(caught!.message).not.toContain(API_KEY)
+  })
+
+  it('the key never appears in a network-error AiError', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    let caught: AiError | null = null
+    try {
+      await generateGemini(baseArgs())
+    } catch (err) {
+      caught = err as AiError
+    }
+    expect(caught!.message).not.toContain(API_KEY)
+  })
+
+  it('never logs the API key, on success or failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse(successBody('ok'))))
+    await generateGemini(baseArgs())
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errResponse(401, { error: { message: 'bad key' } })))
+    await generateGemini(baseArgs()).catch(() => {})
+
+    const logged = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...logSpy.mock.calls]
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join('\n')
+    expect(logged).not.toContain(API_KEY)
+
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+    logSpy.mockRestore()
+  })
+})

--- a/src/lib/ai/providers/gemini.ts
+++ b/src/lib/ai/providers/gemini.ts
@@ -1,0 +1,138 @@
+import { AiError, type ChatMessage, type ProviderResult } from '../types'
+import { MAX_OUTPUT_TOKENS } from '../defaults'
+import {
+  mergeConsecutive,
+  normalizeUsage,
+  providerHttpError,
+  toNetworkError,
+  type ProviderArgs,
+} from './shared'
+
+const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models'
+
+interface GeminiPart {
+  text?: string
+  /** Set on a reasoning/"thinking" part. We never request these
+   *  (`includeThoughts` is not sent) but parse defensively anyway. */
+  thought?: boolean
+}
+
+interface GeminiResponse {
+  candidates?: { content?: { parts?: GeminiPart[] } }[]
+  usageMetadata?: {
+    promptTokenCount?: number
+    candidatesTokenCount?: number
+    thoughtsTokenCount?: number
+    totalTokenCount?: number
+  }
+}
+
+interface GeminiContent {
+  role: 'user' | 'model'
+  parts: { text: string }[]
+}
+
+/**
+ * Gemini expects the conversation as `contents` with roles 'user' /
+ * 'model' (our `ChatMessage` uses 'user' / 'assistant') and generates
+ * the NEXT turn after the last entry — which only makes sense when the
+ * transcript ends on the customer's turn (the normal CRM case: the
+ * customer just wrote in).
+ *
+ * Defensively drop any trailing model-role turns rather than asking
+ * Gemini to continue its own last message — this never mutates the
+ * persisted conversation (it only reshapes a local copy for the
+ * request) and never fabricates a "prefilled" model answer. Falls back
+ * to a neutral placeholder user turn only if that leaves nothing at
+ * all (e.g. history is bot-only so far) — mirrors the Anthropic
+ * adapter's analogous edge case (see `normalizeForAnthropic`).
+ */
+function toGeminiContents(messages: ChatMessage[]): GeminiContent[] {
+  const merged = mergeConsecutive(messages).filter((m) => m.content.trim().length > 0)
+  while (merged.length > 0 && merged[merged.length - 1].role === 'assistant') {
+    merged.pop()
+  }
+  const turns =
+    merged.length > 0
+      ? merged
+      : [{ role: 'user' as const, content: '(The customer has not sent a message yet.)' }]
+  return turns.map((m) => ({
+    role: m.role === 'assistant' ? 'model' : 'user',
+    parts: [{ text: m.content }],
+  }))
+}
+
+/**
+ * Call Gemini's `generateContent` REST endpoint with the caller's own
+ * key. Returns the raw assistant text + token usage (handoff parsing
+ * happens in `generateReply`).
+ *
+ * Fixed at `thinkingLevel: 'low'` for this first version — WA CRM is
+ * conversational chat support, where reply latency and per-message
+ * cost matter more than deeper reasoning. Not yet exposed as a user
+ * setting; no `temperature`/`topP`/`topK`/`candidateCount`/
+ * `thinkingBudget` are sent (gemini-3.8-flash uses `thinkingLevel`,
+ * not `thinkingBudget`).
+ */
+export async function generateGemini(args: ProviderArgs): Promise<ProviderResult> {
+  const { apiKey, model, systemPrompt, messages, timeoutMs } = args
+
+  // Build the model path safely — `model` is free text from the
+  // settings form and goes straight into the URL, so it's encoded
+  // rather than interpolated raw.
+  const url = `${GEMINI_API_BASE}/${encodeURIComponent(model)}:generateContent`
+
+  let res: Response
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'x-goog-api-key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: systemPrompt }] },
+        contents: toGeminiContents(messages),
+        generationConfig: {
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          thinkingConfig: { thinkingLevel: 'low' },
+        },
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+  } catch (err) {
+    throw toNetworkError(err)
+  }
+
+  if (!res.ok) {
+    throw await providerHttpError('Gemini', res, { redact: [apiKey] })
+  }
+
+  const data = (await res.json().catch(() => null)) as GeminiResponse | null
+
+  // Only final text parts — a `thought === true` part is reasoning
+  // scratch-space, never shown to the customer, even though we don't
+  // request it via includeThoughts.
+  const text = (data?.candidates?.[0]?.content?.parts ?? [])
+    .filter((p) => p.thought !== true && typeof p.text === 'string')
+    .map((p) => p.text as string)
+    .join('')
+    .trim()
+  if (!text) {
+    throw new AiError('Gemini returned an empty response.', {
+      code: 'empty_response',
+    })
+  }
+
+  const usageMeta = data?.usageMetadata
+  // "Completion" spend includes thinking tokens — they're real spend
+  // against the account's key even though their content never reaches
+  // the customer.
+  const usage = normalizeUsage({
+    prompt: usageMeta?.promptTokenCount,
+    completion: (usageMeta?.candidatesTokenCount ?? 0) + (usageMeta?.thoughtsTokenCount ?? 0),
+    total: usageMeta?.totalTokenCount,
+  })
+
+  return { text, usage }
+}

--- a/src/lib/ai/providers/openai.ts
+++ b/src/lib/ai/providers/openai.ts
@@ -50,7 +50,7 @@ export async function generateOpenAi(args: ProviderArgs): Promise<ProviderResult
   }
 
   if (!res.ok) {
-    throw await providerHttpError('OpenAI', res)
+    throw await providerHttpError('OpenAI', res, { redact: [apiKey] })
   }
 
   const data = (await res.json().catch(() => null)) as OpenAiResponse | null

--- a/src/lib/ai/providers/shared.test.ts
+++ b/src/lib/ai/providers/shared.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+import { redactSecrets, providerHttpError } from './shared'
+
+function errResponse(status: number, json: unknown): Response {
+  return { ok: false, status, json: async () => json } as unknown as Response
+}
+
+describe('redactSecrets', () => {
+  it('redacts a single occurrence', () => {
+    expect(redactSecrets('key is sk-abc123', ['sk-abc123'])).toBe('key is [REDACTED]')
+  })
+
+  it('redacts multiple occurrences of the same secret', () => {
+    expect(redactSecrets('sk-abc123 ... again: sk-abc123', ['sk-abc123'])).toBe(
+      '[REDACTED] ... again: [REDACTED]',
+    )
+  })
+
+  it('redacts multiple distinct secrets in one pass', () => {
+    expect(redactSecrets('a=key-one b=key-two', ['key-one', 'key-two'])).toBe(
+      'a=[REDACTED] b=[REDACTED]',
+    )
+  })
+
+  it('secrets with regex-special characters do not break sanitization (split/join, not regex)', () => {
+    const weird = 'sk-a.b*c(d)e+f$g[h]i|j\\k'
+    expect(redactSecrets(`token: ${weird} end`, [weird])).toBe('token: [REDACTED] end')
+  })
+
+  it('ignores empty/nullish secrets — the message is unchanged', () => {
+    expect(redactSecrets('nothing to redact here', ['', null, undefined])).toBe(
+      'nothing to redact here',
+    )
+  })
+
+  it('an empty redact list leaves the message unchanged', () => {
+    expect(redactSecrets('some message with sk-real-key', [])).toBe(
+      'some message with sk-real-key',
+    )
+  })
+
+  it('a secret not present in the text leaves the message unchanged', () => {
+    expect(redactSecrets('unrelated message', ['sk-not-here'])).toBe('unrelated message')
+  })
+})
+
+describe('providerHttpError — redaction', () => {
+  it('redacts the secret from the provider detail message before building AiError', async () => {
+    const res = errResponse(400, { error: { message: 'bad request, key=sk-leak-me was rejected' } })
+    const err = await providerHttpError('TestProvider', res, { redact: ['sk-leak-me'] })
+    expect(err.message).not.toContain('sk-leak-me')
+    expect(err.message).toContain('[REDACTED]')
+  })
+
+  it('redacts every occurrence when the secret appears more than once', async () => {
+    const res = errResponse(400, {
+      error: { message: 'sk-dup rejected sk-dup, retry without sk-dup' },
+    })
+    const err = await providerHttpError('TestProvider', res, { redact: ['sk-dup'] })
+    expect(err.message).not.toContain('sk-dup')
+    expect(err.message.match(/\[REDACTED\]/g)).toHaveLength(3)
+  })
+
+  it('a secret with special characters is fully redacted', async () => {
+    const weird = 'sk-a.b*c(d)e+f$g[h]i'
+    const res = errResponse(400, { error: { message: `rejected: ${weird}` } })
+    const err = await providerHttpError('TestProvider', res, { redact: [weird] })
+    expect(err.message).not.toContain(weird)
+    expect(err.message).toContain('[REDACTED]')
+  })
+
+  it('an empty/omitted redact list leaves the provider detail intact', async () => {
+    const res = errResponse(400, { error: { message: 'plain error, nothing secret' } })
+    const withEmpty = await providerHttpError('TestProvider', res, { redact: [] })
+    expect(withEmpty.message).toContain('plain error, nothing secret')
+
+    const res2 = errResponse(400, { error: { message: 'plain error, nothing secret' } })
+    const withOmitted = await providerHttpError('TestProvider', res2)
+    expect(withOmitted.message).toContain('plain error, nothing secret')
+  })
+
+  it.each([
+    [401, 'invalid_key', 401],
+    [403, 'invalid_key', 401],
+    [429, 'rate_limited', 502],
+    [500, 'provider_error', 502],
+  ])(
+    'status %i still maps to code %s / status %i, even with redaction active',
+    async (upstreamStatus, expectedCode, expectedStatus) => {
+      const res = errResponse(upstreamStatus, {
+        error: { message: `upstream said no, key sk-should-be-gone` },
+      })
+      const err = await providerHttpError('TestProvider', res, { redact: ['sk-should-be-gone'] })
+      expect(err.code).toBe(expectedCode)
+      expect(err.status).toBe(expectedStatus)
+      expect(err.message).not.toContain('sk-should-be-gone')
+    },
+  )
+
+  it('never logs the secret, on success or on a redacted error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const res = errResponse(403, { error: { message: 'bad key sk-never-logged' } })
+    await providerHttpError('TestProvider', res, { redact: ['sk-never-logged'] })
+
+    const logged = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...logSpy.mock.calls]
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join('\n')
+    expect(logged).not.toContain('sk-never-logged')
+
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+    logSpy.mockRestore()
+  })
+})

--- a/src/lib/ai/providers/shared.ts
+++ b/src/lib/ai/providers/shared.ts
@@ -51,11 +51,41 @@ export function toNetworkError(err: unknown): AiError {
   })
 }
 
-/** Build a typed AiError from a non-2xx provider response, pulling the
- *  provider's own error message out of the JSON body when present. */
+/**
+ * Replace every occurrence of each secret in `text` with `[REDACTED]`.
+ * Uses split/join rather than a regex built from the secret, so special
+ * regex characters that can legally appear in an API key (`.`, `*`,
+ * `(`, `+`, …) never produce a broken or wrong-matching pattern.
+ * Falsy/empty secrets are ignored (nothing to redact, and an empty
+ * needle would otherwise "match" between every character).
+ */
+export function redactSecrets(
+  text: string,
+  secrets: readonly (string | null | undefined)[],
+): string {
+  let out = text
+  for (const secret of secrets) {
+    if (!secret) continue
+    out = out.split(secret).join('[REDACTED]')
+  }
+  return out
+}
+
+/**
+ * Build a typed AiError from a non-2xx provider response, pulling the
+ * provider's own error message out of the JSON body when present.
+ *
+ * `redact` — secrets (typically the caller's own apiKey) that must
+ * never reach the constructed AiError even if the upstream response
+ * happens to echo one back (accidentally, or via a misconfigured
+ * proxy). Redaction runs on the extracted detail text BEFORE the
+ * AiError is built, so there is no path from an unsanitized value to
+ * the thrown error, an HTTP response, or a log line.
+ */
 export async function providerHttpError(
   provider: string,
   res: Response,
+  opts: { redact?: readonly (string | null | undefined)[] } = {},
 ): Promise<AiError> {
   let detail = ''
   try {
@@ -66,6 +96,10 @@ export async function providerHttpError(
         : (body?.error?.message ?? '')
   } catch {
     // Non-JSON error body — fall back to the status line.
+  }
+
+  if (opts.redact && opts.redact.length > 0) {
+    detail = redactSecrets(detail, opts.redact)
   }
 
   const { status } = res

--- a/src/lib/ai/send.test.ts
+++ b/src/lib/ai/send.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  resolveOutboundTransport: vi.fn(),
+  sendManyChatTextToContact: vi.fn(),
+  engineSendText: vi.fn(),
+  state: {
+    insertCalls: [] as Record<string, unknown>[],
+    insertError: null as { message: string } | null,
+    conversationUpdateCalls: [] as Record<string, unknown>[],
+  },
+}))
+
+vi.mock('@/lib/whatsapp/send-message', () => ({
+  resolveOutboundTransport: h.resolveOutboundTransport,
+}))
+
+// Keep the real error classes (`instanceof` checks in send.ts depend on
+// them) — mock only the network-touching function.
+vi.mock('@/lib/manychat/contact-send', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sendManyChatTextToContact: h.sendManyChatTextToContact,
+}))
+
+vi.mock('@/lib/flows/meta-send', () => ({
+  engineSendText: h.engineSendText,
+}))
+
+vi.mock('./admin-client', () => ({
+  supabaseAdmin: () => ({
+    from(table: string) {
+      if (table === 'messages') {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            h.state.insertCalls.push(row)
+            return Promise.resolve({ error: h.state.insertError })
+          },
+        }
+      }
+      if (table === 'conversations') {
+        return {
+          update: (row: Record<string, unknown>) => {
+            h.state.conversationUpdateCalls.push(row)
+            return { eq: () => Promise.resolve({ error: null }) }
+          },
+        }
+      }
+      // Proves flow_runs (or anything else) is never touched by the AI
+      // ManyChat send path — reaching this is a test failure.
+      throw new Error(`unexpected table: ${table}`)
+    },
+  }),
+}))
+
+import { sendAiTextToConversation } from './send'
+import {
+  ManyChatNotConfiguredError,
+  ManyChatContactNotLinkedError,
+} from '@/lib/manychat/contact-send'
+import { ManyChatApiError } from '@/lib/manychat/api'
+
+const ARGS = {
+  accountId: 'acct-1',
+  conversationId: 'conv-1',
+  contactId: 'contact-1',
+  text: 'Hola! ¿En qué puedo ayudarte?',
+  configOwnerUserId: 'user-1',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.state.insertCalls = []
+  h.state.insertError = null
+  h.state.conversationUpdateCalls = []
+  h.resolveOutboundTransport.mockReturnValue('meta')
+  h.engineSendText.mockResolvedValue({ whatsapp_message_id: 'wamid.ai1' })
+  h.sendManyChatTextToContact.mockResolvedValue({
+    whatsappMessageId: 'manychat-out:abc-123',
+  })
+})
+
+describe('sendAiTextToConversation — transport=manychat', () => {
+  beforeEach(() => {
+    h.resolveOutboundTransport.mockReturnValue('manychat')
+  })
+
+  it('sends via the ManyChat transport primitive, never Meta', async () => {
+    await sendAiTextToConversation(ARGS)
+    expect(h.sendManyChatTextToContact).toHaveBeenCalledWith({
+      db: expect.anything(),
+      accountId: 'acct-1',
+      contactId: 'contact-1',
+      text: ARGS.text,
+    })
+    expect(h.engineSendText).not.toHaveBeenCalled()
+  })
+
+  it('persists exactly one message row on success', async () => {
+    await sendAiTextToConversation(ARGS)
+    expect(h.state.insertCalls).toHaveLength(1)
+  })
+
+  it("persists sender_type='bot', content_type='text', status='sent', ai_generated=true", async () => {
+    await sendAiTextToConversation(ARGS)
+    expect(h.state.insertCalls[0]).toMatchObject({
+      conversation_id: 'conv-1',
+      sender_type: 'bot',
+      content_type: 'text',
+      content_text: ARGS.text,
+      status: 'sent',
+      ai_generated: true,
+    })
+  })
+
+  it('uses the transport-returned message id — never a fabricated wamid', async () => {
+    await sendAiTextToConversation(ARGS)
+    expect(h.state.insertCalls[0].message_id).toBe('manychat-out:abc-123')
+    expect(String(h.state.insertCalls[0].message_id)).not.toMatch(/^wamid\./)
+  })
+
+  it('updates last_message_text and last_message_at', async () => {
+    await sendAiTextToConversation(ARGS)
+    expect(h.state.conversationUpdateCalls).toHaveLength(1)
+    expect(h.state.conversationUpdateCalls[0]).toMatchObject({
+      last_message_text: ARGS.text,
+    })
+    expect(h.state.conversationUpdateCalls[0].last_message_at).toBeTruthy()
+  })
+
+  it('never touches flow_runs (no pause-on-agent-send for an AI reply)', async () => {
+    // The fake admin-client throws on any table other than
+    // messages/conversations — a successful resolve proves this.
+    await expect(sendAiTextToConversation(ARGS)).resolves.toBeDefined()
+  })
+
+  it('does not persist when the mapping is missing (no send, no fallback)', async () => {
+    h.sendManyChatTextToContact.mockRejectedValue(
+      new ManyChatContactNotLinkedError('not linked yet'),
+    )
+    await expect(sendAiTextToConversation(ARGS)).rejects.toBeInstanceOf(
+      ManyChatContactNotLinkedError,
+    )
+    expect(h.state.insertCalls).toHaveLength(0)
+    expect(h.engineSendText).not.toHaveBeenCalled()
+  })
+
+  it('does not persist when MANYCHAT_API_KEY is missing (no send, no fallback)', async () => {
+    h.sendManyChatTextToContact.mockRejectedValue(
+      new ManyChatNotConfiguredError('MANYCHAT_API_KEY missing'),
+    )
+    await expect(sendAiTextToConversation(ARGS)).rejects.toBeInstanceOf(
+      ManyChatNotConfiguredError,
+    )
+    expect(h.state.insertCalls).toHaveLength(0)
+    expect(h.engineSendText).not.toHaveBeenCalled()
+  })
+
+  it.each([401, 403, 429, 500])(
+    'does not persist a message when ManyChat responds %i',
+    async (status) => {
+      h.sendManyChatTextToContact.mockRejectedValue(
+        new ManyChatApiError(status, `ManyChat error ${status}`),
+      )
+      await expect(sendAiTextToConversation(ARGS)).rejects.toMatchObject({ status })
+      expect(h.state.insertCalls).toHaveLength(0)
+      expect(h.engineSendText).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does not persist on a ManyChat timeout (504)', async () => {
+    h.sendManyChatTextToContact.mockRejectedValue(
+      new ManyChatApiError(504, 'ManyChat request timed out after 10000ms'),
+    )
+    await expect(sendAiTextToConversation(ARGS)).rejects.toMatchObject({ status: 504 })
+    expect(h.state.insertCalls).toHaveLength(0)
+  })
+
+  it('does not persist when ManyChat 200s but status != "success" (502 from the client)', async () => {
+    h.sendManyChatTextToContact.mockRejectedValue(
+      new ManyChatApiError(502, 'ManyChat returned HTTP 200 but did not confirm success'),
+    )
+    await expect(sendAiTextToConversation(ARGS)).rejects.toMatchObject({ status: 502 })
+    expect(h.state.insertCalls).toHaveLength(0)
+  })
+
+  it('does not swallow a DB insert failure — throws rather than silently dropping the reply', async () => {
+    h.state.insertError = { message: 'constraint violation' }
+    await expect(sendAiTextToConversation(ARGS)).rejects.toThrow()
+  })
+
+  it('never logs MANYCHAT_API_KEY on a ManyChat failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    h.sendManyChatTextToContact.mockRejectedValue(
+      new ManyChatApiError(401, 'unauthorized — invalid token'),
+    )
+    await sendAiTextToConversation(ARGS).catch(() => {})
+    const logged = errorSpy.mock.calls
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join('\n')
+    expect(logged).not.toContain('mc-key-test')
+    errorSpy.mockRestore()
+  })
+})
+
+describe('sendAiTextToConversation — transport=meta (unchanged behavior)', () => {
+  beforeEach(() => {
+    h.resolveOutboundTransport.mockReturnValue('meta')
+  })
+
+  it('delegates to engineSendText with aiGenerated: true, exactly as before', async () => {
+    await sendAiTextToConversation(ARGS)
+    expect(h.engineSendText).toHaveBeenCalledWith({
+      accountId: 'acct-1',
+      userId: 'user-1',
+      conversationId: 'conv-1',
+      contactId: 'contact-1',
+      text: ARGS.text,
+      aiGenerated: true,
+    })
+  })
+
+  it('never touches the ManyChat transport primitive', async () => {
+    await sendAiTextToConversation(ARGS)
+    expect(h.sendManyChatTextToContact).not.toHaveBeenCalled()
+  })
+
+  it('returns engineSendText\'s result untouched', async () => {
+    const result = await sendAiTextToConversation(ARGS)
+    expect(result).toEqual({ whatsapp_message_id: 'wamid.ai1' })
+  })
+
+  it('propagates an engineSendText failure (e.g. Meta rejects the send)', async () => {
+    h.engineSendText.mockRejectedValue(new Error('Meta API error: 400'))
+    await expect(sendAiTextToConversation(ARGS)).rejects.toThrow('Meta API error: 400')
+  })
+})

--- a/src/lib/ai/send.ts
+++ b/src/lib/ai/send.ts
@@ -1,0 +1,121 @@
+import { supabaseAdmin } from './admin-client'
+import { resolveOutboundTransport } from '@/lib/whatsapp/send-message'
+import {
+  sendManyChatTextToContact,
+  ManyChatNotConfiguredError,
+  ManyChatContactNotLinkedError,
+  ManyChatMappingLookupError,
+} from '@/lib/manychat/contact-send'
+import { ManyChatApiError } from '@/lib/manychat/api'
+import { engineSendText } from '@/lib/flows/meta-send'
+
+export interface SendAiTextArgs {
+  accountId: string
+  conversationId: string
+  contactId: string
+  text: string
+  /** WhatsApp config owner — only consulted on the Meta path (it's `engineSendText`'s audit column). */
+  configOwnerUserId: string
+}
+
+export interface SendAiTextResult {
+  whatsapp_message_id: string
+}
+
+/**
+ * Transport-aware AI outbound sender.
+ *
+ * `dispatchInboundToAiReply` calls this instead of `engineSendText`
+ * directly, so the AI's transport tracks the account's
+ * `WHATSAPP_OUTBOUND_TRANSPORT` + `MANYCHAT_INGEST_ACCOUNT_ID` scoping
+ * (see `resolveOutboundTransport`) without the AI engine itself
+ * knowing or caring which transport is live. When a future cutover
+ * flips the account back to 'meta', this same call site keeps working
+ * unchanged — no AI engine rewrite needed.
+ *
+ * ManyChat branch (`resolveOutboundTransport(accountId) === 'manychat'`):
+ *   - text only (the caller only ever passes generated text — there is
+ *     no media/template/interactive concept for an AI reply);
+ *   - resolves the account-scoped `manychat_contact_links` mapping and
+ *     calls ManyChat's Public API via the shared transport primitive
+ *     `sendManyChatTextToContact` (also used by the manual-agent send
+ *     path in `send-message.ts`) — NEVER falls back to Meta;
+ *   - persists ONLY after ManyChat confirms success, with
+ *     `sender_type='bot'` + `ai_generated=true` — NEVER 'agent';
+ *   - deliberately does NOT touch `flow_runs`: an AI auto-reply is not
+ *     a human agent stepping in, so it must not trigger the
+ *     "pause on agent send" signal `send-message.ts` uses for manual
+ *     replies.
+ *   On any failure (missing mapping, missing MANYCHAT_API_KEY, a
+ *   ManyChat error/timeout/non-success status, or a DB insert failure)
+ *   this throws — never persists a false "sent" message. The caller,
+ *   `dispatchInboundToAiReply`, already wraps its whole dispatch in a
+ *   try/catch that logs `[ai auto-reply] dispatch failed:` and never
+ *   rethrows, so no additional handling is required at the call site.
+ *
+ * Meta branch: delegates to `engineSendText` with `aiGenerated: true`
+ * — EXACTLY today's behavior, unchanged.
+ */
+export async function sendAiTextToConversation(
+  args: SendAiTextArgs,
+): Promise<SendAiTextResult> {
+  const { accountId, conversationId, contactId, text, configOwnerUserId } = args
+
+  if (resolveOutboundTransport(accountId) !== 'manychat') {
+    return engineSendText({
+      accountId,
+      userId: configOwnerUserId,
+      conversationId,
+      contactId,
+      text,
+      aiGenerated: true,
+    })
+  }
+
+  const db = supabaseAdmin()
+
+  let whatsappMessageId: string
+  try {
+    const result = await sendManyChatTextToContact({ db, accountId, contactId, text })
+    whatsappMessageId = result.whatsappMessageId
+  } catch (err) {
+    const message =
+      err instanceof ManyChatNotConfiguredError ||
+      err instanceof ManyChatContactNotLinkedError ||
+      err instanceof ManyChatMappingLookupError ||
+      err instanceof ManyChatApiError ||
+      err instanceof Error
+        ? err.message
+        : 'Unknown ManyChat send failure'
+    console.error('[ai send] ManyChat send failed:', message)
+    throw err
+  }
+
+  const { error: msgError } = await db.from('messages').insert({
+    conversation_id: conversationId,
+    sender_type: 'bot',
+    content_type: 'text',
+    content_text: text,
+    message_id: whatsappMessageId,
+    status: 'sent',
+    ai_generated: true,
+  })
+  if (msgError) {
+    console.error('[ai send] sent via ManyChat but DB insert failed:', msgError.message)
+    throw new Error(`AI reply sent via ManyChat but failed to save to DB: ${msgError.message}`)
+  }
+
+  await db
+    .from('conversations')
+    .update({
+      last_message_text: text,
+      last_message_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', conversationId)
+
+  // Deliberately NOT touching flow_runs here — see the module doc
+  // comment above: an AI auto-reply is not a human agent stepping in.
+
+  return { whatsapp_message_id: whatsappMessageId }
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -25,11 +25,26 @@ export interface AiConfig {
    *  agent's `auth.users.id`, or null to leave it unassigned (drop into
    *  the shared queue). */
   handoffAgentId: string | null
-  /** Optional OpenAI-compatible key for embeddings. When set, the
-   *  knowledge base is embedded and semantic retrieval turns on; when
-   *  null, retrieval falls back to lexical full-text search. */
+  /** Optional key for embeddings (OpenAI-compatible, or a Gemini key —
+   *  see `embeddingsProvider`). When set, the knowledge base is embedded
+   *  and semantic retrieval turns on; when null, retrieval falls back to
+   *  lexical full-text search. */
   embeddingsApiKey: string | null
+  /**
+   * Which embeddings provider `embeddingsApiKey` belongs to. Derived
+   * (in `config.ts`), never stored as its own column: 'gemini' when the
+   * account's chat provider is Gemini and an embeddings key is set,
+   * 'openai' when the chat provider is OpenAI/Anthropic and a key is
+   * set, null when there's no embeddings key at all. Never guessed from
+   * the key's shape/prefix — always this explicit rule.
+   */
+  embeddingsProvider: EmbeddingsProvider | null
 }
+
+/** Provider `embedTexts` can dispatch to. A subset of `AiProvider` —
+ *  Anthropic has no embeddings endpoint, so an Anthropic-chat account
+ *  with an embeddings key still uses OpenAI for embeddings. */
+export type EmbeddingsProvider = 'openai' | 'gemini'
 
 /** A single conversation turn in the shape both providers accept. */
 export interface ChatMessage {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -3,10 +3,10 @@
 //
 // One small provider-agnostic surface so the inbox draft route and the
 // inbound auto-reply bot both talk to `generateReply` without caring
-// whether the account is on OpenAI or Anthropic.
+// whether the account is on OpenAI, Anthropic, or Gemini.
 // ============================================================
 
-export type AiProvider = 'openai' | 'anthropic'
+export type AiProvider = 'openai' | 'anthropic' | 'gemini'
 
 /**
  * Account AI setup, decrypted and ready to use. Produced by

--- a/src/lib/contacts/find-or-create.ts
+++ b/src/lib/contacts/find-or-create.ts
@@ -1,0 +1,74 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { findExistingContact, isUniqueViolation } from '@/lib/contacts/dedupe'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ContactRow = any
+
+export interface ContactOutcome {
+  contact: ContactRow
+  /** True when this call created the row — callers use this to decide
+   *  whether a `new_contact_created`-style trigger should fire. */
+  wasCreated: boolean
+}
+
+/**
+ * Find-or-create a contact by phone, scoped to `accountId`. Shared by
+ * every inbound path that mirrors a customer message into the CRM (the
+ * Meta webhook, and the ManyChat bridge — see
+ * src/app/api/integrations/manychat/inbound/route.ts) so they agree on
+ * what "same contact" means and how a create-race is resolved.
+ *
+ * Extracted verbatim from the Meta webhook's private helper (issue
+ * #212's dedupe logic already lived in `dedupe.ts`; this just gives the
+ * find-or-create *shape* around it a second caller) — behavior is
+ * unchanged, confirmed by the webhook's existing test suite passing
+ * after the extraction.
+ */
+export async function findOrCreateContact(
+  db: SupabaseClient,
+  accountId: string,
+  configOwnerUserId: string,
+  phone: string,
+  name: string,
+): Promise<ContactOutcome | null> {
+  const existingContact = await findExistingContact(db, accountId, phone)
+
+  if (existingContact) {
+    if (name && name !== existingContact.name) {
+      await db
+        .from('contacts')
+        .update({ name, updated_at: new Date().toISOString() })
+        .eq('id', existingContact.id)
+    }
+    return { contact: existingContact, wasCreated: false }
+  }
+
+  // account_id is the tenancy column; user_id is the NOT NULL FK audit
+  // column (no inbound message has a single "user who created" it — we
+  // attribute to the WhatsApp config owner as a stable default).
+  const { data: newContact, error: createError } = await db
+    .from('contacts')
+    .insert({
+      account_id: accountId,
+      user_id: configOwnerUserId,
+      phone,
+      name: name || phone,
+    })
+    .select()
+    .single()
+
+  if (createError) {
+    // Lost a race: a concurrent inbound delivery (or another path)
+    // created this contact between our lookup and insert, and the
+    // unique index (migration 022) rejected the duplicate. Re-resolve
+    // the existing row instead of dropping the message.
+    if (isUniqueViolation(createError)) {
+      const raced = await findExistingContact(db, accountId, phone)
+      if (raced) return { contact: raced, wasCreated: false }
+    }
+    console.error('Error creating contact:', createError)
+    return null
+  }
+
+  return { contact: newContact, wasCreated: true }
+}

--- a/src/lib/conversations/find-or-create.ts
+++ b/src/lib/conversations/find-or-create.ts
@@ -1,0 +1,83 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { isUniqueViolation } from '@/lib/contacts/dedupe'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ConversationRow = any
+
+export interface ConversationOutcome {
+  conversation: ConversationRow
+  created: boolean
+}
+
+/**
+ * Find-or-create the (account, contact) conversation. Shared by every
+ * inbound path that mirrors a customer message into the CRM (the Meta
+ * webhook, and the ManyChat bridge — see
+ * src/app/api/integrations/manychat/inbound/route.ts).
+ *
+ * Extracted verbatim from the Meta webhook's private helper — behavior
+ * is unchanged, confirmed by the webhook's existing test suite passing
+ * after the extraction.
+ */
+export async function findOrCreateConversation(
+  db: SupabaseClient,
+  accountId: string,
+  configOwnerUserId: string,
+  contactId: string,
+): Promise<ConversationOutcome | null> {
+  // Oldest-first, one row. `.single()` is deliberately avoided — it
+  // errors on both 0 rows and ≥2 rows, which used to make a duplicate
+  // pair snowball into a wall of duplicate chats (issue #363). Ordering
+  // oldest-first resolves to the same canonical survivor the dedup
+  // migration (036) keeps.
+  const { data: existingRows, error: findError } = await db
+    .from('conversations')
+    .select('*')
+    .eq('account_id', accountId)
+    .eq('contact_id', contactId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+
+  if (findError) {
+    console.error('Error finding conversation:', findError)
+    return null
+  }
+
+  if (existingRows && existingRows.length > 0) {
+    return { conversation: existingRows[0], created: false }
+  }
+
+  // Same tenancy + audit split as findOrCreateContact.
+  const { data: newConv, error: createError } = await db
+    .from('conversations')
+    .insert({
+      account_id: accountId,
+      user_id: configOwnerUserId,
+      contact_id: contactId,
+    })
+    .select()
+    .single()
+
+  if (createError) {
+    // Lost a race: a concurrent inbound delivery created the
+    // conversation between our lookup and insert, and the unique index
+    // (migration 036) rejected the duplicate. Re-resolve the winning
+    // row instead of dropping the message — mirrors findOrCreateContact.
+    if (isUniqueViolation(createError)) {
+      const { data: raced } = await db
+        .from('conversations')
+        .select('*')
+        .eq('account_id', accountId)
+        .eq('contact_id', contactId)
+        .order('created_at', { ascending: true })
+        .limit(1)
+      if (raced && raced.length > 0) {
+        return { conversation: raced[0], created: false }
+      }
+    }
+    console.error('Error creating conversation:', createError)
+    return null
+  }
+
+  return { conversation: newConv, created: true }
+}

--- a/src/lib/manychat/api.test.ts
+++ b/src/lib/manychat/api.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { sendManyChatText, ManyChatApiError } from './api'
+
+const API_KEY = 'mc-secret-key-12345'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+describe('sendManyChatText — request contract', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => jsonResponse(200, { status: 'success' }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs to the documented sendContent endpoint', async () => {
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://api.manychat.com/fb/sending/sendContent')
+  })
+
+  it('sends the exact Bearer + Content-Type headers', async () => {
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers).toMatchObject({
+      Authorization: `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+    })
+  })
+
+  it('uses content.type "whatsapp" and message type "text" (dynamic content v2)', async () => {
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'Hola!' })
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string)
+    expect(body).toEqual({
+      subscriber_id: 123,
+      data: {
+        version: 'v2',
+        content: {
+          type: 'whatsapp',
+          messages: [{ type: 'text', text: 'Hola!' }],
+        },
+      },
+    })
+  })
+
+  it('sends subscriber_id as a number when the ManyChat contact id is purely numeric', async () => {
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '987654321', text: 'x' })
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.subscriber_id).toBe(987654321)
+    expect(typeof body.subscriber_id).toBe('number')
+  })
+
+  it('passes an AbortController signal for the timeout', async () => {
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('returns the raw parsed body on a 2xx response', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { status: 'success' }))
+    const result = await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    expect(result.raw).toEqual({ status: 'success' })
+  })
+})
+
+describe('sendManyChatText — subscriber_id validation (fails BEFORE fetch)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => jsonResponse(200, { status: 'success' }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    ['non-numeric string', 'abc-123'],
+    ['zero', '0'],
+    ['a value with a leading sign', '-123'],
+    ['a decimal', '12.5'],
+    ['an unsafe integer (past MAX_SAFE_INTEGER)', String(Number.MAX_SAFE_INTEGER + 1)],
+    ['empty string', ''],
+    ['whitespace', '  '],
+  ])('rejects %s without calling fetch', async (_label, manyChatContactId) => {
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId, text: 'hi' }),
+    ).rejects.toBeInstanceOf(ManyChatApiError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('the thrown error is a 400 with no network call made', async () => {
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: 'not-a-number', text: 'hi' }),
+    ).rejects.toMatchObject({ status: 400 })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a positive safe integer string and sends it as a number', async () => {
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123456789', text: 'hi' })
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.subscriber_id).toBe(123456789)
+    expect(Number.isSafeInteger(body.subscriber_id)).toBe(true)
+  })
+
+  it('accepts the largest safe integer', async () => {
+    await sendManyChatText({
+      apiKey: API_KEY,
+      manyChatContactId: String(Number.MAX_SAFE_INTEGER),
+      text: 'hi',
+    })
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.subscriber_id).toBe(Number.MAX_SAFE_INTEGER)
+  })
+})
+
+describe('sendManyChatText — 2xx responses must confirm status: "success"', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('accepts a 200 with status: "success"', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(200, { status: 'success' })))
+    const result = await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    expect(result.raw).toEqual({ status: 'success' })
+  })
+
+  it('rejects a 200 with status: "error"', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(200, { status: 'error', message: 'not delivered' })),
+    )
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }),
+    ).rejects.toBeInstanceOf(ManyChatApiError)
+  })
+
+  it('rejects a 200 with no status field at all', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(200, { unexpected: 'shape' })))
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }),
+    ).rejects.toBeInstanceOf(ManyChatApiError)
+  })
+
+  it('rejects a 200 with an unparseable (non-JSON) body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token')
+        },
+      })) as unknown as typeof fetch,
+    )
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }),
+    ).rejects.toBeInstanceOf(ManyChatApiError)
+  })
+
+  it('a rejected 2xx does not silently look like success — status is not itself 2xx-coded', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(200, { status: 'error' })))
+    let caught: ManyChatApiError | null = null
+    try {
+      await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    } catch (err) {
+      caught = err as ManyChatApiError
+    }
+    expect(caught).toBeInstanceOf(ManyChatApiError)
+    // Distinct from a plain HTTP failure — callers can tell "ManyChat said
+    // 200 but the payload disputes it" apart from a transport-level error.
+    expect(caught!.status).toBe(502)
+  })
+})
+
+describe('sendManyChatText — error handling', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each([401, 403, 429, 500])('throws a typed ManyChatApiError on HTTP %i', async (status) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(status, { status: 'error', message: `boom ${status}` })),
+    )
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }),
+    ).rejects.toMatchObject({
+      status,
+      message: `boom ${status}`,
+    })
+  })
+
+  it('throws ManyChatApiError instances specifically', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(500, { message: 'boom' })))
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }),
+    ).rejects.toBeInstanceOf(ManyChatApiError)
+  })
+
+  it('falls back to a generic message when the error body has no message field', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(500, { status: 'error' })))
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }),
+    ).rejects.toMatchObject({ status: 500, message: 'ManyChat API error: HTTP 500' })
+  })
+
+  it('surfaces a network failure as a 502 ManyChatApiError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('getaddrinfo ENOTFOUND')
+      }),
+    )
+    await expect(
+      sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }),
+    ).rejects.toMatchObject({ status: 502 })
+  })
+
+  it('surfaces an aborted request as a 504 timeout ManyChatApiError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const err = new Error('The operation was aborted')
+        err.name = 'AbortError'
+        throw err
+      }),
+    )
+    await expect(
+      sendManyChatText({
+        apiKey: API_KEY,
+        manyChatContactId: '123',
+        text: 'hi',
+        timeoutMs: 5,
+      }),
+    ).rejects.toMatchObject({ status: 504 })
+  })
+
+  it('redacts the literal API key if it ever appears in an error body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse(400, { message: `invalid token ${API_KEY}`, echoed_auth: `Bearer ${API_KEY}` }),
+      ),
+    )
+    let caught: ManyChatApiError | null = null
+    try {
+      await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    } catch (err) {
+      caught = err as ManyChatApiError
+    }
+    expect(caught).toBeInstanceOf(ManyChatApiError)
+    expect(caught!.message).not.toContain(API_KEY)
+    expect(JSON.stringify(caught!.body)).not.toContain(API_KEY)
+  })
+})
+
+describe('sendManyChatText — never logs the API key', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+    logSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  function loggedText(): string {
+    return [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...logSpy.mock.calls]
+      .flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join('\n')
+  }
+
+  it('on success', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(200, { status: 'success' })))
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' })
+    expect(loggedText()).not.toContain(API_KEY)
+  })
+
+  it('on a ManyChat error response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, { message: 'unauthorized' })))
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }).catch(() => {})
+    expect(loggedText()).not.toContain(API_KEY)
+  })
+
+  it('on a network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      }),
+    )
+    await sendManyChatText({ apiKey: API_KEY, manyChatContactId: '123', text: 'hi' }).catch(() => {})
+    expect(loggedText()).not.toContain(API_KEY)
+  })
+})

--- a/src/lib/manychat/api.ts
+++ b/src/lib/manychat/api.ts
@@ -1,0 +1,202 @@
+/**
+ * ManyChat Public API — server-side client.
+ *
+ * TEMPORARY bridge: while a WhatsApp number is still operated in
+ * ManyChat (see src/app/api/integrations/manychat/inbound/route.ts for
+ * the inbound half, and src/lib/whatsapp/send-message.ts for where
+ * this is called from the outbound side), an agent's reply from the
+ * WA CRM Inbox has to leave through ManyChat rather than Meta's Cloud
+ * API directly.
+ *
+ * Implements only `sendManyChatText` — the single call the outbound
+ * bridge needs today. Request shape follows ManyChat's documented
+ * `sendContent` (dynamic content v2) envelope for WhatsApp:
+ *   POST /fb/sending/sendContent
+ *   { "subscriber_id": <integer, required>,
+ *     "data": { "version": "v2",
+ *                "content": { "type": "whatsapp",
+ *                              "messages": [{ "type": "text", "text": "…" }] } } }
+ * (https://api.manychat.com/swagger#/Sending/post_fb_sending_sendContent).
+ * `subscriber_id` is validated as a positive, `Number.isSafeInteger`
+ * value BEFORE any network call — see `toSubscriberId`.
+ *
+ * ManyChat's documented success envelope is `{ "status": "success" }`,
+ * with no confirmed message-id field, so callers must not assume one —
+ * see `SendManyChatTextResult.raw`. A 2xx HTTP status alone is not
+ * treated as success: the body's `status` field must literally read
+ * `"success"`, or the call throws `ManyChatApiError`.
+ */
+
+const MANYCHAT_API_BASE = 'https://api.manychat.com'
+const DEFAULT_TIMEOUT_MS = 10_000
+
+/**
+ * Typed failure for a non-2xx response, a network error, or a timeout.
+ * `body` is ManyChat's parsed JSON error body with the literal API key
+ * redacted if it somehow appears in it (defense in depth — ManyChat has
+ * no documented reason to echo the Authorization header back).
+ */
+export class ManyChatApiError extends Error {
+  readonly status: number
+  readonly body: unknown
+  constructor(status: number, message: string, body?: unknown) {
+    super(message)
+    this.name = 'ManyChatApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
+export interface SendManyChatTextArgs {
+  /** MANYCHAT_API_KEY — never logged, never included in a thrown error. */
+  apiKey: string
+  /** The target subscriber's ManyChat contact id (manychat_contact_links.manychat_contact_id). */
+  manyChatContactId: string
+  text: string
+  /** Abort the request after this many ms. Default 10000. */
+  timeoutMs?: number
+}
+
+export interface SendManyChatTextResult {
+  /**
+   * Raw parsed JSON body ManyChat returned on success. Callers may look
+   * for a message id opportunistically (`raw.message_id`,
+   * `raw.data.message_id`) but must not assume one is present.
+   */
+  raw: unknown
+}
+
+function redactApiKey(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value
+}
+
+/** Best-effort redaction of the literal API key from an error body before it's ever thrown/logged. */
+function sanitizeErrorBody(body: unknown, apiKey: string): unknown {
+  if (!apiKey) return body
+  try {
+    const serialized = JSON.stringify(body)
+    if (!serialized || !serialized.includes(apiKey)) return body
+    return JSON.parse(redactApiKey(serialized, apiKey))
+  } catch {
+    return typeof body === 'string' ? redactApiKey(body, apiKey) : body
+  }
+}
+
+/**
+ * ManyChat's `subscriber_id` is a required integer (their Public API
+ * spec: `subscriber_id: integer`) — there is no documented string form.
+ * Validate BEFORE any network call: a non-digit string, a non-positive
+ * value, or a value outside `Number.isSafeInteger` range all fail here
+ * rather than being sent as-is or silently coerced.
+ */
+function toSubscriberId(manyChatContactId: string): number {
+  if (!/^\d+$/.test(manyChatContactId)) {
+    throw new ManyChatApiError(
+      400,
+      `Invalid ManyChat contact id — expected a positive integer, got "${manyChatContactId}"`,
+    )
+  }
+  const n = Number(manyChatContactId)
+  if (!Number.isSafeInteger(n) || n <= 0) {
+    throw new ManyChatApiError(
+      400,
+      `Invalid ManyChat contact id — not a positive safe integer: "${manyChatContactId}"`,
+    )
+  }
+  return n
+}
+
+/**
+ * Send a WhatsApp text message through ManyChat's Public API, targeting
+ * a subscriber by their ManyChat contact id.
+ *
+ * Never logs `apiKey` or the `Authorization` header. Throws
+ * `ManyChatApiError` on: an invalid `manyChatContactId` (before any
+ * network call), a non-2xx response, a 2xx response that doesn't
+ * confirm `status: "success"`, a network failure, or a timeout — it
+ * never returns a "failed" result, so a caller that awaits this
+ * successfully can persist the message as sent.
+ */
+export async function sendManyChatText(
+  args: SendManyChatTextArgs,
+): Promise<SendManyChatTextResult> {
+  const { apiKey, manyChatContactId, text, timeoutMs = DEFAULT_TIMEOUT_MS } = args
+
+  // Validated BEFORE the fetch — an invalid id must never reach the
+  // network call.
+  const subscriberId = toSubscriberId(manyChatContactId)
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  let response: Response
+  try {
+    response = await fetch(`${MANYCHAT_API_BASE}/fb/sending/sendContent`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        subscriber_id: subscriberId,
+        data: {
+          version: 'v2',
+          content: {
+            type: 'whatsapp',
+            messages: [{ type: 'text', text }],
+          },
+        },
+      }),
+      signal: controller.signal,
+    })
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new ManyChatApiError(504, `ManyChat request timed out after ${timeoutMs}ms`)
+    }
+    throw new ManyChatApiError(
+      502,
+      `ManyChat request failed: ${err instanceof Error ? err.message : 'network error'}`,
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  let body: unknown = null
+  try {
+    body = await response.json()
+  } catch {
+    // Non-JSON body — response.ok still governs the outcome below.
+  }
+
+  if (!response.ok) {
+    const sanitized = sanitizeErrorBody(body, apiKey)
+    const message =
+      sanitized &&
+      typeof sanitized === 'object' &&
+      'message' in sanitized &&
+      typeof (sanitized as Record<string, unknown>).message === 'string'
+        ? ((sanitized as Record<string, unknown>).message as string)
+        : `ManyChat API error: HTTP ${response.status}`
+    throw new ManyChatApiError(response.status, message, sanitized)
+  }
+
+  // A 2xx status alone isn't proof of success — ManyChat's own
+  // documented envelope is `{ "status": "success" }` / `{ "status":
+  // "error" }`. Require the field to say so explicitly; a 200 with an
+  // unexpected or missing `status` is treated as a failure, not
+  // silently accepted.
+  const statusField =
+    body && typeof body === 'object' && 'status' in body
+      ? (body as Record<string, unknown>).status
+      : undefined
+  if (statusField !== 'success') {
+    const sanitized = sanitizeErrorBody(body, apiKey)
+    throw new ManyChatApiError(
+      502,
+      `ManyChat returned HTTP ${response.status} but did not confirm success (status: ${JSON.stringify(statusField)})`,
+      sanitized,
+    )
+  }
+
+  return { raw: body }
+}

--- a/src/lib/manychat/contact-send.test.ts
+++ b/src/lib/manychat/contact-send.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const sendManyChatTextMock = vi.fn()
+vi.mock('./api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sendManyChatText: (...args: unknown[]) =>
+    (sendManyChatTextMock as unknown as (...a: unknown[]) => unknown)(...args),
+}))
+
+import {
+  sendManyChatTextToContact,
+  ManyChatNotConfiguredError,
+  ManyChatContactNotLinkedError,
+  ManyChatMappingLookupError,
+} from './contact-send'
+import { ManyChatApiError } from './api'
+
+const API_KEY = 'mc-key-test'
+
+interface Captured {
+  lookup?: { accountId: string; contactId: string }
+}
+
+function fakeDb(opts: {
+  link?: { manychat_contact_id: string } | null
+  linkError?: { message: string } | null
+  captured: Captured
+}): SupabaseClient {
+  return {
+    from(table: string) {
+      if (table === 'manychat_contact_links') {
+        return {
+          select: () => ({
+            eq: (_col: string, accountId: string) => ({
+              eq: (_col2: string, contactId: string) => ({
+                maybeSingle: async () => {
+                  opts.captured.lookup = { accountId, contactId }
+                  return { data: opts.link ?? null, error: opts.linkError ?? null }
+                },
+              }),
+            }),
+          }),
+        }
+      }
+      // Any other table access from this primitive would be a bug — it
+      // must never touch messages/conversations/flow_runs.
+      throw new Error(`unexpected table: ${table}`)
+    },
+  } as unknown as SupabaseClient
+}
+
+const originalApiKey = process.env.MANYCHAT_API_KEY
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.MANYCHAT_API_KEY = API_KEY
+  sendManyChatTextMock.mockResolvedValue({ raw: { status: 'success' } })
+})
+
+afterEach(() => {
+  if (originalApiKey === undefined) delete process.env.MANYCHAT_API_KEY
+  else process.env.MANYCHAT_API_KEY = originalApiKey
+})
+
+describe('sendManyChatTextToContact — tenancy', () => {
+  it('looks up the mapping scoped to BOTH account_id and contact_id', async () => {
+    const captured: Captured = {}
+    await sendManyChatTextToContact({
+      db: fakeDb({ link: { manychat_contact_id: 'mc-1' }, captured }),
+      accountId: 'acct-1',
+      contactId: 'contact-1',
+      text: 'hi',
+    })
+    expect(captured.lookup).toEqual({ accountId: 'acct-1', contactId: 'contact-1' })
+  })
+
+  it("a different account's mapping is invisible — the scoped lookup returns null", async () => {
+    const captured: Captured = {}
+    await expect(
+      sendManyChatTextToContact({
+        // Simulates account B querying with account A's contact_id: the
+        // real account_id-scoped query would return no row.
+        db: fakeDb({ link: null, captured }),
+        accountId: 'acct-B',
+        contactId: 'contact-owned-by-acct-A',
+        text: 'hi',
+      }),
+    ).rejects.toBeInstanceOf(ManyChatContactNotLinkedError)
+    expect(captured.lookup).toEqual({
+      accountId: 'acct-B',
+      contactId: 'contact-owned-by-acct-A',
+    })
+  })
+})
+
+describe('sendManyChatTextToContact — guard clauses (fail before any send)', () => {
+  it('throws ManyChatNotConfiguredError before any DB lookup when the API key is missing', async () => {
+    delete process.env.MANYCHAT_API_KEY
+    const captured: Captured = {}
+    await expect(
+      sendManyChatTextToContact({
+        db: fakeDb({ link: { manychat_contact_id: 'mc-1' }, captured }),
+        accountId: 'acct-1',
+        contactId: 'contact-1',
+        text: 'hi',
+      }),
+    ).rejects.toBeInstanceOf(ManyChatNotConfiguredError)
+    expect(captured.lookup).toBeUndefined()
+    expect(sendManyChatTextMock).not.toHaveBeenCalled()
+  })
+
+  it('throws ManyChatContactNotLinkedError when no mapping row exists', async () => {
+    const captured: Captured = {}
+    await expect(
+      sendManyChatTextToContact({
+        db: fakeDb({ link: null, captured }),
+        accountId: 'acct-1',
+        contactId: 'contact-1',
+        text: 'hi',
+      }),
+    ).rejects.toBeInstanceOf(ManyChatContactNotLinkedError)
+    expect(sendManyChatTextMock).not.toHaveBeenCalled()
+  })
+
+  it('throws ManyChatMappingLookupError on a genuine DB error (distinct from "no row")', async () => {
+    const captured: Captured = {}
+    await expect(
+      sendManyChatTextToContact({
+        db: fakeDb({ linkError: { message: 'db down' }, captured }),
+        accountId: 'acct-1',
+        contactId: 'contact-1',
+        text: 'hi',
+      }),
+    ).rejects.toBeInstanceOf(ManyChatMappingLookupError)
+    expect(sendManyChatTextMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('sendManyChatTextToContact — ManyChat failures propagate untouched', () => {
+  it.each([401, 403, 429, 500, 502, 504])(
+    'propagates a ManyChatApiError(%i) from sendManyChatText',
+    async (status) => {
+      sendManyChatTextMock.mockRejectedValue(new ManyChatApiError(status, `boom ${status}`))
+      const captured: Captured = {}
+      await expect(
+        sendManyChatTextToContact({
+          db: fakeDb({ link: { manychat_contact_id: 'mc-1' }, captured }),
+          accountId: 'acct-1',
+          contactId: 'contact-1',
+          text: 'hi',
+        }),
+      ).rejects.toMatchObject({ status, message: `boom ${status}` })
+    },
+  )
+})
+
+describe('sendManyChatTextToContact — success', () => {
+  it('passes the mapped manychat_contact_id + text through to sendManyChatText', async () => {
+    await sendManyChatTextToContact({
+      db: fakeDb({ link: { manychat_contact_id: 'mc-999' }, captured: {} }),
+      accountId: 'acct-1',
+      contactId: 'contact-1',
+      text: 'Hola!',
+    })
+    expect(sendManyChatTextMock).toHaveBeenCalledWith({
+      apiKey: API_KEY,
+      manyChatContactId: 'mc-999',
+      text: 'Hola!',
+    })
+  })
+
+  it('returns manychat-out:<uuid> when ManyChat gives no message id', async () => {
+    const result = await sendManyChatTextToContact({
+      db: fakeDb({ link: { manychat_contact_id: 'mc-1' }, captured: {} }),
+      accountId: 'acct-1',
+      contactId: 'contact-1',
+      text: 'hi',
+    })
+    expect(result.whatsappMessageId).toMatch(/^manychat-out:/)
+    // Never a fabricated Meta-shaped id.
+    expect(result.whatsappMessageId).not.toMatch(/^wamid\./)
+  })
+
+  it('does not touch messages/conversations/flow_runs — transport only', async () => {
+    // fakeDb throws on any table other than manychat_contact_links, so
+    // reaching a resolved result at all proves this.
+    await expect(
+      sendManyChatTextToContact({
+        db: fakeDb({ link: { manychat_contact_id: 'mc-1' }, captured: {} }),
+        accountId: 'acct-1',
+        contactId: 'contact-1',
+        text: 'hi',
+      }),
+    ).resolves.toBeDefined()
+  })
+})

--- a/src/lib/manychat/contact-send.ts
+++ b/src/lib/manychat/contact-send.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from 'node:crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { sendManyChatText } from './api'
+
+/** Thrown when `MANYCHAT_API_KEY` is missing from the environment. */
+export class ManyChatNotConfiguredError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ManyChatNotConfiguredError'
+  }
+}
+
+/** Thrown when the (account, contact) pair has no `manychat_contact_links` row. */
+export class ManyChatContactNotLinkedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ManyChatContactNotLinkedError'
+  }
+}
+
+/**
+ * Thrown when the `manychat_contact_links` lookup itself errors — a
+ * real DB problem, distinct from "no row found" (`ManyChatContactNotLinkedError`).
+ */
+export class ManyChatMappingLookupError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ManyChatMappingLookupError'
+  }
+}
+
+export interface SendManyChatTextToContactArgs {
+  db: SupabaseClient
+  accountId: string
+  contactId: string
+  text: string
+}
+
+export interface SendManyChatTextToContactResult {
+  /** `manychat-out:<id>` — never a Meta-shaped `wamid`. */
+  whatsappMessageId: string
+}
+
+/**
+ * TRANSPORT-ONLY primitive for the ManyChat outbound bridge.
+ *
+ * Resolves the account-scoped `manychat_contact_links` mapping, calls
+ * ManyChat's Public API, and returns a message id. Deliberately does
+ * NOT: insert into `messages`, update `conversations`, pause
+ * `flow_runs`, or decide `sender_type`. Every caller owns its own
+ * persistence semantics —
+ *   - the manual-agent send path (`src/lib/whatsapp/send-message.ts`)
+ *     persists `sender_type='agent'` and pauses active flow runs;
+ *   - the AI send path (`src/lib/ai/send.ts`) persists
+ *     `sender_type='bot'` + `ai_generated=true` and never pauses flows.
+ * Sharing this primitive is only about not duplicating the mapping
+ * lookup + wire call in two places — it carries no opinion about who
+ * the sender is.
+ *
+ * Scoped to BOTH `account_id` and `contact_id` together — never
+ * `contact_id` alone — so account A can never reach account B's
+ * ManyChat mapping.
+ *
+ * Throws `ManyChatNotConfiguredError`, `ManyChatContactNotLinkedError`,
+ * `ManyChatMappingLookupError`, or `ManyChatApiError` (from
+ * `sendManyChatText`) — never returns a "failed" result, and never
+ * falls back to Meta. Transport selection is entirely the caller's
+ * responsibility, decided BEFORE calling this (via
+ * `resolveOutboundTransport`).
+ */
+export async function sendManyChatTextToContact(
+  args: SendManyChatTextToContactArgs,
+): Promise<SendManyChatTextToContactResult> {
+  const { db, accountId, contactId, text } = args
+
+  const apiKey = process.env.MANYCHAT_API_KEY
+  if (!apiKey) {
+    throw new ManyChatNotConfiguredError(
+      'ManyChat outbound is not configured (MANYCHAT_API_KEY missing)',
+    )
+  }
+
+  const { data: link, error: linkError } = await db
+    .from('manychat_contact_links')
+    .select('manychat_contact_id')
+    .eq('account_id', accountId)
+    .eq('contact_id', contactId)
+    .maybeSingle()
+
+  if (linkError) {
+    console.error('[manychat] manychat_contact_links lookup failed:', linkError.message)
+    throw new ManyChatMappingLookupError('Failed to resolve the ManyChat mapping')
+  }
+  if (!link) {
+    throw new ManyChatContactNotLinkedError(
+      'This contact has not been synced from ManyChat yet — an inbound message must arrive first.',
+    )
+  }
+
+  const sendResult = await sendManyChatText({
+    apiKey,
+    manyChatContactId: link.manychat_contact_id as string,
+    text,
+  })
+
+  // ManyChat's documented sendContent response is `{ "status": "success" }`
+  // with no confirmed message-id field. Use one opportunistically if a
+  // future/undocumented shape carries it; otherwise generate our own —
+  // never invent a wamid-shaped id.
+  const raw = sendResult.raw as Record<string, unknown> | null
+  const nestedData =
+    raw && typeof raw.data === 'object' ? (raw.data as Record<string, unknown>) : null
+  const returnedId = raw?.message_id ?? nestedData?.message_id
+  const whatsappMessageId =
+    typeof returnedId === 'string' && returnedId.trim()
+      ? `manychat-out:${returnedId.trim()}`
+      : `manychat-out:${randomUUID()}`
+
+  return { whatsappMessageId }
+}

--- a/src/lib/whatsapp/send-message.test.ts
+++ b/src/lib/whatsapp/send-message.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
   sendMessageToConversation,
   SendMessageError,
+  resolveOutboundTransport,
   type SendMessageParams,
 } from './send-message';
+import { ManyChatApiError } from '@/lib/manychat/api';
 
 // A db that explodes if touched — these tests cover the param
 // validation that MUST short-circuit before any query runs.
@@ -193,6 +195,15 @@ vi.mock('@/lib/flows/admin-client', () => ({
   }),
 }));
 
+// Mock only `sendManyChatText` — keep the real `ManyChatApiError` class so
+// send-message.ts's `instanceof ManyChatApiError` checks still work.
+const sendManyChatTextMock = vi.fn(async () => ({ raw: { status: 'success' } }));
+vi.mock('@/lib/manychat/api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sendManyChatText: (...args: unknown[]) =>
+    (sendManyChatTextMock as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+
 interface CapturedWrites {
   message?: Record<string, unknown>;
   conversation?: Record<string, unknown>;
@@ -344,5 +355,436 @@ describe('sendMessageToConversation — template persistence (#483)', () => {
     // name rather than inventing a body.
     expect(captured.message?.content_text).toBeNull();
     expect(captured.conversation?.last_message_text).toBe('[template]');
+  });
+});
+
+// ============================================================
+// Outbound transport selection (ManyChat coexistence bridge).
+// ============================================================
+
+interface ManyChatCaptured {
+  message?: Record<string, unknown>;
+  conversation?: Record<string, unknown>;
+  linkLookup?: { accountId: string; contactId: string };
+}
+
+const MC_CONVERSATION = {
+  id: 'cv-mc-1',
+  account_id: 'acct-mc',
+  contact_id: 'ct-mc-1',
+  contact: { id: 'ct-mc-1', phone: '+15559990000' },
+};
+
+/**
+ * Minimal fake covering only the tables the ManyChat branch touches
+ * (conversations, manychat_contact_links, messages) — deliberately NOT
+ * whatsapp_config or message_templates, since the whole point of this
+ * branch is to never need them.
+ */
+function manyChatSendDb(opts: {
+  conversation?: typeof MC_CONVERSATION | null;
+  link?: { manychat_contact_id: string } | null;
+  linkError?: { message: string } | null;
+  captured: ManyChatCaptured;
+}): SupabaseClient {
+  const conversation =
+    opts.conversation === undefined ? MC_CONVERSATION : opts.conversation;
+
+  return {
+    from(table: string) {
+      if (table === 'conversations') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: async () =>
+                  conversation
+                    ? { data: conversation, error: null }
+                    : { data: null, error: { message: 'not found' } },
+              }),
+            }),
+          }),
+          update: (row: Record<string, unknown>) => ({
+            eq: async () => {
+              opts.captured.conversation = row;
+              return { error: null };
+            },
+          }),
+        };
+      }
+      if (table === 'manychat_contact_links') {
+        return {
+          select: () => ({
+            eq: (_col: string, accountId: string) => ({
+              eq: (_col2: string, contactId: string) => ({
+                maybeSingle: async () => {
+                  opts.captured.linkLookup = { accountId, contactId };
+                  return { data: opts.link ?? null, error: opts.linkError ?? null };
+                },
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'messages') {
+        return {
+          insert: (row: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                opts.captured.message = row;
+                return { data: { id: 'msg-out-1', ...row }, error: null };
+              },
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe('resolveOutboundTransport(accountId) — per-account scoping', () => {
+  const originalTransport = process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+  const originalBridgeAccount = process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+
+  afterEach(() => {
+    if (originalTransport === undefined) delete process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+    else process.env.WHATSAPP_OUTBOUND_TRANSPORT = originalTransport;
+    if (originalBridgeAccount === undefined) delete process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+    else process.env.MANYCHAT_INGEST_ACCOUNT_ID = originalBridgeAccount;
+  });
+
+  it('transport=manychat + accountId === MANYCHAT_INGEST_ACCOUNT_ID → manychat', () => {
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'manychat';
+    process.env.MANYCHAT_INGEST_ACCOUNT_ID = 'acct-bridge';
+    expect(resolveOutboundTransport('acct-bridge')).toBe('manychat');
+  });
+
+  it('transport=manychat + a DIFFERENT accountId → meta (never global)', () => {
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'manychat';
+    process.env.MANYCHAT_INGEST_ACCOUNT_ID = 'acct-bridge';
+    expect(resolveOutboundTransport('some-other-account')).toBe('meta');
+  });
+
+  it('transport=meta (regardless of accountId) → meta', () => {
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'meta';
+    process.env.MANYCHAT_INGEST_ACCOUNT_ID = 'acct-bridge';
+    expect(resolveOutboundTransport('acct-bridge')).toBe('meta');
+  });
+
+  it('transport unset/garbage → meta', () => {
+    delete process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+    process.env.MANYCHAT_INGEST_ACCOUNT_ID = 'acct-bridge';
+    expect(resolveOutboundTransport('acct-bridge')).toBe('meta');
+
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'carrier-pigeon';
+    expect(resolveOutboundTransport('acct-bridge')).toBe('meta');
+  });
+
+  it('transport=manychat but MANYCHAT_INGEST_ACCOUNT_ID unset → meta for every account', () => {
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'manychat';
+    delete process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+    expect(resolveOutboundTransport('acct-bridge')).toBe('meta');
+    expect(resolveOutboundTransport('')).toBe('meta');
+  });
+});
+
+describe('sendMessageToConversation — WHATSAPP_OUTBOUND_TRANSPORT=meta (unchanged behavior)', () => {
+  const originalTransport = process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+  const originalApiKey = process.env.MANYCHAT_API_KEY;
+  const originalBridgeAccount = process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+
+  beforeEach(() => {
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'meta';
+    sendManyChatTextMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalTransport === undefined) delete process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+    else process.env.WHATSAPP_OUTBOUND_TRANSPORT = originalTransport;
+    if (originalApiKey === undefined) delete process.env.MANYCHAT_API_KEY;
+    else process.env.MANYCHAT_API_KEY = originalApiKey;
+    if (originalBridgeAccount === undefined) delete process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+    else process.env.MANYCHAT_INGEST_ACCOUNT_ID = originalBridgeAccount;
+  });
+
+  it('still sends via Meta (sendTemplateMessage) and never touches ManyChat', async () => {
+    const captured: CapturedWrites = {};
+    const result = await sendMessageToConversation(
+      sendPathDb([TEMPLATE_ROW], captured),
+      'acct-1',
+      {
+        conversationId: 'cv-1',
+        messageType: 'template',
+        templateName: 'order_update',
+        templateParams: ['A123', 'Friday'],
+      },
+    );
+    expect(result.whatsappMessageId).toBe('wamid.1');
+    expect(sendManyChatTextMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendMessageToConversation — tenancy: manychat transport never leaks to other accounts', () => {
+  const originalTransport = process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+  const originalApiKey = process.env.MANYCHAT_API_KEY;
+  const originalBridgeAccount = process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+
+  beforeEach(() => {
+    // Globally "armed" for ManyChat, and MANYCHAT_INGEST_ACCOUNT_ID names
+    // a DIFFERENT account than the one this test sends from — this is
+    // the exact shape of the bug being fixed: a global env flip must not
+    // change transport for an account it wasn't scoped to.
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'manychat';
+    process.env.MANYCHAT_INGEST_ACCOUNT_ID = 'acct-bridge-account';
+    process.env.MANYCHAT_API_KEY = 'mc-key-test';
+    sendManyChatTextMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalTransport === undefined) delete process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+    else process.env.WHATSAPP_OUTBOUND_TRANSPORT = originalTransport;
+    if (originalApiKey === undefined) delete process.env.MANYCHAT_API_KEY;
+    else process.env.MANYCHAT_API_KEY = originalApiKey;
+    if (originalBridgeAccount === undefined) delete process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+    else process.env.MANYCHAT_INGEST_ACCOUNT_ID = originalBridgeAccount;
+  });
+
+  it('an unrelated account still sends via Meta even while WHATSAPP_OUTBOUND_TRANSPORT=manychat is set', async () => {
+    const captured: CapturedWrites = {};
+    const result = await sendMessageToConversation(
+      sendPathDb([TEMPLATE_ROW], captured),
+      // NOT 'acct-bridge-account' — a different account on the same deployment.
+      'acct-1',
+      {
+        conversationId: 'cv-1',
+        messageType: 'template',
+        templateName: 'order_update',
+        templateParams: ['A123', 'Friday'],
+      },
+    );
+    expect(result.whatsappMessageId).toBe('wamid.1');
+    expect(sendManyChatTextMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendMessageToConversation — WHATSAPP_OUTBOUND_TRANSPORT=manychat', () => {
+  const originalTransport = process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+  const originalApiKey = process.env.MANYCHAT_API_KEY;
+  const originalBridgeAccount = process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+
+  beforeEach(() => {
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT = 'manychat';
+    // Every test below sends from accountId 'acct-mc' — must match for
+    // the manychat branch to activate at all (see the tenancy suite
+    // above for the case where it deliberately does NOT match).
+    process.env.MANYCHAT_INGEST_ACCOUNT_ID = 'acct-mc';
+    process.env.MANYCHAT_API_KEY = 'mc-key-test';
+    sendManyChatTextMock.mockReset();
+    sendManyChatTextMock.mockResolvedValue({ raw: { status: 'success' } });
+  });
+
+  afterEach(() => {
+    if (originalTransport === undefined) delete process.env.WHATSAPP_OUTBOUND_TRANSPORT;
+    else process.env.WHATSAPP_OUTBOUND_TRANSPORT = originalTransport;
+    if (originalApiKey === undefined) delete process.env.MANYCHAT_API_KEY;
+    else process.env.MANYCHAT_API_KEY = originalApiKey;
+    if (originalBridgeAccount === undefined) delete process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+    else process.env.MANYCHAT_INGEST_ACCOUNT_ID = originalBridgeAccount;
+  });
+
+  it('sends a text message through ManyChat and never calls Meta', async () => {
+    const captured: ManyChatCaptured = {};
+    const result = await sendMessageToConversation(
+      manyChatSendDb({
+        link: { manychat_contact_id: 'mc-contact-1' },
+        captured,
+      }),
+      'acct-mc',
+      { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+    );
+
+    expect(sendManyChatTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'mc-key-test',
+        manyChatContactId: 'mc-contact-1',
+        text: 'Hola!',
+      }),
+    );
+    expect(result.messageId).toBe('msg-out-1');
+    expect(result.whatsappMessageId).toMatch(/^manychat-out:/);
+  });
+
+  it('persists exactly one message row, sender_type agent, status sent', async () => {
+    const captured: ManyChatCaptured = {};
+    await sendMessageToConversation(
+      manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+      'acct-mc',
+      { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+    );
+
+    expect(captured.message).toMatchObject({
+      conversation_id: 'cv-mc-1',
+      sender_type: 'agent',
+      content_type: 'text',
+      content_text: 'Hola!',
+      status: 'sent',
+    });
+    expect(String(captured.message?.message_id)).toMatch(/^manychat-out:/);
+    // Never Meta's wamid shape.
+    expect(String(captured.message?.message_id)).not.toMatch(/^wamid\./);
+  });
+
+  it('looks up the mapping scoped to BOTH account_id and contact_id', async () => {
+    const captured: ManyChatCaptured = {};
+    await sendMessageToConversation(
+      manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+      'acct-mc',
+      { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+    );
+    expect(captured.linkLookup).toEqual({ accountId: 'acct-mc', contactId: 'ct-mc-1' });
+  });
+
+  it('does not send when no mapping exists for this contact (no fallback to Meta)', async () => {
+    const captured: ManyChatCaptured = {};
+    await expect(
+      sendMessageToConversation(
+        manyChatSendDb({ link: null, captured }),
+        'acct-mc',
+        { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+      ),
+    ).rejects.toMatchObject({ code: 'manychat_contact_not_linked' });
+
+    expect(sendManyChatTextMock).not.toHaveBeenCalled();
+    expect(captured.message).toBeUndefined();
+  });
+
+  it('a mapping row from another account is invisible — the lookup itself is account-scoped', async () => {
+    // The fake DB always filters by the accountId/contactId passed to
+    // .eq() — simulate "another account's mapping" by returning null,
+    // exactly what a real account_id-scoped query would do for a link
+    // that belongs to a different account.
+    const captured: ManyChatCaptured = {};
+    await expect(
+      sendMessageToConversation(
+        manyChatSendDb({ link: null, captured }),
+        'acct-mc',
+        { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+      ),
+    ).rejects.toMatchObject({ code: 'manychat_contact_not_linked' });
+    // Proves tenancy: the lookup was scoped to THIS account, not run
+    // account-agnostically.
+    expect(captured.linkLookup?.accountId).toBe('acct-mc');
+  });
+
+  it('errors before sending when MANYCHAT_API_KEY is missing', async () => {
+    delete process.env.MANYCHAT_API_KEY;
+    const captured: ManyChatCaptured = {};
+    await expect(
+      sendMessageToConversation(
+        manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+        'acct-mc',
+        { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+      ),
+    ).rejects.toMatchObject({ code: 'manychat_not_configured', status: 503 });
+
+    expect(sendManyChatTextMock).not.toHaveBeenCalled();
+    expect(captured.message).toBeUndefined();
+  });
+
+  it.each([401, 403, 429, 500])(
+    'does not persist a message when ManyChat responds %i',
+    async (status) => {
+      sendManyChatTextMock.mockRejectedValue(
+        new ManyChatApiError(status, `ManyChat error ${status}`),
+      );
+      const captured: ManyChatCaptured = {};
+      await expect(
+        sendMessageToConversation(
+          manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+          'acct-mc',
+          { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+        ),
+      ).rejects.toMatchObject({ code: 'manychat_error', status: 502 });
+
+      expect(captured.message).toBeUndefined();
+    },
+  );
+
+  it('rejects template messages — no fallback to Meta', async () => {
+    const captured: ManyChatCaptured = {};
+    await expect(
+      sendMessageToConversation(
+        manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+        'acct-mc',
+        { conversationId: 'cv-mc-1', messageType: 'template', templateName: 'order_update' },
+      ),
+    ).rejects.toMatchObject({ code: 'manychat_unsupported_type' });
+    expect(sendManyChatTextMock).not.toHaveBeenCalled();
+    expect(captured.message).toBeUndefined();
+  });
+
+  it('rejects media messages — no fallback to Meta', async () => {
+    const captured: ManyChatCaptured = {};
+    await expect(
+      sendMessageToConversation(
+        manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+        'acct-mc',
+        { conversationId: 'cv-mc-1', messageType: 'image', mediaUrl: 'https://x/y.jpg' },
+      ),
+    ).rejects.toMatchObject({ code: 'manychat_unsupported_type' });
+    expect(sendManyChatTextMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects interactive messages — no fallback to Meta', async () => {
+    const captured: ManyChatCaptured = {};
+    await expect(
+      sendMessageToConversation(
+        manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+        'acct-mc',
+        {
+          conversationId: 'cv-mc-1',
+          messageType: 'interactive',
+          interactivePayload: { kind: 'buttons', body: 'Pick one', buttons: [{ id: 'a', title: 'A' }] },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'manychat_unsupported_type' });
+    expect(sendManyChatTextMock).not.toHaveBeenCalled();
+  });
+
+  it('updates last_message_text/last_message_at and pauses active flow runs, same as the Meta path', async () => {
+    const captured: ManyChatCaptured = {};
+    await sendMessageToConversation(
+      manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+      'acct-mc',
+      { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+    );
+    expect(captured.conversation).toMatchObject({ last_message_text: 'Hola!' });
+    expect(captured.conversation?.last_message_at).toBeTruthy();
+    // Flow-pause goes through the mocked @/lib/flows/admin-client, which
+    // always resolves { error: null } — reaching it without throwing is
+    // the signal the best-effort pause step ran.
+  });
+
+  it('never logs MANYCHAT_API_KEY, even when ManyChat rejects the send', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    sendManyChatTextMock.mockRejectedValue(new ManyChatApiError(401, 'unauthorized'));
+
+    const captured: ManyChatCaptured = {};
+    await sendMessageToConversation(
+      manyChatSendDb({ link: { manychat_contact_id: 'mc-contact-1' }, captured }),
+      'acct-mc',
+      { conversationId: 'cv-mc-1', messageType: 'text', contentText: 'Hola!' },
+    ).catch(() => {});
+
+    const logged = [...errorSpy.mock.calls, ...warnSpy.mock.calls]
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join('\n');
+    expect(logged).not.toContain('mc-key-test');
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/src/lib/whatsapp/send-message.ts
+++ b/src/lib/whatsapp/send-message.ts
@@ -19,7 +19,6 @@
 // without duplicating ~250 lines of Meta plumbing.
 // ============================================================
 
-import { randomUUID } from 'node:crypto';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
@@ -49,7 +48,13 @@ import {
   templateBodyParams,
   templateContentText,
 } from '@/lib/whatsapp/template-body';
-import { sendManyChatText, ManyChatApiError } from '@/lib/manychat/api';
+import { ManyChatApiError } from '@/lib/manychat/api';
+import {
+  sendManyChatTextToContact,
+  ManyChatNotConfiguredError,
+  ManyChatContactNotLinkedError,
+  ManyChatMappingLookupError,
+} from '@/lib/manychat/contact-send';
 
 export const MEDIA_KINDS = ['image', 'video', 'document', 'audio'] as const;
 export const VALID_MESSAGE_TYPES = [
@@ -633,68 +638,34 @@ async function sendViaManyChat(
     );
   }
 
-  const apiKey = process.env.MANYCHAT_API_KEY;
-  if (!apiKey) {
-    throw new SendMessageError(
-      'manychat_not_configured',
-      'ManyChat outbound is not configured (MANYCHAT_API_KEY missing)',
-      503,
-    );
-  }
-
-  // Scoped to BOTH account_id and contact_id — never contact_id alone —
-  // so account A can never reach account B's ManyChat mapping.
-  const { data: link, error: linkError } = await db
-    .from('manychat_contact_links')
-    .select('manychat_contact_id')
-    .eq('account_id', accountId)
-    .eq('contact_id', contactId)
-    .maybeSingle();
-
-  if (linkError) {
-    console.error(
-      '[send-message] manychat_contact_links lookup failed:',
-      linkError.message,
-    );
-    throw new SendMessageError('db_error', 'Failed to resolve the ManyChat mapping', 500);
-  }
-  if (!link) {
-    throw new SendMessageError(
-      'manychat_contact_not_linked',
-      'This contact has not been synced from ManyChat yet — an inbound message must arrive first.',
-      409,
-    );
-  }
-
-  let sendResult: Awaited<ReturnType<typeof sendManyChatText>>;
+  // Transport only — mapping lookup + the ManyChat wire call, shared
+  // with the AI send path (src/lib/ai/send.ts). Carries no opinion
+  // about sender_type; that's decided right here, below.
+  let messageId: string;
   try {
-    sendResult = await sendManyChatText({
-      apiKey,
-      manyChatContactId: link.manychat_contact_id as string,
+    const result = await sendManyChatTextToContact({
+      db,
+      accountId,
+      contactId,
       text: contentText!,
     });
+    messageId = result.whatsappMessageId;
   } catch (err) {
-    const message =
-      err instanceof ManyChatApiError
-        ? err.message
-        : err instanceof Error
-          ? err.message
-          : 'Unknown ManyChat API error';
-    console.error('[send-message] ManyChat send failed:', message);
-    throw new SendMessageError('manychat_error', `ManyChat API error: ${message}`, 502);
+    if (err instanceof ManyChatNotConfiguredError) {
+      throw new SendMessageError('manychat_not_configured', err.message, 503);
+    }
+    if (err instanceof ManyChatContactNotLinkedError) {
+      throw new SendMessageError('manychat_contact_not_linked', err.message, 409);
+    }
+    if (err instanceof ManyChatMappingLookupError) {
+      throw new SendMessageError('db_error', err.message, 500);
+    }
+    if (err instanceof ManyChatApiError) {
+      console.error('[send-message] ManyChat send failed:', err.message);
+      throw new SendMessageError('manychat_error', `ManyChat API error: ${err.message}`, 502);
+    }
+    throw err;
   }
-
-  // ManyChat's documented sendContent response is `{ "status": "success" }`
-  // with no confirmed message-id field. Use one opportunistically if a
-  // future/undocumented shape carries it; otherwise generate our own —
-  // never invent a wamid-shaped id.
-  const raw = sendResult.raw as Record<string, unknown> | null;
-  const nestedData = raw && typeof raw.data === 'object' ? (raw.data as Record<string, unknown>) : null;
-  const returnedId = raw?.message_id ?? nestedData?.message_id;
-  const messageId =
-    typeof returnedId === 'string' && returnedId.trim()
-      ? `manychat-out:${returnedId.trim()}`
-      : `manychat-out:${randomUUID()}`;
 
   const { data: messageRecord, error: msgError } = await db
     .from('messages')

--- a/src/lib/whatsapp/send-message.ts
+++ b/src/lib/whatsapp/send-message.ts
@@ -19,6 +19,7 @@
 // without duplicating ~250 lines of Meta plumbing.
 // ============================================================
 
+import { randomUUID } from 'node:crypto';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
@@ -48,6 +49,7 @@ import {
   templateBodyParams,
   templateContentText,
 } from '@/lib/whatsapp/template-body';
+import { sendManyChatText, ManyChatApiError } from '@/lib/manychat/api';
 
 export const MEDIA_KINDS = ['image', 'video', 'document', 'audio'] as const;
 export const VALID_MESSAGE_TYPES = [
@@ -93,8 +95,48 @@ export interface SendMessageParams {
 export interface SendMessageResult {
   /** Our `messages.id` (the persisted row). */
   messageId: string;
-  /** Meta's `wamid` for the delivered message. */
+  /**
+   * The transport's own message id — Meta's `wamid` when sent via Meta,
+   * or `manychat-out:<id>` when sent via the ManyChat bridge (see
+   * `resolveOutboundTransport`). Always what's stored in
+   * `messages.message_id`.
+   */
   whatsappMessageId: string;
+}
+
+// ============================================================
+// Outbound transport selection (ManyChat coexistence bridge, temporary).
+//
+// While a WhatsApp number is still operated in ManyChat (see
+// src/app/api/integrations/manychat/inbound/route.ts for the inbound
+// half), WHATSAPP_OUTBOUND_TRANSPORT=manychat routes agent-composed
+// sends through ManyChat's Public API instead of Meta's Cloud API.
+//
+// This is deliberately scoped to ONE account, not global: wacrm is
+// multi-account, and MANYCHAT_INGEST_ACCOUNT_ID already names the
+// single account this temporary bridge exists for (the inbound route
+// resolves its whatsapp_config from the same var). Reusing it here
+// means flipping WHATSAPP_OUTBOUND_TRANSPORT=manychat can never change
+// outbound behavior for any OTHER account on this deployment — every
+// other account keeps sending via Meta regardless of this env var.
+//
+// Resolution:
+//   transport=manychat AND accountId === MANYCHAT_INGEST_ACCOUNT_ID → manychat
+//   transport=manychat AND any other accountId                      → meta
+//   transport=meta (or unset/garbage)                                → meta
+// ============================================================
+export type WhatsAppOutboundTransport = 'meta' | 'manychat';
+
+export function resolveOutboundTransport(accountId: string): WhatsAppOutboundTransport {
+  const bridgeAccountId = process.env.MANYCHAT_INGEST_ACCOUNT_ID;
+  if (
+    process.env.WHATSAPP_OUTBOUND_TRANSPORT === 'manychat' &&
+    !!bridgeAccountId &&
+    accountId === bridgeAccountId
+  ) {
+    return 'manychat';
+  }
+  return 'meta';
 }
 
 /**
@@ -231,6 +273,23 @@ export async function sendMessageToConversation(
 
   if (convError || !conversation) {
     throw new SendMessageError('not_found', 'Conversation not found', 404);
+  }
+
+  // Transport branch — MUST come before any Meta-specific validation
+  // below (phone format, whatsapp_config lookup) since accounts bridged
+  // through ManyChat deliberately have no whatsapp_config row yet
+  // (the number isn't registered directly in WA CRM during this
+  // coexistence phase). Everything from here to the end of this
+  // function, when this branch is NOT taken, is byte-for-byte the
+  // pre-existing Meta send path.
+  if (resolveOutboundTransport(accountId) === 'manychat') {
+    return sendViaManyChat(db, accountId, {
+      conversationId,
+      contactId: conversation.contact_id as string,
+      messageType,
+      contentText,
+      replyToMessageId,
+    });
   }
 
   const contact = conversation.contact;
@@ -533,4 +592,164 @@ export async function sendMessageToConversation(
   }
 
   return { messageId: messageRecord.id, whatsappMessageId: waMessageId };
+}
+
+// ============================================================
+// ManyChat outbound path (temporary coexistence bridge).
+//
+// Mirrors the shape of the Meta path above — validate → send →
+// persist → update conversation → pause flows — but:
+//   - text only, no phone/whatsapp_config lookup (ManyChat targets a
+//     subscriber id, not a phone number through Meta);
+//   - the contact must already be linked via `manychat_contact_links`
+//     (populated by the inbound bridge) — no mapping means no send,
+//     ever, with no fallback to Meta;
+//   - a message is persisted ONLY after ManyChat accepts the send —
+//     same ordering guarantee as the Meta path, so a failed send never
+//     shows up as delivered in the Inbox.
+// ============================================================
+interface ManyChatSendArgs {
+  conversationId: string;
+  contactId: string;
+  messageType: string;
+  contentText?: string | null;
+  replyToMessageId?: string | null;
+}
+
+async function sendViaManyChat(
+  db: SupabaseClient,
+  accountId: string,
+  args: ManyChatSendArgs,
+): Promise<SendMessageResult> {
+  const { conversationId, contactId, messageType, contentText, replyToMessageId } = args;
+
+  // No silent fallback to Meta for anything ManyChat can't carry yet —
+  // a clear, typed rejection instead.
+  if (messageType !== 'text') {
+    throw new SendMessageError(
+      'manychat_unsupported_type',
+      `ManyChat outbound only supports text messages while WHATSAPP_OUTBOUND_TRANSPORT=manychat (got "${messageType}")`,
+      409,
+    );
+  }
+
+  const apiKey = process.env.MANYCHAT_API_KEY;
+  if (!apiKey) {
+    throw new SendMessageError(
+      'manychat_not_configured',
+      'ManyChat outbound is not configured (MANYCHAT_API_KEY missing)',
+      503,
+    );
+  }
+
+  // Scoped to BOTH account_id and contact_id — never contact_id alone —
+  // so account A can never reach account B's ManyChat mapping.
+  const { data: link, error: linkError } = await db
+    .from('manychat_contact_links')
+    .select('manychat_contact_id')
+    .eq('account_id', accountId)
+    .eq('contact_id', contactId)
+    .maybeSingle();
+
+  if (linkError) {
+    console.error(
+      '[send-message] manychat_contact_links lookup failed:',
+      linkError.message,
+    );
+    throw new SendMessageError('db_error', 'Failed to resolve the ManyChat mapping', 500);
+  }
+  if (!link) {
+    throw new SendMessageError(
+      'manychat_contact_not_linked',
+      'This contact has not been synced from ManyChat yet — an inbound message must arrive first.',
+      409,
+    );
+  }
+
+  let sendResult: Awaited<ReturnType<typeof sendManyChatText>>;
+  try {
+    sendResult = await sendManyChatText({
+      apiKey,
+      manyChatContactId: link.manychat_contact_id as string,
+      text: contentText!,
+    });
+  } catch (err) {
+    const message =
+      err instanceof ManyChatApiError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : 'Unknown ManyChat API error';
+    console.error('[send-message] ManyChat send failed:', message);
+    throw new SendMessageError('manychat_error', `ManyChat API error: ${message}`, 502);
+  }
+
+  // ManyChat's documented sendContent response is `{ "status": "success" }`
+  // with no confirmed message-id field. Use one opportunistically if a
+  // future/undocumented shape carries it; otherwise generate our own —
+  // never invent a wamid-shaped id.
+  const raw = sendResult.raw as Record<string, unknown> | null;
+  const nestedData = raw && typeof raw.data === 'object' ? (raw.data as Record<string, unknown>) : null;
+  const returnedId = raw?.message_id ?? nestedData?.message_id;
+  const messageId =
+    typeof returnedId === 'string' && returnedId.trim()
+      ? `manychat-out:${returnedId.trim()}`
+      : `manychat-out:${randomUUID()}`;
+
+  const { data: messageRecord, error: msgError } = await db
+    .from('messages')
+    .insert({
+      conversation_id: conversationId,
+      sender_type: 'agent',
+      content_type: 'text',
+      content_text: contentText,
+      message_id: messageId,
+      status: 'sent',
+      reply_to_message_id: replyToMessageId || null,
+    })
+    .select()
+    .single();
+
+  if (msgError) {
+    console.error('[send-message] error inserting sent (manychat) message:', msgError);
+    throw new SendMessageError(
+      'db_error',
+      `Message sent via ManyChat but failed to save to DB: ${msgError.message}`,
+      500,
+    );
+  }
+
+  await db
+    .from('conversations')
+    .update({
+      last_message_text: contentText || '[text]',
+      last_message_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', conversationId);
+
+  // Pause any active Flow run — same "agent stepped in" signal as the
+  // Meta path. Best-effort.
+  try {
+    const { error: pauseErr } = await supabaseAdmin()
+      .from('flow_runs')
+      .update({
+        status: 'paused_by_agent',
+        ended_at: new Date().toISOString(),
+        end_reason: 'agent_replied',
+      })
+      .eq('account_id', accountId)
+      .eq('contact_id', contactId)
+      .eq('status', 'active');
+    if (pauseErr) {
+      console.error('[flows] pause-on-agent-send failed:', pauseErr.message);
+    }
+  } catch (err) {
+    console.error(
+      '[flows] pause-on-agent-send threw:',
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  return { messageId: messageRecord.id, whatsappMessageId: messageId };
 }

--- a/supabase/migrations/040_manychat_contact_links.sql
+++ b/supabase/migrations/040_manychat_contact_links.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- 040_manychat_contact_links
+--
+-- TEMPORARY-bridge persistence: records which WA CRM contact
+-- corresponds to which ManyChat subscriber. The inbound bridge
+-- (POST /api/integrations/manychat/inbound) upserts a row here on
+-- every delivery — including retries, since the mapping has nothing
+-- to do with message idempotency. The outbound bridge
+-- (src/lib/whatsapp/send-message.ts, gated on
+-- WHATSAPP_OUTBOUND_TRANSPORT=manychat) reads it back to learn which
+-- manychat_contact_id to hand to ManyChat's Public API when an agent
+-- replies from the Inbox.
+--
+-- A dedicated table rather than a column on `contacts`:
+--   - `contacts` is the account's canonical customer record, read and
+--     written by every non-ManyChat path (manual create, CSV import,
+--     the Meta webhook). Bolting a temporary-bridge concern onto it
+--     means every future change to that table has to reason about an
+--     unrelated integration's lifecycle.
+--   - this bridge is explicitly temporary — removed once the number is
+--     registered directly in WA CRM and ManyChat is decommissioned. A
+--     separate table drops cleanly with one `DROP TABLE`; a column on
+--     `contacts` would need its own migration to reverse.
+--
+-- RLS mirrors `webhook_endpoints` (028) — a settings-adjacent,
+-- account-scoped table: any member may read the mapping, only admin+
+-- may write it via the dashboard/API. In practice all writes today
+-- come from the inbound bridge's service-role client, which bypasses
+-- RLS entirely — no dashboard UI exists yet to create or edit these
+-- rows by hand, but the write policies are in place for when one does.
+--
+-- Idempotent — safe to re-run.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS manychat_contact_links (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id           UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  contact_id           UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  manychat_contact_id  TEXT NOT NULL,
+  whatsapp_id          TEXT,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- One ManyChat mapping per CRM contact. This is also the inbound
+  -- bridge's upsert conflict target — a re-delivery for the same
+  -- contact updates the existing row instead of erroring.
+  UNIQUE (account_id, contact_id),
+
+  -- One CRM contact per ManyChat subscriber, scoped to the account so
+  -- two different accounts' ManyChat integrations can never collide on
+  -- the same manychat_contact_id.
+  UNIQUE (account_id, manychat_contact_id)
+);
+
+-- Outbound-send lookups filter by BOTH (account_id, contact_id)
+-- together (never contact_id alone — see send-message.ts), which the
+-- first UNIQUE constraint above already backs with a matching index.
+-- This second index exists purely for the ON DELETE CASCADE from
+-- `contacts` (and any future direct by-contact lookup), since
+-- contact_id is only the trailing column in that composite index.
+CREATE INDEX IF NOT EXISTS idx_manychat_contact_links_contact
+  ON manychat_contact_links (contact_id);
+
+ALTER TABLE manychat_contact_links ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS manychat_contact_links_select ON manychat_contact_links;
+CREATE POLICY manychat_contact_links_select ON manychat_contact_links FOR SELECT
+  USING (is_account_member(account_id));
+
+DROP POLICY IF EXISTS manychat_contact_links_insert ON manychat_contact_links;
+CREATE POLICY manychat_contact_links_insert ON manychat_contact_links FOR INSERT
+  WITH CHECK (is_account_member(account_id, 'admin'));
+
+DROP POLICY IF EXISTS manychat_contact_links_update ON manychat_contact_links;
+CREATE POLICY manychat_contact_links_update ON manychat_contact_links FOR UPDATE
+  USING (is_account_member(account_id, 'admin'));
+
+DROP POLICY IF EXISTS manychat_contact_links_delete ON manychat_contact_links;
+CREATE POLICY manychat_contact_links_delete ON manychat_contact_links FOR DELETE
+  USING (is_account_member(account_id, 'admin'));
+
+DROP TRIGGER IF EXISTS set_updated_at ON manychat_contact_links;
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON manychat_contact_links
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/041_add_gemini_ai_provider.sql
+++ b/supabase/migrations/041_add_gemini_ai_provider.sql
@@ -1,0 +1,79 @@
+-- ============================================================
+-- 041_add_gemini_ai_provider
+--
+-- Widens the `provider` CHECK constraint to allow 'gemini' alongside
+-- the existing 'openai' / 'anthropic' (see src/lib/ai/types.ts
+-- AiProvider). Two tables carry their own independent CHECK on this
+-- column, both declared inline in their CREATE TABLE:
+--   - ai_configs   (029_ai_reply.sql)       — the account's chosen provider
+--   - ai_usage_log (033_ai_reply_polish.sql) — which provider a given
+--     LLM call spent tokens on
+-- Both need the same widening, or a Gemini call's usage row would
+-- fail its INSERT. That failure would be SILENT: logAiUsage (see
+-- src/lib/ai/usage.ts) deliberately swallows its own errors so a
+-- broken usage log can never fail the customer-facing reply — which
+-- is exactly why it's worth closing here rather than discovering it
+-- later as "Gemini usage never shows up in the account's spend."
+--
+-- Both constraints were declared as inline column CHECKs with no
+-- explicit name, so Postgres auto-named them — for a table's first
+-- (and only) CHECK on a given column this is `<table>_<column>_check`
+-- by convention, i.e. ai_configs_provider_check /
+-- ai_usage_log_provider_check. Rather than hardcode that assumption,
+-- this migration looks up each constraint DYNAMICALLY by its actual
+-- definition (a CHECK on `provider` naming exactly 'openai' and
+-- 'anthropic', not yet 'gemini') and drops whatever it is actually
+-- called — so a renamed constraint in a real install is still found
+-- and replaced safely. No other CHECK constraint on either table
+-- (e.g. ai_usage_log's `mode` CHECK) is touched.
+--
+-- Idempotent — safe to run multiple times.
+-- ============================================================
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  -- 1) Drop the existing 2-provider CHECK on each table, whatever it's
+  --    actually named. Matched by definition, not by a guessed name:
+  --    a CHECK constraint on `provider` that mentions 'openai' and
+  --    'anthropic' but not yet 'gemini'.
+  FOR r IN
+    SELECT con.oid, con.conname, con.conrelid::regclass AS tbl
+    FROM pg_constraint con
+    WHERE con.contype = 'c'
+      AND con.conrelid IN ('public.ai_configs'::regclass, 'public.ai_usage_log'::regclass)
+      AND pg_get_constraintdef(con.oid) ILIKE '%provider%'
+      AND pg_get_constraintdef(con.oid) ILIKE '%openai%'
+      AND pg_get_constraintdef(con.oid) ILIKE '%anthropic%'
+      AND pg_get_constraintdef(con.oid) NOT ILIKE '%gemini%'
+  LOOP
+    EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', r.tbl, r.conname);
+  END LOOP;
+
+  -- 2) Re-add under the canonical (Postgres-default) name, guarded so
+  --    a re-run — or an install where the constraint was already
+  --    correctly named and thus untouched by step 1 — doesn't error
+  --    on "constraint already exists". PostgreSQL has no
+  --    "ADD CONSTRAINT IF NOT EXISTS", so guard via pg_constraint
+  --    (same idiom as migration 013).
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ai_configs_provider_check'
+      AND conrelid = 'public.ai_configs'::regclass
+  ) THEN
+    ALTER TABLE public.ai_configs
+      ADD CONSTRAINT ai_configs_provider_check
+      CHECK (provider IN ('openai', 'anthropic', 'gemini'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ai_usage_log_provider_check'
+      AND conrelid = 'public.ai_usage_log'::regclass
+  ) THEN
+    ALTER TABLE public.ai_usage_log
+      ADD CONSTRAINT ai_usage_log_provider_check
+      CHECK (provider IN ('openai', 'anthropic', 'gemini'));
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Improves AI Knowledge Base retrieval and adds Gemini semantic embeddings support.

### Retrieval
- Keeps strict PostgreSQL FTS first
- Adds keyword fallback when natural-language queries return no strict matches
- Preserves lexical-only operation when no embeddings key is configured

### Gemini embeddings
- Adds gemini-embedding-2 support
- Uses 1536-dimensional vectors compatible with the existing pgvector schema
- Uses asymmetric retrieval prompts:
  - query: task: question answering | query: ...
  - document: title: ... | text: ...
- Keeps OpenAI embeddings behavior unchanged
- Uses bounded Gemini concurrency (max 6 requests)
- Stops claiming new work after the first embedding failure

### Provider safety
- Derives the embeddings provider from the configured AI provider
- Prevents mixing incompatible OpenAI/Gemini embedding spaces
- Clears existing vectors before saving an embeddings-provider change
- Aborts the config save if that clear fails
- Marks the Knowledge Base as requiring Reindex after a successful provider change

### Knowledge Base
- Propagates document titles through create/update/reindex
- Keeps stored chunk content unchanged
- Reindex rebuilds vectors without deleting documents or lexical FTS data

### Security
- Redacts embeddings API keys from provider errors
- Keeps embeddings key opt-in and independently encrypted

### Validation
- Typecheck: pass
- Build: pass
- Focused AI/KB tests: 128/128 pass
- Full suite: 1156/1158 pass
- Only the same two pre-existing mondayIndex/date-utils failures remain
- No database migration required
- No ManyChat changes
