### PR TITLE
fix(whatsapp): keep the stored verify_token when config is saved without one

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1497,6 +1497,7 @@
       "webhookVerifyToken": "Webhook Verify Token",
       "webhookVerifyTokenPlaceholder": "Create a custom verify token",
       "webhookVerifyTokenHint": "A custom string you create. Must match the token you set in Meta webhook settings.",
+      "webhookVerifyTokenSaved": "Saved. Leave as is to keep it, or enter a new value to rotate.",
       "twoStepPin": "Two-step verification PIN",
       "optional": "(optional)",
       "pinPlaceholder": "6-digit PIN from Meta WhatsApp Manager",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1497,6 +1497,7 @@
       "webhookVerifyToken": "웹훅 인증 토큰",
       "webhookVerifyTokenPlaceholder": "사용자 지정 인증 토큰을 만드세요",
       "webhookVerifyTokenHint": "직접 만드는 문자열입니다. Meta 웹훅 설정에 지정한 토큰과 일치해야 합니다.",
+      "webhookVerifyTokenSaved": "저장되어 있습니다. 유지하려면 그대로 두고, 교체하려면 새 값을 입력하세요.",
       "twoStepPin": "2단계 인증 PIN",
       "optional": "(선택)",
       "pinPlaceholder": "Meta WhatsApp 관리자에서 발급받은 6자리 PIN",

--- a/src/app/api/whatsapp/config/route.ts
+++ b/src/app/api/whatsapp/config/route.ts
@@ -7,6 +7,7 @@ import {
   verifyPhoneNumber,
 } from '@/lib/whatsapp/meta-api'
 import { encrypt, decrypt } from '@/lib/whatsapp/encryption'
+import { resolveVerifyTokenForSave } from '@/lib/whatsapp/verify-token'
 
 /**
  * Resolve the caller's account_id from their profile. Inlined here
@@ -251,12 +252,27 @@ export async function POST(request: Request) {
       )
     }
 
+    // Look up any pre-existing row for this account. Two reasons: we need
+    // to know whether this number is already registered with Meta (so we
+    // can skip /register when the user didn't provide a PIN this time
+    // around), and we need the stored verify_token — the settings form
+    // never shows it, so a save that leaves the field blank must keep it
+    // rather than null it out.
+    const { data: existing } = await supabase
+      .from('whatsapp_config')
+      .select('id, registered_at, phone_number_id, verify_token')
+      .eq('account_id', accountId)
+      .maybeSingle()
+
     // Encrypt sensitive tokens before storing
     let encryptedAccessToken: string
     let encryptedVerifyToken: string | null
     try {
       encryptedAccessToken = encrypt(access_token)
-      encryptedVerifyToken = verify_token ? encrypt(verify_token) : null
+      encryptedVerifyToken = resolveVerifyTokenForSave(
+        verify_token,
+        existing?.verify_token ?? null
+      )
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown encryption error'
       console.error('Encryption failed:', message)
@@ -268,15 +284,6 @@ export async function POST(request: Request) {
         { status: 500 }
       )
     }
-
-    // Look up any pre-existing row for this account so we know whether
-    // this number is already registered with Meta — if so we can skip
-    // /register when the user didn't provide a PIN this time around.
-    const { data: existing } = await supabase
-      .from('whatsapp_config')
-      .select('id, registered_at, phone_number_id')
-      .eq('account_id', accountId)
-      .maybeSingle()
 
     const sameNumber =
       existing?.phone_number_id === phone_number_id &&

--- a/src/components/settings/whatsapp-config.tsx
+++ b/src/components/settings/whatsapp-config.tsx
@@ -76,6 +76,7 @@ export function WhatsAppConfig() {
   const [verifyToken, setVerifyToken] = useState('');
   const [pin, setPin] = useState('');
   const [tokenEdited, setTokenEdited] = useState(false);
+  const [verifyEdited, setVerifyEdited] = useState(false);
 
   // Inbound-media mirror (issue #466). Unlike everything else on this
   // page it is NOT part of handleSave: that path insists on re-entering
@@ -135,7 +136,11 @@ export function WhatsAppConfig() {
         setPhoneNumberId(data.phone_number_id || '');
         setWabaId(data.waba_id || '');
         setAccessToken(MASKED_TOKEN);
-        setVerifyToken('');
+        // Same treatment as the access token: the row carries the encrypted
+        // value, which is enough to know one exists. Show a mask instead of
+        // an empty box so nobody concludes the token was never saved.
+        setVerifyToken(data.verify_token ? MASKED_TOKEN : '');
+        setVerifyEdited(false);
         setPin('');
         setTokenEdited(false);
         // Undefined on a row read before migration 039 — treat that as
@@ -149,6 +154,7 @@ export function WhatsAppConfig() {
         setVerifyToken('');
         setPin('');
         setTokenEdited(false);
+        setVerifyEdited(false);
         setMirrorMedia(true);
       }
       // Clear any stale probe result when reloading the row.
@@ -246,7 +252,14 @@ export function WhatsAppConfig() {
       const payload: Record<string, unknown> = {
         phone_number_id: phoneNumberId.trim(),
         waba_id: wabaId.trim() || null,
-        verify_token: verifyToken.trim() || null,
+        // Only sent when the user actually typed one. Left out otherwise
+        // (undefined is dropped from the JSON body) so the server keeps the
+        // stored token instead of nulling it — see resolveVerifyTokenForSave.
+        ...(verifyEdited &&
+        verifyToken.trim() &&
+        verifyToken.trim() !== MASKED_TOKEN
+          ? { verify_token: verifyToken.trim() }
+          : {}),
         // Optional — only sent when the user filled it in. The server
         // requires it on first save or when changing numbers; for a
         // simple token rotation, leaving it blank skips re-register.
@@ -399,6 +412,7 @@ export function WhatsAppConfig() {
       setAccessToken('');
       setVerifyToken('');
       setTokenEdited(false);
+      setVerifyEdited(false);
       setConnectionStatus('disconnected');
       setResetReason(null);
       setStatusMessage('');
@@ -666,11 +680,22 @@ export function WhatsAppConfig() {
               <Input
                 placeholder={t('webhookVerifyTokenPlaceholder')}
                 value={verifyToken}
-                onChange={(e) => setVerifyToken(e.target.value)}
+                onChange={(e) => {
+                  setVerifyToken(e.target.value);
+                  setVerifyEdited(true);
+                }}
+                onFocus={() => {
+                  if (verifyToken === MASKED_TOKEN) {
+                    setVerifyToken('');
+                    setVerifyEdited(true);
+                  }
+                }}
                 className="bg-muted border-border text-foreground placeholder:text-muted-foreground"
               />
               <p className="text-xs text-muted-foreground">
-                {t('webhookVerifyTokenHint')}
+                {config?.verify_token && !verifyEdited
+                  ? t('webhookVerifyTokenSaved')
+                  : t('webhookVerifyTokenHint')}
               </p>
             </div>
 

--- a/src/lib/whatsapp/verify-token.test.ts
+++ b/src/lib/whatsapp/verify-token.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { decrypt, encrypt } from './encryption'
+import { resolveVerifyTokenForSave } from './verify-token'
+
+/**
+ * Regression cover for the settings page silently dropping the webhook
+ * verify token.
+ *
+ * The settings form never shows the stored token (it is encrypted at rest
+ * and the GET endpoint does not return it), so the field is always empty
+ * when the page loads. Saving any OTHER field then posted `verify_token`
+ * as empty, and the route wrote NULL over the stored value. Measured live
+ * on 2026-09-05: `whatsapp_config.verify_token` was NULL, every Meta GET
+ * handshake got 403, and from the outside that was indistinguishable from
+ * a wrong token.
+ *
+ * Contract: an empty incoming token means "keep what is stored". Clearing
+ * the token on its own is not a supported operation — "Reset Configuration"
+ * wipes the whole row for that.
+ */
+describe('resolveVerifyTokenForSave', () => {
+  const stored = encrypt('old-token')
+
+  it('a non-empty incoming token replaces the stored one, re-encrypted', () => {
+    const out = resolveVerifyTokenForSave('new-token', stored)
+    expect(out).not.toBeNull()
+    expect(out).not.toBe(stored)
+    expect(decrypt(out!)).toBe('new-token')
+  })
+
+  it.each([undefined, null, '', '   '])(
+    'incoming %j keeps the stored encrypted token untouched',
+    (incoming) => {
+      expect(resolveVerifyTokenForSave(incoming, stored)).toBe(stored)
+    },
+  )
+
+  it('nothing incoming and nothing stored stays null', () => {
+    expect(resolveVerifyTokenForSave(undefined, null)).toBeNull()
+    expect(resolveVerifyTokenForSave('', null)).toBeNull()
+  })
+
+  it('trims surrounding whitespace before encrypting', () => {
+    const out = resolveVerifyTokenForSave('  padded  ', null)
+    expect(decrypt(out!)).toBe('padded')
+  })
+})

--- a/src/lib/whatsapp/verify-token.test.ts
+++ b/src/lib/whatsapp/verify-token.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest';
 
-import { decrypt, encrypt } from './encryption'
-import { resolveVerifyTokenForSave } from './verify-token'
+import { decrypt, encrypt } from './encryption';
+import { resolveVerifyTokenForSave } from './verify-token';
 
 /**
  * Regression cover for the settings page silently dropping the webhook
@@ -20,29 +20,29 @@ import { resolveVerifyTokenForSave } from './verify-token'
  * wipes the whole row for that.
  */
 describe('resolveVerifyTokenForSave', () => {
-  const stored = encrypt('old-token')
+  const stored = encrypt('old-token');
 
   it('a non-empty incoming token replaces the stored one, re-encrypted', () => {
-    const out = resolveVerifyTokenForSave('new-token', stored)
-    expect(out).not.toBeNull()
-    expect(out).not.toBe(stored)
-    expect(decrypt(out!)).toBe('new-token')
-  })
+    const out = resolveVerifyTokenForSave('new-token', stored);
+    expect(out).not.toBeNull();
+    expect(out).not.toBe(stored);
+    expect(decrypt(out!)).toBe('new-token');
+  });
 
   it.each([undefined, null, '', '   '])(
     'incoming %j keeps the stored encrypted token untouched',
     (incoming) => {
-      expect(resolveVerifyTokenForSave(incoming, stored)).toBe(stored)
-    },
-  )
+      expect(resolveVerifyTokenForSave(incoming, stored)).toBe(stored);
+    }
+  );
 
   it('nothing incoming and nothing stored stays null', () => {
-    expect(resolveVerifyTokenForSave(undefined, null)).toBeNull()
-    expect(resolveVerifyTokenForSave('', null)).toBeNull()
-  })
+    expect(resolveVerifyTokenForSave(undefined, null)).toBeNull();
+    expect(resolveVerifyTokenForSave('', null)).toBeNull();
+  });
 
   it('trims surrounding whitespace before encrypting', () => {
-    const out = resolveVerifyTokenForSave('  padded  ', null)
-    expect(decrypt(out!)).toBe('padded')
-  })
-})
+    const out = resolveVerifyTokenForSave('  padded  ', null);
+    expect(decrypt(out!)).toBe('padded');
+  });
+});

--- a/src/lib/whatsapp/verify-token.ts
+++ b/src/lib/whatsapp/verify-token.ts
@@ -1,0 +1,15 @@
+import { encrypt } from './encryption'
+
+/**
+ * Decide what `whatsapp_config.verify_token` should hold after a config save.
+ *
+ * Skeleton: mirrors the current behaviour in `config/route.ts` verbatim so
+ * the regression test can go red first (assert-red, not import-red).
+ */
+export function resolveVerifyTokenForSave(
+  incoming: string | null | undefined,
+  existingEncrypted: string | null,
+): string | null {
+  void existingEncrypted
+  return incoming ? encrypt(incoming) : null
+}

--- a/src/lib/whatsapp/verify-token.ts
+++ b/src/lib/whatsapp/verify-token.ts
@@ -1,15 +1,25 @@
-import { encrypt } from './encryption'
+import { encrypt } from './encryption';
 
 /**
  * Decide what `whatsapp_config.verify_token` should hold after a config save.
  *
- * Skeleton: mirrors the current behaviour in `config/route.ts` verbatim so
- * the regression test can go red first (assert-red, not import-red).
+ * The settings form never shows the stored token (it is encrypted at rest
+ * and the GET endpoint does not return it), so the field arrives empty on
+ * every save that did not deliberately change it. Empty therefore means
+ * "keep what is stored", not "clear it" — the previous
+ * `incoming ? encrypt(incoming) : null` nulled the token whenever any OTHER
+ * field was saved. Measured live on 2026-09-05: the row had
+ * verify_token = NULL and every Meta GET handshake got 403, which from the
+ * outside looks exactly like a wrong token.
+ *
+ * Clearing the token on its own is not a supported operation; "Reset
+ * Configuration" wipes the whole row for that.
  */
 export function resolveVerifyTokenForSave(
   incoming: string | null | undefined,
-  existingEncrypted: string | null,
+  existingEncrypted: string | null
 ): string | null {
-  void existingEncrypted
-  return incoming ? encrypt(incoming) : null
+  const trimmed = typeof incoming === 'string' ? incoming.trim() : '';
+  if (trimmed) return encrypt(trimmed);
+  return existingEncrypted ?? null;
 }


### PR DESCRIPTION
## Summary

Saving the WhatsApp settings form clears `whatsapp_config.verify_token` unless
the token field happens to be filled in — which it never is, because the form
does not render the stored value. Every save of any *other* field (phone
number id, WABA id, access token…) silently nulls the verify token, and Meta's
webhook GET handshake then returns **403**. From the outside this is
indistinguishable from "you typed the wrong token".

Root cause is one expression in the save path:

```ts
verify_token: incoming ? encrypt(incoming) : null
```

An empty field means *"keep what is stored"*, not *"clear it"* — the settings
GET endpoint deliberately never returns the token (it is encrypted at rest),
so empty is the normal state of that input.

Measured on a live self-hosted instance (2026-09-05): the row held
`verify_token = NULL`, Meta's verification GET returned 403, inbound message
delivery stopped. Restoring the token fixed it; saving any other field broke
it again.

## What changed

* `src/lib/whatsapp/verify-token.ts` — new `resolveVerifyTokenForSave(incoming, existingEncrypted)`:
  a non-empty value is encrypted and stored, an empty/whitespace value keeps
  the existing ciphertext. Clearing a token on its own is not a supported
  operation; **Reset Configuration** already wipes the whole row.
* `src/app/api/whatsapp/config/route.ts` — save path reads the existing row
  and delegates to the helper instead of inlining the ternary.
* `src/components/settings/whatsapp-config.tsx` — the field now says the token
  is kept when left blank, so the behaviour is discoverable rather than
  implied.
* `messages/en.json`, `messages/ko.json` — that one hint string.

Behaviour is unchanged when a token *is* typed.

## Test plan

* [x] `src/lib/whatsapp/verify-token.test.ts` — **7 passed**, written
  red-first (the test commit precedes the fix commit in this PR).
* [x] **Negative control:** replacing `return existingEncrypted ?? null` with
  `return null` (the old behaviour) turns **4 of the 7 red**; reverting makes
  them green again. The suite genuinely pins this behaviour rather than
  passing vacuously.
* [x] `npm run typecheck` — clean.
* [x] `npx eslint` on the four touched files — **0 errors, 1 warning**, and
  that warning (`react-hooks/exhaustive-deps` in `whatsapp-config.tsx`) is
  **pre-existing**: it reports on `upstream/main` too, at line 204 vs 210 here
  — the shift is just the added lines.
* [ ] `npm run build` — not run locally; left to CI.

## Related

Found while self-hosting; no existing issue covers it (searched open + closed
for `verify_token`). Happy to split the i18n hint into its own commit or drop
it if you would rather keep the fix minimal.
